### PR TITLE
feat: surface enterprise rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,21 @@ SC Console is the development hub for Silicon Crane (SC). It contains:
 
 ## Session Start
 
-Always run `/sod` at the start of every session to:
+Every session must begin with:
 
-- Create session in Context Worker
-- Download current documentation
-- Establish session context for handoffs
+1. Call the `crane_preflight` MCP tool (no arguments)
+2. Call the `crane_sod` MCP tool with `venture: "sc"`
+
+This creates a session, loads documentation, and establishes handoff context.
+
+## Enterprise Rules
+
+- **All changes through PRs.** Never push directly to main. Branch, PR, CI, QA, merge.
+- **Never echo secret values.** Transcripts persist in ~/.claude/ and are sent to API providers. Pipe from Infisical, never inline.
+- **Verify secret VALUES, not just key existence.** Agents have stored descriptions as values before.
+- **Never auto-save to VCMS** without explicit Captain approval.
+- **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
+- **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
 
 ## Build Commands
 
@@ -65,7 +75,21 @@ npx tsc --noEmit        # TypeScript validation
 - Validate all input at API boundaries
 - Use parameterized queries for D1 (always `.bind()`)
 
+## Instruction Modules
+
+Detailed domain instructions stored as on-demand documents.
+Fetch the relevant module when working in that domain.
+
+| Module              | Key Rule (always applies)                                                | Fetch for details                             |
+| ------------------- | ------------------------------------------------------------------------ | --------------------------------------------- |
+| `secrets.md`        | Verify secret VALUES, not just key existence                             | Infisical, vault, API keys, GitHub App        |
+| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                            | VCMS tags, storage rules, editorial, style    |
+| `team-workflow.md`  | All changes through PRs; never push to main                              | Full workflow, QA grades, escalation triggers |
+| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale > CLI > bootstrap > optimize > mesh | SSH, machines, Tailscale, macOS               |
+
+Fetch with: `crane_doc('global', '<module>')`
+
 ## Related Documentation
 
-Venture-specific instructions are served by crane-context via `/sod`.
+Venture-specific instructions are served by crane-context via the `crane_sod` MCP tool.
 See `docs/process/` for process documentation.


### PR DESCRIPTION
## Summary

- Add Enterprise Rules section with 6 critical guardrails (PR workflow, secrets handling, VCMS, scope discipline, escalation triggers)
- Replace `/sod` slash command with standardized MCP session start
- Add Instruction Modules table for on-demand VCMS doc fetching via `crane_doc()`
- Update Related Documentation reference from `/sod` to MCP tool

Part of a cross-venture initiative to surface VCMS enterprise rules directly in agent instruction files.

## Test plan

- [ ] Verify Enterprise Rules section visible in CLAUDE.md
- [ ] Verify session start uses MCP tools (not /sod)
- [ ] Verify Instruction Modules table present

🤖 Generated with [Claude Code](https://claude.com/claude-code)