### PR TITLE
docs: add instruction modules table to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,42 @@ This creates a session, loads documentation, and establishes handoff context.
 - **Verify secret VALUES, not just key existence.** Agents have stored descriptions as values before.
 - **Never auto-save to VCMS** without explicit Captain approval.
 - **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
+- **Never remove, deprecate, or disable existing features** without explicit Captain directive. "Unused" is not sufficient justification. See `guardrails.md`.
 - **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
+
+## Development Workflow
+
+### Commands
+
+| Command             | Purpose                                                    |
+| ------------------- | ---------------------------------------------------------- |
+| `npm run verify`    | Full local verification (typecheck + format + lint + test) |
+| `npm run format`    | Format all files with Prettier                             |
+| `npm run lint`      | Run ESLint on all files                                    |
+| `npm run typecheck` | Check TypeScript                                           |
+| `npm test`          | Run tests                                                  |
+
+### Pre-commit Hooks
+
+Automatically run on staged files:
+
+- Prettier formatting
+- ESLint fixes
+
+### Pre-push Hooks
+
+Full verification runs before push:
+
+- TypeScript compilation check
+- Prettier format check
+- ESLint check
+- Test suite
+
+### CI Must Pass
+
+- Never merge with red CI
+- Fix root cause, not symptoms
+- Run `npm run verify` locally before pushing
 
 ## Build Commands
 
@@ -68,6 +103,18 @@ npx tsc --noEmit        # TypeScript validation
 - `workers/sc-api/src/index.ts` - API routes
 - `docs/technical/sc-technical-spec.md` - Technical specification
 
+## QA Grade Labels
+
+When PM creates an issue, they assign a QA grade. This determines verification requirements:
+
+| Label        | Meaning    | Verification                       |
+| ------------ | ---------- | ---------------------------------- |
+| `qa-grade:0` | CI-only    | Automated - no human review needed |
+| `qa-grade:1` | API/data   | Scriptable checks                  |
+| `qa-grade:2` | Functional | Requires app interaction           |
+| `qa-grade:3` | Visual/UX  | Requires human judgment            |
+| `qa-grade:4` | Security   | Requires specialist review         |
+
 ## Security Requirements
 
 - Never commit secrets to the repository
@@ -80,13 +127,17 @@ npx tsc --noEmit        # TypeScript validation
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module              | Key Rule (always applies)                                                | Fetch for details                             |
-| ------------------- | ------------------------------------------------------------------------ | --------------------------------------------- |
-| `secrets.md`        | Verify secret VALUES, not just key existence                             | Infisical, vault, API keys, GitHub App        |
-| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                            | VCMS tags, storage rules, editorial, style    |
-| `team-workflow.md`  | All changes through PRs; never push to main                              | Full workflow, QA grades, escalation triggers |
-| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale > CLI > bootstrap > optimize > mesh | SSH, machines, Tailscale, macOS               |
-| `pr-workflow.md`    | Push branch, `gh pr create`, assign QA grade - never skip the PR             | Branch naming, commit format, PR template     |
+| Module                    | Key Rule (always applies)                                                       | Fetch for details                                        |
+| ------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `secrets.md`              | Verify secret VALUES, not just key existence                                    | Infisical, vault, API keys, GitHub App                   |
+| `content-policy.md`       | Never auto-save to VCMS; agents ARE the voice                                   | VCMS tags, storage rules, editorial, style               |
+| `team-workflow.md`        | All changes through PRs; never push to main                                     | Full workflow, QA grades, escalation triggers            |
+| `fleet-ops.md`            | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh    | SSH, machines, Tailscale, macOS                          |
+| `creating-issues.md`      | Backlog = GitHub Issues (`gh issue create`), never VCMS notes                   | Templates, labels, target repos                          |
+| `pr-workflow.md`          | Push branch, `gh pr create`, assign QA grade - never skip the PR                | Branch naming, commit format, PR template, post-merge QA |
+| `guardrails.md`           | Never deprecate features, drop schema, or change auth without Captain directive | Protected actions, escalation format, feature manifests  |
+| `wireframe-guidelines.md` | Wireframe committed and linked before status:ready (UI stories)                 | Wireframe generation, file conventions, quality bar      |
+| `design-system.md`        | Load design spec before wireframe/UI work: `crane_doc('sc', 'design-spec.md')`  | Design tokens, component patterns, venture specs         |
 
 Fetch with: `crane_doc('global', '<module>')`
 


### PR DESCRIPTION
## Summary
- Add enterprise rules section (guardrails reference)
- Add development workflow table with verify/format/lint/typecheck/test commands
- Add pre-commit and pre-push hooks documentation
- Add CI requirements
- Add QA grade labels table
- Add instruction modules table for crane_doc integration (9 modules including design-system.md)

## Test plan
- [x] CLAUDE.md contains all required sections from the venture template
- [x] Existing sc-specific content preserved (Build Commands, Tech Stack, Key Files, Security Requirements)
- [x] Pre-commit hooks ran successfully (Prettier formatting)
- [x] Pre-push verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)