### PR TITLE
docs: add v2.0 functional spec, PRD, and validation methodology

### DIFF
--- a/docs/methodology/00-strategy-session.md
+++ b/docs/methodology/00-strategy-session.md
@@ -1,0 +1,281 @@
+# SC Validation Methodology — Strategy Session (March 2026)
+
+> **Source:** Notion page `316786f4-e365-811a-8de3-cc396c256a72`
+> **Document Type:** Strategy Session Summary
+> **Date:** March 1, 2026
+> **Participants:** Captain + Advisor
+> **Status:** Active — Deep dives pending
+
+---
+
+## Context
+
+Silicon Crane is being rethought from first principles. The existing functional spec (v1.0) was built on assumptions that haven't been tested with real campaigns. As Ventracrane migrates off WordPress onto the venture-grade stack (Cloudflare Workers, D1, Astro), this is the right moment to revisit the validation methodology itself before rebuilding the tooling.
+
+The core question: **What does it actually mean to validate a business idea in a meaningful way?**
+
+Silicon Crane serves two purposes: first, as Ventracrane's own internal validation engine for portfolio ventures; second, as a potential public product (Validation-as-a-Service) offered to other entrepreneurs. Everything built internally should be architected with eventual productization in mind.
+
+## Methodology Foundation
+
+The Lean Startup methodology remains the north star. The three validation pillars are:
+
+1. **Problem is real** — Do customers actually have this problem and care about solving it?
+2. **Customers will pay** — Is there willingness to exchange money for a solution?
+3. **Buildability** — Can we create a sustainable solution at reasonable cost?
+
+Customer interviews should come first because they validate the problem space before money is spent on campaigns. However, in practice, lightweight customer discovery and messaging tests can run in parallel — ads tell you _what_ resonates, interviews tell you _why_ it resonates.
+
+## Validation Workflow (End-to-End)
+
+The complete validation cycle from idea to kill/pivot/accelerate decision:
+
+### Step 1: Idea Capture
+
+Someone at Ventracrane has a raw idea — a problem they've noticed, a market opportunity, something they think customers need. At this stage it's messy and half-baked. The idea gets captured and fed into the story-based framework (see Deep Dive #1) which articulates the customer problem, the stakes, and a potential solution. AI agents can automate the evolution of a raw idea into structured hypothesis components.
+
+**Output:** Structured Hypothesis Card — see Artifact Map
+
+### Step 2: Customer Discovery Interviews
+
+The story-structured hypothesis gets tested against real potential customers. The goal is to validate whether the problem is actually real and whether people care about solving it. This is a known bottleneck for a solopreneur — scaling interviews without losing signal quality is critical (see Deep Dive #3).
+
+**Output:** Discovery Summary — see Artifact Map
+
+### Step 3: Test Type Selection
+
+Before running campaigns, determine which type of test applies to the hypothesis. Different ideas need different test types: problem awareness, solution fit, pricing sensitivity, market size. The test type definition includes the landing page template, signal capture mechanism, success metrics, and pass/pivot/kill thresholds — the complete test blueprint (see Deep Dive #2).
+
+**Output:** Test Blueprint — see Artifact Map
+
+### Step 4: Marketing Content & Campaign Production
+
+Using what was learned from interviews, craft messaging around the validated problem using the story framework. Generate creative assets (images, copy, video) and launch lightweight social media campaigns in the $300-500 range to measure intent signals (see Deep Dive #4).
+
+**Output:** Campaign Package — see Artifact Map
+
+### Step 5: Landing Page & Signal Capture
+
+Campaigns drive traffic to landing pages that match the test type. Landing pages offer various engagement levels: join a waitlist, view pricing, commit to purchase, etc. The landing pages must align with test types and leverage marketing assets from the campaigns (see Deep Dive #5).
+
+**Output:** Live Experiment — see Artifact Map
+
+### Step 6: Measurement & Decision
+
+Results are measured against the metrics defined in the test type. The test definition itself includes pass/pivot/kill thresholds. A report is generated — internally for Ventracrane use, or delivered to the customer if offered as VaaS (see Deep Dive #6).
+
+**Output:** Validation Report — see Artifact Map
+
+### Step 7: Decision Outcomes
+
+The validation data is evaluated against the Decision Framework (see below) to reach one of four verdicts:
+
+- **Kill** — No viable demand. Archive and move on. The venture dies.
+- **Pivot** — Partial signal. Route through the Pivot Routing Table to the appropriate re-entry point.
+- **Accelerate (GO)** — Validated demand. Move into actual product development and go-to-market.
+- **Invalid** — Inconclusive data (insufficient sample size, data quality issues). Re-run or redesign the test.
+
+**Output:** Decision Memo — see Artifact Map
+
+---
+
+## Artifact Map
+
+Each step in the validation workflow produces a defined artifact that feeds the next step.
+
+| Step                   | Input                                            | Output Artifact                                                                                                                                                                        |
+| ---------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Idea Capture        | Raw Idea Brief                                   | **Structured Hypothesis Card** — customer, problem, stakes, solution, why-now, market sizing / competitive context (via story framework)                                               |
+| 2. Customer Discovery  | Hypothesis Card                                  | **Discovery Summary** — problem confirmed Y/N, pain severity 1-5, WTP signal, ICP refinements, top quotes, interview count                                                             |
+| 3. Test Type Selection | Discovery Summary + Hypothesis Card              | **Test Blueprint** — archetype, metrics + thresholds, landing page template, signal capture mechanism, budget, kill criteria, feasibility rating, build cost estimate, technical risks |
+| 4. Marketing Content   | Test Blueprint + Hypothesis Card                 | **Campaign Package** — ad copy variants, creative assets, targeting spec, channel selection                                                                                            |
+| 5. Landing Page        | Test Blueprint + Campaign Package                | **Live Experiment** — deployed page, tracking verified, signals capturing                                                                                                              |
+| 6. Measurement         | Live Experiment data + Test Blueprint thresholds | **Validation Report** — metrics vs thresholds, evidence table, sample size verification                                                                                                |
+| 7. Decision            | Validation Report                                | **Decision Memo** — GO / KILL / PIVOT / INVALID verdict + rationale                                                                                                                    |
+
+**Design notes:**
+
+- **Discovery Summary** is the bridging artifact that solves the Step 2 → Step 3 gap — it gives test selection concrete data to work from rather than relying on the original hypothesis alone.
+- **Hypothesis Card** persists as a reference through Steps 2-4 (not consumed and discarded at Step 1).
+- **INVALID** is added as a 4th decision outcome, matching FR-1502 in the functional spec.
+- **Buildability** is addressed as fields in the Test Blueprint (feasibility rating, build cost estimate, technical risks) rather than adding a separate step.
+- **Market sizing and competitive context** are addressed as fields in the Hypothesis Card, captured during idea structuring.
+
+---
+
+## Decision Framework
+
+### Accelerate (GO) Criteria
+
+All of the following must be met to issue a GO verdict:
+
+1. Primary metric meets or exceeds the threshold defined in the Test Blueprint
+2. Sample size rule satisfied — not just time-box expired (minimum 20 conversions or per-archetype minimum)
+3. Data quality verified — no INVALID flags (bot traffic, tracking failures, platform anomalies)
+4. Discovery Summary showed pain severity ≥ 3/5
+
+### Kill Criteria
+
+#### Hard Kill (immediate, no second chance)
+
+- CTR < 0.4% after 1,000+ impressions
+- Zero conversions after full budget spend
+- 0 out of 5+ interviews confirming the problem exists
+
+#### Soft Kill (after one creative/messaging swap)
+
+- Primary metric below 50% of threshold
+- CPL exceeds 2× the cap defined in Test Blueprint
+- All viable audience segments tested with no segment clearing threshold
+
+#### Kill Protocol
+
+- Decision Memo is required even for kills — document what was learned
+- Archive the full experiment pack (Hypothesis Card through Validation Report)
+- 90-day PII retention policy on any collected contact data, then purge
+
+### Pivot Routing Table
+
+When the verdict is PIVOT, use the signal pattern to determine re-entry point:
+
+| Signal Pattern                                                   | Pivot To | What Changes                                                     |
+| ---------------------------------------------------------------- | -------- | ---------------------------------------------------------------- |
+| Problem not confirmed in interviews                              | Step 1   | New Hypothesis Card with different ICP or problem angle          |
+| Problem confirmed, campaign metrics poor across variants         | Step 4   | New Campaign Package — revised messaging/channel                 |
+| Good CTR, poor landing page CVR                                  | Step 5   | Revised page CTA/offer; possibly revisit Test Blueprint (Step 3) |
+| Mixed metrics — some segments convert, others don't              | Step 3   | Narrow ICP in Test Blueprint, possibly different archetype       |
+| Inconclusive discovery (too few interviews, conflicting signals) | Step 2   | More interviews with tighter screening criteria                  |
+| Metrics meet threshold but unit economics fail                   | Step 3   | Revise budget model, test lower-cost channels                    |
+
+#### Pivot Rules
+
+- **Maximum 2 pivots** before a forced kill-or-park decision
+- Each pivot receives a new Experiment ID suffix (e.g., EXP-042a, EXP-042b)
+- **Total spend cap across pivots:** $1,500
+
+#### Budget Rationale
+
+$300-500 per test buys 150-600 clicks at typical $0.50-$2.00 CPCs. At a 10% CVR baseline, that yields 15-60 conversions — clearing the 20-conversion sample size minimum. The $500 upper range provides headroom for higher-CPC B2B tests where clicks may cost $3-5.
+
+---
+
+## Deep Dive List
+
+Six topics identified for detailed exploration, sequenced by dependency (each deep dive builds on the outputs of the ones before it). Each will become its own working document.
+
+| #   | Deep Dive                               | Rationale for Position                                                                                 |
+| --- | --------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 1   | Story-Based Framework (was #3)          | Foundational — the Hypothesis Card is the first artifact in the chain                                  |
+| 2   | Test Type Taxonomy (was #4)             | Core abstraction — metrics, thresholds, and templates all depend on this                               |
+| 3   | AI-Scaled Customer Discovery (was #1)   | Now references story framework outputs and feeds into test selection                                   |
+| 4   | AI-Generated Marketing Content (was #2) | Depends on story framework for messaging + test types for strategy                                     |
+| 5   | Landing Page Automation (was #5)        | Consumes test types + content pipeline outputs                                                         |
+| 6   | Measurement & Decision System (was #6)  | Renamed from "Accelerate" — calibration of thresholds, metric collection, decision framework evolution |
+
+### Deep Dive #1: Story-Based Framework for Ideas
+
+**The inspiration:** Donald Miller's StoryBrand framework — positioning the customer as the hero, the brand as the guide, with clear problem-solution-stakes narrative.
+
+**Questions to answer:**
+
+- How do we build our own branded framework inspired by StoryBrand principles without licensing issues?
+- Can AI agents take a raw idea and automatically scaffold it through the story framework?
+- What are the specific outputs of the framework that feed into test design?
+- How does this integrate with the existing Distill Brief concept in the functional spec?
+- What fields capture market sizing and competitive context within the Hypothesis Card?
+
+### Deep Dive #2: Test Type Taxonomy
+
+**The foundation:** This is the most critical piece. The test type determines everything downstream — metrics, campaign strategy, landing page design, success criteria.
+
+**Questions to answer:**
+
+- What are the standard test types Silicon Crane should offer?
+- How do you map from a story framework output to the right test type?
+- What metrics and thresholds define pass/pivot/kill for each type?
+- How does this relate to the 7 archetypes already defined in the functional spec?
+- Should we simplify, expand, or restructure the existing archetype system?
+- How are buildability fields (feasibility, cost, technical risks) assessed per archetype?
+
+### Deep Dive #3: AI-Scaled Customer Discovery Interviews
+
+**The bottleneck:** Customer discovery doesn't scale if it's just the founder doing interviews manually. LinkedIn contacts and cold calls based on web searches don't feel scalable.
+
+**Questions to answer:**
+
+- Can AI agents help source and screen interview candidates?
+- Can AI conduct preliminary discovery interviews?
+- What's the trade-off between AI interviews and human intuition for catching real pain points?
+- If offered as VaaS, do customers trust AI-conducted interviews?
+- What technology exists today to enable this?
+- How does the Discovery Summary artifact get populated from interview data?
+
+### Deep Dive #4: AI-Generated Marketing Content at Scale
+
+**The bottleneck:** Producing campaign content (images, infographics, videos, ad copy) is manual and doesn't scale for a solopreneur, let alone as a service offering.
+
+**Questions to answer:**
+
+- What AI tools can produce campaign-quality creative assets today?
+- How do we maintain brand consistency across AI-generated content?
+- What's the quality bar for social media campaign creative?
+- Can we build a content pipeline that generates complete campaign packages from a hypothesis?
+- What are the ethical considerations around AI-generated marketing content?
+- How does the story framework output inform messaging and creative direction?
+
+### Deep Dive #5: Landing Page Automation & Generation
+
+**The need:** Landing pages must match test types, pull in marketing creative, and capture the right signals.
+
+**Questions to answer:**
+
+- How do we automate landing page generation aligned to test types?
+- How do landing pages leverage the marketing assets produced for campaigns?
+- What's the minimum viable landing page system for validation?
+- How does this integrate with the existing pattern library concept in the functional spec?
+
+### Deep Dive #6: Measurement & Decision System
+
+**The scope:** Calibration and evolution of the measurement infrastructure and decision framework — how thresholds are set, how metrics are collected, and how the Decision Framework improves over time with data.
+
+**Questions to answer:**
+
+- How should initial thresholds be calibrated before we have historical data?
+- What measurement infrastructure is needed (analytics, event tracking, data pipelines)?
+- How does the Decision Framework evolve as we accumulate validation data across ventures?
+- What artifacts from validation carry forward when a venture receives a GO verdict?
+- How does the handoff work from Silicon Crane validation into Ventracrane product development?
+
+## Relationship to Existing Functional Spec
+
+The functional spec (v1.0) already covers much of this ground in detail — particularly the 7 archetypes, the 9-stage lifecycle, gates, and the decision framework. This strategy session is stepping back to question whether those assumptions are correct before rebuilding the tooling. The deep dives may confirm, modify, or replace elements of the existing spec.
+
+Key areas of overlap and potential revision:
+
+- The 7 archetypes may map to or be restructured as test types
+- The StoryBrand framework support (FR-203) needs to be fleshed out into a complete methodology
+- Customer interviews (Problem Interview Sprint archetype) may need to be elevated from one archetype to a foundational step in every validation
+- The AI-assisted generation capabilities need to be evaluated against current AI tooling capabilities
+
+### Strategy → Functional Spec Mapping
+
+| Strategy Concept                             | FR Reference                         | Status                                    |
+| -------------------------------------------- | ------------------------------------ | ----------------------------------------- |
+| Structured Hypothesis Card (story framework) | FR-203 (StoryBrand support)          | Confirmed — expanding scope               |
+| Discovery Summary artifact                   | —                                    | New — not in v1.0 spec                    |
+| Test Blueprint / archetype selection         | FR-301 through FR-307 (7 archetypes) | Under review — may restructure            |
+| Campaign Package generation                  | FR-401 (AI content generation)       | Confirmed — scope TBD in Deep Dive #4     |
+| Landing page automation                      | FR-501 (pattern library)             | Confirmed — scope TBD in Deep Dive #5     |
+| Validation Report                            | FR-601 (analytics dashboard)         | Under review — may need richer artifact   |
+| INVALID as 4th outcome                       | FR-1502 (inconclusive handling)      | Confirmed — aligns with spec              |
+| Pivot Routing Table                          | FR-701 (pivot recommendations)       | New structure — replaces simple loop-back |
+| Kill protocol / archival                     | FR-702 (kill archival)               | Confirmed — adding PII retention rule     |
+| Buildability in Test Blueprint               | —                                    | New — addresses 3rd validation pillar     |
+
+## Next Steps
+
+1. Begin deep dives sequentially, starting with **Deep Dive #1: Story-Based Framework**
+2. Deep Dive #1 defines the Hypothesis Card structure, which unlocks Deep Dives #2-4
+3. Each deep dive produces a working document with recommendations
+4. Recommendations feed back into an updated functional spec (v2.0)
+5. Updated spec drives the technical rebuild on the venture-grade stack

--- a/docs/methodology/01-deep-dive-venture-narrative.md
+++ b/docs/methodology/01-deep-dive-venture-narrative.md
@@ -1,0 +1,298 @@
+# Deep Dive #1: Story-Based Framework — The Venture Narrative
+
+> **Source:** Notion page `318786f4e365811f8590c2e625c3b324`
+> **Document Type:** Deep Dive Working Document
+> **Series:** SC Validation Methodology
+> **Date:** March 2, 2026
+> **Status:** Complete — pending functional spec integration
+> **Parent:** SC Validation Methodology — Strategy Session (March 2026)
+
+---
+
+# 1. Purpose & Scope
+
+This deep dive defines the **Structured Hypothesis Card** — the first artifact in the SC validation workflow (Step 1 output). It answers the five questions identified in the strategy session for Deep Dive #1: Story-Based Framework for Ideas.
+
+**What this document covers:**
+
+- A branded story-based framework ("Venture Narrative") for structuring raw ideas into testable hypotheses
+- The Structured Hypothesis Card field specification with two completion tiers
+- An early-kill mechanism (confidence score + red flag patterns) to make Step 1 the cheapest kill point
+- Integration path with the existing Distill Brief and functional spec
+- AI agent automation workflow for card generation
+
+**Relationship to the validation workflow:**
+
+The Hypothesis Card is consumed by Steps 2–4 in the validation chain. It persists as a reference artifact — not consumed and discarded at Step 1. Customer Discovery (Step 2) enriches it, Test Type Selection (Step 3) reads from it, and Marketing Content (Step 4) uses it for messaging direction.
+
+---
+
+# 2. Framework Design — The Venture Narrative
+
+The **Venture Narrative** is SC's branded story-based framework for structuring business hypotheses. It is inspired by the hero/guide narrative structure popularized in brand storytelling, adapted specifically for hypothesis validation.
+
+## The Five Narrative Elements
+
+### 1. The Hero
+
+Who is the customer? A specific segment — not "everyone." Defined by demographics, psychographics, and behavioral characteristics. Specific enough to find 5 real people matching the description.
+
+### 2. The Struggle
+
+What problem do they face? Articulated across three dimensions:
+
+- **Functional pain** — What doesn't work, or takes too long?
+- **Emotional cost** — How does this problem make them feel? (frustrated, anxious, embarrassed)
+- **Opportunity cost** — What can't they do because of this problem?
+
+### 3. The Stakes
+
+What happens if this stays unsolved? And what does success look like? Both sides of the coin — the cost of inaction and the desired transformation.
+
+### 4. The Breakthrough
+
+What's our proposed solution? The brand is positioned as the guide enabling the hero's success — not as the hero itself.
+
+### 5. The Moment
+
+Why now? What has changed — new technology, regulatory shift, cultural moment, market timing — that makes this problem solvable or urgent today?
+
+## Design Rationale
+
+**Five elements instead of seven.** Traditional story-based marketing frameworks include Guide, Plan, and Call-to-Action as separate elements. Those are marketing execution concerns addressed in Step 4 (Campaign Package), not hypothesis structuring. The Venture Narrative keeps the focus on what needs to be validated.
+
+**Validation-native problem taxonomy.** The three-dimensional problem decomposition uses **Functional Pain / Emotional Cost / Opportunity Cost** rather than the external/internal/philosophical framing common in brand storytelling. This framing is oriented toward measuring pain severity in Step 2 (Customer Discovery) — each dimension maps to interview questions and can be scored on a severity scale.
+
+---
+
+# 3. The Structured Hypothesis Card — Field Specification
+
+The Hypothesis Card has two completion tiers, reflecting the reality that some fields can't be well-informed until after customer discovery.
+
+## Tier 1 — Draft Card
+
+_Approximately 30 minutes to complete. Sufficient to enter Step 2 (Customer Discovery)._
+
+| Field                   | Description                                                                                                                   | Narrative Element | Replaces (Distill Brief) |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------------ |
+| **Customer Segment**    | Specific ICP — demographics, psychographics, one segment per card. Must be specific enough to find 5 real people matching it. | The Hero          | `target_audience`        |
+| **Problem Statement**   | The core friction — articulated across functional pain, emotional cost, and opportunity cost.                                 | The Struggle      | `problem_statement`      |
+| **Stakes: Failure**     | What the customer loses if this stays unsolved — the cost of inaction.                                                        | The Stakes        | — (new)                  |
+| **Stakes: Success**     | The transformation or outcome the customer desires.                                                                           | The Stakes        | — (new)                  |
+| **Solution Hypothesis** | What we believe solves it — positioned as guide enabling the hero.                                                            | The Breakthrough  | `value_proposition`      |
+| **Why Now**             | Market shift, new technology, regulatory change, or cultural moment that creates urgency.                                     | The Moment        | — (new)                  |
+
+6 core fields. Enough narrative structure to run customer discovery interviews.
+
+## Tier 2 — Full Card
+
+_Enriched after Step 2 discovery, before Step 3 test selection._
+
+| Field                     | Description                                                                                    | Narrative Element | Replaces (Distill Brief) |
+| ------------------------- | ---------------------------------------------------------------------------------------------- | ----------------- | ------------------------ |
+| **Current Alternatives**  | How the customer solves this today (including "do nothing"). Informed by discovery interviews. | The Struggle      | — (new)                  |
+| **Market Sizing**         | TAM / SAM / SOM estimates with methodology notes.                                              | Context           | `market_size_estimate`   |
+| **Competitive Landscape** | Direct competitors, adjacent solutions, positioning gaps.                                      | Context           | — (new)                  |
+| **Key Assumptions**       | 3–5 riskiest things that must be true — structured format (see below).                         | Validation Bridge | — (new)                  |
+
+10 fields total (Tier 1 + Tier 2). Strict superset of the 4 Distill Brief fields.
+
+## Key Assumptions — Structured Format
+
+Each assumption follows this template:
+
+> **We believe** \[testable claim\] **because** \[evidence or reasoning\].
+> **Risk:** High / Medium / Low — **Basis:** \[what we know or don't know\]
+
+### Risk Rubric
+
+- **High** — No evidence, business-critical. If wrong, the venture fails.
+- **Medium** — Some indirect evidence, important but not fatal if wrong.
+- **Low** — Reasonable evidence, worth confirming but unlikely to derail.
+
+### Worked Examples
+
+> **Good example:** "We believe marketing managers at B2B SaaS companies (50–200 employees) will pay \$99/mo for automated competitor tracking because 3/5 discovery interviewees mentioned doing this manually in spreadsheets. Risk: Medium — we have interview signal but no payment commitment."
+
+> **Bad example:** "People will want this product." — Not testable, no evidence, no specificity.
+
+---
+
+# 3.5. Card Confidence Score & Early Kill
+
+After completing the card (either tier), the founder or AI agent assigns a confidence rating.
+
+**Confidence:** `Proceed` / `Uncertain` / `Abandon` — with a one-line justification.
+
+## Red Flag Patterns
+
+Any one of the following suggests **Abandon** or pivot before spending on Steps 2–4:
+
+- Cannot articulate **Why Now** after honest attempt
+- Customer Segment is "everyone" or "small businesses" (too broad to validate)
+- No differentiation from Current Alternatives that the customer would notice
+- All Key Assumptions are High-risk with zero supporting evidence
+- Stakes: Failure produces a shrug, not urgency
+
+This makes Step 1 the **cheapest kill point** in the validation workflow. Over time, tracking the kill rate at Step 1 vs. later steps provides methodology effectiveness data.
+
+---
+
+# 3.7. Schema Sketch
+
+Field specification for the `hypothesis_card` JSONB column, to minimize interpretation during implementation:
+
+```json
+{
+  "customer_segment": { "type": "string", "required": true, "maxLength": 500, "tier": 1 },
+  "problem_statement": { "type": "string", "required": true, "maxLength": 1000, "tier": 1 },
+  "stakes_failure": { "type": "string", "required": true, "maxLength": 500, "tier": 1 },
+  "stakes_success": { "type": "string", "required": true, "maxLength": 500, "tier": 1 },
+  "solution_hypothesis": { "type": "string", "required": true, "maxLength": 1000, "tier": 1 },
+  "why_now": { "type": "string", "required": true, "maxLength": 500, "tier": 1 },
+  "current_alternatives": { "type": "string", "required": false, "maxLength": 1000, "tier": 2 },
+  "market_sizing": { "type": "string", "required": false, "maxLength": 1000, "tier": 2 },
+  "competitive_landscape": { "type": "string", "required": false, "maxLength": 1000, "tier": 2 },
+  "key_assumptions": {
+    "type": "array",
+    "required": false,
+    "tier": 2,
+    "items": {
+      "claim": "string",
+      "evidence": "string",
+      "risk": "high | medium | low",
+      "basis": "string"
+    },
+    "minItems": 3,
+    "maxItems": 5
+  },
+  "confidence": { "type": "string", "enum": ["proceed", "uncertain", "abandon"], "required": true },
+  "confidence_rationale": { "type": "string", "required": true, "maxLength": 500 },
+  "one_liner": { "type": "string", "required": false, "maxLength": 200 },
+  "tier": { "type": "string", "enum": ["draft", "full"], "required": true }
+}
+```
+
+---
+
+# 4. Venture Narrative One-Liner
+
+The one-liner is an **AI-generated synthesis**, not a template interpolation. After all card fields are populated, the agent generates a single sentence that captures the essence of the hypothesis.
+
+## Quality Criteria
+
+- Under 30 words
+- Readable aloud in one breath
+- A stranger with no context would understand the business idea
+- Editable by human reviewer
+
+## Examples
+
+> **Good:** "Time-pressed B2B marketers waste 5+ hours weekly tracking competitors manually — CompetitorPulse automates it for \$99/mo."
+
+> **Bad:** "Our target segment of marketing managers at B2B SaaS companies with 50–200 employees struggles with the problem of tracking competitors which causes frustration and lost opportunity."
+
+The bad example fails three criteria: over 30 words, not readable in one breath, reads like a database dump rather than a pitch.
+
+---
+
+# 5. Integration with Existing Spec
+
+## Distill Brief Migration Path
+
+- The Hypothesis Card **replaces** the Distill Brief as the pre-experiment structuring tool
+- The 4 existing Distill Brief DB columns remain for backward compatibility, populated FROM card fields
+- Field mapping:
+
+| Distill Brief Column   | Populated From      |
+| ---------------------- | ------------------- |
+| `target_audience`      | Customer Segment    |
+| `problem_statement`    | Problem Statement   |
+| `value_proposition`    | Solution Hypothesis |
+| `market_size_estimate` | Market Sizing       |
+
+## Relationship to BVM 24-Step Framework
+
+- **Draft Card (Tier 1)** is the minimum viable capture — enough to start validating
+- **Full Card (Tier 2)** captures the output of a lightweight pass through BVM Steps 1–12
+- For full BVM engagements (VaaS clients), the 24 steps produce a richer version of the same structure
+
+## Relationship to CopyPack Schema
+
+- CopyPack is generated FROM the Hypothesis Card in Step 4
+- Stakes fields feed `urgency_hook`
+- Solution Hypothesis feeds `value_props`
+- Customer Segment feeds targeting parameters
+
+---
+
+# 6. AI Agent Automation
+
+## Input
+
+Raw idea brief (free text) from the founder or intake form.
+
+## Agent Workflow
+
+1. **Extract & Structure** — Parse the raw idea into Tier 1 draft card fields. Fill what's stated, flag what's missing.
+2. **Research & Enrich** — For Tier 2 fields: web search for market sizing, identify competitors, assess why-now signals.
+3. **Challenge & Stress-Test** — Generate structured Key Assumptions. Rate risk per rubric. Identify red flag patterns.
+4. **Generate Variants** — 2–3 alternative framings: different customer segments, problem angles, solution approaches.
+5. **Synthesize One-Liner** — Generate one-liner from completed card (AI synthesis, not template interpolation).
+6. **Assign Confidence** — Evaluate red flag patterns, propose confidence score with rationale.
+7. **Human Review Gate** — Present card(s) for human review. No auto-save to VCMS.
+
+## Quality Criteria for AI-Generated Cards
+
+- Every Tier 1 field populated (no blanks)
+- Customer Segment passes the "find 5 real people" test
+- Problem Statement articulates all three dimensions (functional, emotional, opportunity cost)
+- At least 3 Key Assumptions with structured format
+- Market Sizing includes methodology (not just a number)
+- Confidence score with honest rationale
+
+---
+
+# 7. Answering the Five Questions
+
+The strategy session identified five questions for this deep dive. Here are the answers:
+
+**1. How do we build our own branded framework inspired by StoryBrand principles without licensing issues?**
+
+The **Venture Narrative** — 5 elements (Hero, Struggle, Stakes, Breakthrough, Moment) with a validation-native problem taxonomy (Functional Pain / Emotional Cost / Opportunity Cost). No StoryBrand trademarked terminology or structure used. The problem decomposition creates real IP distance by orienting toward pain severity measurement rather than marketing philosophy.
+
+**2. Can AI agents take a raw idea and automatically scaffold it through the story framework?**
+
+Yes — a 7-step agent workflow takes a raw idea brief through extraction, research, stress-testing, variant generation, one-liner synthesis, and confidence scoring. Tier 1 draft cards can be generated in minutes. Tier 2 enrichment happens after discovery interviews.
+
+**3. What are the specific outputs of the framework that feed into test design?**
+
+The **Structured Hypothesis Card** — 10 fields across 2 tiers, plus an AI-generated one-liner and confidence score. The card persists through Steps 2–4 as a reference artifact. Key Assumptions bridge directly to kill criteria in Deep Dive #2.
+
+**4. How does this integrate with the existing Distill Brief concept in the functional spec?**
+
+The Hypothesis Card is a strict superset of the Distill Brief's 4 fields. The card replaces the Brief as the structuring tool; legacy DB columns are populated from card fields for backward compatibility.
+
+**5. What fields capture market sizing and competitive context within the Hypothesis Card?**
+
+**Market Sizing** (TAM/SAM/SOM with methodology notes) and **Competitive Landscape** (direct competitors, adjacent solutions, positioning gaps) are dedicated Tier 2 fields, enriched after customer discovery.
+
+---
+
+# 8. Recommendations for Functional Spec v2.0
+
+1. **Replace Distill Brief** with Hypothesis Card schema (see Schema Sketch in Section 3.7)
+2. **Add `hypothesis_card` JSONB column** to the experiments table
+3. **Keep legacy Distill Brief columns** as computed views populated from card fields
+4. **Add confidence score as a workflow gate** — Abandon triggers archive, Uncertain triggers flag for review
+5. **Define AI agent scaffolding** as a system capability (7-step workflow)
+6. **Key Assumptions bridge** directly to `kill_criteria` in Deep Dive #2 (Test Type Taxonomy)
+
+---
+
+# 9. Open Questions for Deep Dive #2
+
+- How do Key Assumptions map to specific test archetypes?
+- Does each archetype have a recommended Hypothesis Card template?
+- How does Competitive Landscape inform channel selection?
+- How does the confidence score interact with test budget allocation?

--- a/docs/methodology/02-deep-dive-validation-ladder.md
+++ b/docs/methodology/02-deep-dive-validation-ladder.md
@@ -1,0 +1,1510 @@
+# Deep Dive #2: Test Type Taxonomy — The Validation Ladder
+
+> **Source:** Notion page `318786f4e36581c89f22f7a6fe58d2cc`
+> **Document Type:** Deep Dive Working Document
+> **Series:** SC Validation Methodology
+> **Date:** March 2, 2026
+> **Status:** Complete — pending functional spec integration
+> **Parent:** SC Validation Methodology — Strategy Session (March 2026)
+> **Prior:** Deep Dive #1: Story-Based Framework — The Venture Narrative
+
+---
+
+# 1. Purpose & Scope
+
+This deep dive defines the **Test Blueprint** — the third artifact in the SC validation workflow (Step 3 output). It answers the six questions identified in the strategy session for Deep Dive #2: Test Type Taxonomy.
+
+**What this document covers:**
+
+- A restructured archetype system (the "Validation Ladder") that replaces the functional spec v1.0 taxonomy
+- Detailed per-archetype specifications with metrics, thresholds, kill criteria, and decision rules
+- The mapping from Hypothesis Card assumptions to test type selection
+- The Test Blueprint artifact specification and schema
+- Test sequencing strategy for multi-rung validation
+- Kill criteria defaults and calibration mechanics
+
+**Relationship to the validation workflow:**
+
+The Test Blueprint consumes the Hypothesis Card (Step 1) and the Discovery Summary (Step 2) to produce a fully specified experiment design. It feeds into Campaign Package generation (Step 4) and Landing Page construction (Step 5). The metrics and thresholds defined here are evaluated in Step 6 (Measurement) against the Decision Framework established in the strategy session.
+
+**Relationship to Deep Dive #1:**
+
+The Hypothesis Card's **Key Assumptions** are the primary input for test type selection. Each assumption's risk level and type (demand, willingness-to-pay, buildability) maps to a specific category on the Validation Ladder. The **confidence score** from DD#1 interacts with budget allocation — lower confidence warrants cheaper first-rung tests.
+
+---
+
+# 2. Archetype Restructuring — The Validation Ladder
+
+## Changes from Functional Spec v1.0
+
+The v1.0 spec defined 7 archetypes: `waitlist`, `priced_waitlist`, `presale`, `service_pilot`, `content_magnet`, `concierge`, and `interview`. This deep dive restructures the taxonomy based on what was learned in the strategy session and DD#1.
+
+### Removing `interview`
+
+Customer discovery interviews are no longer an archetype — they are a **foundational step** (Step 2) that precedes all test types. The strategy session elevated interviews from "one test among many" to "a required phase in every validation." The Discovery Summary artifact bridges interview outputs into test selection. Removing `interview` from the archetype list eliminates the confusion between a methodology step and a campaign-driven experiment.
+
+### Adding `fake_door`
+
+The `fake_door` archetype fills a critical gap: the **cheapest, fastest demand signal test**. A fake door presents a product concept (button, feature, pricing page) that does not yet exist and measures click-through or signup intent. It costs less than a waitlist, runs faster, and answers the most basic question: "Does anyone care enough to click?"
+
+Fake doors are the default entry point for ventures with high-risk demand assumptions and no prior signal.
+
+### Three Categories
+
+The 7 archetypes are organized into three categories that map to the three validation pillars from the strategy session:
+
+**Demand Signal** — Is the problem real and does anyone care?
+
+- `fake_door`
+- `waitlist`
+- `content_magnet`
+
+**Willingness to Pay (WTP)** — Will customers exchange money for a solution?
+
+- `priced_waitlist`
+- `presale`
+
+**Solution Validation** — Can we deliver the solution and do customers value the actual experience?
+
+- `concierge`
+- `service_pilot`
+
+### Summary of Changes
+
+| Change                              | Rationale                                                                                      |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Removed `interview`                 | Elevated to foundational Step 2; not a campaign-driven experiment                              |
+| Added `fake_door`                   | Cheapest demand signal; fills the gap below `waitlist`                                         |
+| Organized into 3 categories         | Maps to validation pillars; clarifies what each test actually proves                           |
+| Category names use plain language   | "Demand Signal" / "Willingness to Pay" / "Solution Validation" instead of academic terminology |
+| Buildability assessed per-archetype | Addresses the 3rd validation pillar identified in the strategy session                         |
+
+### Updated CHECK Constraint
+
+The `archetype` column CHECK constraint in the experiments table changes from:
+
+```sql
+-- v1.0
+CHECK(archetype IN ('waitlist','priced_waitlist','presale','service_pilot','content_magnet','concierge','interview'))
+
+-- v2.0
+CHECK(archetype IN ('fake_door','waitlist','content_magnet','priced_waitlist','presale','concierge','service_pilot'))
+```
+
+Migration required: rename existing `interview` experiments to an archived status or migrate to the appropriate replacement archetype.
+
+---
+
+# 3. Per-Archetype Specifications
+
+Each archetype is specified with the same structure: description, what it validates, signal capture mechanism, metrics and thresholds, kill criteria JSON, budget and duration, landing page spec, CopyPack requirements, buildability rating and checklist, decision criteria, usage guidance, and a worked example.
+
+---
+
+## 3.1 `fake_door` — Demand Signal
+
+**Description:** A fake door test presents a product, feature, or offer that does not yet exist and measures whether potential customers take the action to learn more, sign up, or engage. The "door" leads to a capture page (email, waitlist, or "coming soon" acknowledgment) rather than an actual product. It is the lightest-weight demand signal available.
+
+**What it validates:** Basic demand — do people in the target segment care enough about this problem/solution to take a micro-action (click, sign up)?
+
+**Signal capture:** Email submission on a "coming soon" or "notify me" page. The visitor sees a compelling value proposition, clicks the CTA, and lands on a capture form. The conversion event is the form submission.
+
+### Metrics & Thresholds
+
+| Metric                   | Target (GO) | Amber (Investigate) | Kill           |
+| ------------------------ | ----------- | ------------------- | -------------- |
+| CVR (sessions to signup) | >= 2%       | 0.5% - 2%           | < 0.5%         |
+| CPL (cost per lead)      | <= $8       | $8 - $20            | > $20          |
+| CTR (ad click-through)   | >= 1%       | 0.4% - 1%           | < 0.4%         |
+| Min. conversions         | >= 20       | 10 - 20             | < 10 (INVALID) |
+
+### Kill Criteria JSON
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "metric": "cvr_bp",
+      "operator": "lt",
+      "threshold": 50,
+      "label": "Conversion rate below 0.5%"
+    },
+    {
+      "metric": "cpl_cents",
+      "operator": "gt",
+      "threshold": 2000,
+      "label": "Cost per lead exceeds $20"
+    },
+    {
+      "metric": "total_spend_cents",
+      "operator": "gte",
+      "threshold": 30000,
+      "label": "Total spend reaches $300 budget cap"
+    },
+    {
+      "metric": "days_elapsed",
+      "operator": "gt",
+      "threshold": 7,
+      "label": "Test duration exceeds 7 days"
+    }
+  ]
+}
+```
+
+### Budget & Duration
+
+| Parameter                         | Value       |
+| --------------------------------- | ----------- |
+| Budget range                      | $150 - $300 |
+| Duration                          | 7 days      |
+| Min. sample (sessions)            | 1,000       |
+| Min. conversions for valid result | 20          |
+
+### Landing Page Spec
+
+- **Template:** Single-page, above-the-fold value proposition with CTA button
+- **Sections:** Headline, subheadline, 3 value props (bullet or icon), single CTA button, minimal footer
+- **CTA:** "Get Notified" / "Join the Waitlist" / "Notify Me When It Launches"
+- **Post-CTA:** Thank-you message confirming interest was recorded. No product access, no timeline promise.
+- **No pricing shown** — this tests demand, not WTP
+- **Mobile-first** — majority of ad traffic arrives on mobile
+
+### CopyPack Requirements
+
+The CopyPack for a fake door test requires these fields from the standard schema:
+
+- `headline` — must articulate the core value proposition in under 10 words
+- `subheadline` — expands on the problem being solved
+- `value_props` — 3 bullet points (functional benefit, emotional benefit, differentiation)
+- `cta_primary` — the fake door CTA text
+- `ad_headlines` — 3-5 variants for A/B testing in ad platform
+- `ad_descriptions` — 3-5 variants
+- `meta_title`, `meta_description`, `og_title`, `og_description`
+
+Optional fields not required: `cta_secondary`, `social_proof` (no proof exists yet), `urgency_hook` (can be added but not required).
+
+### Buildability Rating
+
+**Buildability: 1/5** — Minimal technical requirements.
+
+| Checklist Item                 | Required? |
+| ------------------------------ | --------- |
+| Landing page (single template) | Yes       |
+| Email capture form             | Yes       |
+| Ad account + campaign          | Yes       |
+| Payment integration            | No        |
+| Backend service / fulfillment  | No        |
+| Custom development             | No        |
+
+### Decision Criteria
+
+- **GO:** CVR >= 2% AND CPL <= $8 AND min. 20 conversions AND no INVALID flags. Proceed to next rung on the Validation Ladder (typically `waitlist` or `priced_waitlist`).
+- **KILL:** CVR < 0.5% after 1,000+ sessions OR CPL > $20 OR zero conversions after full budget spend. Issue Decision Memo with kill rationale. Archive experiment.
+- **PIVOT:** CVR in amber range (0.5% - 2%) with 10+ conversions. Check if specific audience segments outperform. Options: swap messaging (Step 4 re-entry), narrow ICP (Step 3 re-entry), or test different problem angle (Step 1 re-entry).
+- **INVALID:** Fewer than 10 conversions AND fewer than 500 sessions. Insufficient data — extend budget or relaunch with revised targeting.
+
+### When to Use
+
+- **Use when:** First test for a new venture hypothesis. No prior demand signal exists. Key Assumptions include high-risk demand assumptions. Budget is constrained. You want the cheapest possible signal before investing further.
+- **Do not use when:** Demand has already been validated (skip to WTP tests). The hypothesis is about pricing, not demand. The product already exists and has users.
+
+### Worked Example
+
+> **Venture:** CompetitorPulse — automated competitor tracking for B2B marketers
+>
+> **Hypothesis Card excerpt:** "We believe marketing managers at B2B SaaS companies (50-200 employees) waste 5+ hours weekly tracking competitors manually."
+>
+> **Test setup:** Facebook/LinkedIn campaign targeting B2B marketing managers. Ad creative emphasizes the time-waste problem. Landing page headline: "Stop Wasting 5 Hours a Week on Competitor Research." CTA: "Get Notified When We Launch." Budget: $200 over 7 days.
+>
+> **Results:** 1,400 sessions, 42 signups. CVR = 3.0%. CPL = $4.76. CTR = 1.8%.
+>
+> **Decision:** GO — all metrics exceed thresholds. 42 conversions well above the 20 minimum. Proceed to `priced_waitlist` test to validate WTP at the $99/mo price point.
+
+---
+
+## 3.2 `waitlist` — Demand Signal
+
+**Description:** A waitlist test captures email signups from people who want to be notified when a product or service becomes available. Unlike a fake door, a waitlist implies a more concrete product concept — the visitor understands what they would be getting, even if it does not exist yet. The commitment level is slightly higher: the visitor expects to hear from you again.
+
+**What it validates:** Sustained demand signal — do people want this enough to give their email and expect follow-up? Higher-fidelity than a fake door because the implied social contract is stronger.
+
+**Signal capture:** Email submission with optional additional fields (name, company, role). The visitor sees a more detailed value proposition, understands the product concept, and actively joins a waitlist.
+
+### Metrics & Thresholds
+
+| Metric                   | Target (GO) | Amber (Investigate) | Kill           |
+| ------------------------ | ----------- | ------------------- | -------------- |
+| CVR (sessions to signup) | >= 3%       | 1% - 3%             | < 1%           |
+| CPL (cost per lead)      | <= $15      | $15 - $30           | > $30          |
+| CTR (ad click-through)   | >= 1%       | 0.4% - 1%           | < 0.4%         |
+| Min. conversions         | >= 25       | 15 - 25             | < 15 (INVALID) |
+
+### Kill Criteria JSON
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "metric": "cvr_bp",
+      "operator": "lt",
+      "threshold": 100,
+      "label": "Conversion rate below 1%"
+    },
+    {
+      "metric": "cpl_cents",
+      "operator": "gt",
+      "threshold": 3000,
+      "label": "Cost per lead exceeds $30"
+    },
+    {
+      "metric": "total_spend_cents",
+      "operator": "gte",
+      "threshold": 50000,
+      "label": "Total spend reaches $500 budget cap"
+    },
+    {
+      "metric": "days_elapsed",
+      "operator": "gt",
+      "threshold": 14,
+      "label": "Test duration exceeds 14 days"
+    }
+  ]
+}
+```
+
+### Budget & Duration
+
+| Parameter                         | Value       |
+| --------------------------------- | ----------- |
+| Budget range                      | $300 - $500 |
+| Duration                          | 14 days     |
+| Min. sample (sessions)            | 1,500       |
+| Min. conversions for valid result | 25          |
+
+### Landing Page Spec
+
+- **Template:** Single-page with expanded product description
+- **Sections:** Headline, subheadline, problem statement, solution overview (3-5 features/benefits), social proof placeholder, CTA, FAQ (optional), footer
+- **CTA:** "Join the Waitlist" / "Reserve Your Spot" / "Get Early Access"
+- **Post-CTA:** Thank-you page with estimated timeline and option to share with colleagues
+- **No pricing shown** — demand test, not WTP
+- **Email sequence:** Welcome email via Kit with product concept overview
+
+### CopyPack Requirements
+
+All standard CopyPack fields required:
+
+- `headline`, `subheadline`, `value_props` (3-5 bullets)
+- `cta_primary` — waitlist CTA text
+- `social_proof` — can be placeholder ("Join 100+ marketers on the waitlist") once initial signups arrive
+- `ad_headlines`, `ad_descriptions` — 3-5 variants each
+- `meta_title`, `meta_description`, `og_title`, `og_description`
+- `urgency_hook` — optional ("Limited early-access spots")
+
+### Buildability Rating
+
+**Buildability: 1/5** — Minimal technical requirements, same as fake door.
+
+| Checklist Item                    | Required? |
+| --------------------------------- | --------- |
+| Landing page (single template)    | Yes       |
+| Email capture form (name + email) | Yes       |
+| Email welcome sequence (Kit)      | Yes       |
+| Ad account + campaign             | Yes       |
+| Payment integration               | No        |
+| Backend service / fulfillment     | No        |
+| Custom development                | No        |
+
+### Decision Criteria
+
+- **GO:** CVR >= 3% AND CPL <= $15 AND min. 25 conversions AND no INVALID flags. Proceed to WTP test (`priced_waitlist` or `presale`) depending on the venture's pricing model.
+- **KILL:** CVR < 1% after 1,500+ sessions OR CPL > $30 OR zero conversions after full budget spend.
+- **PIVOT:** CVR in amber range (1% - 3%) with 15+ conversions. Investigate segment performance, messaging resonance, channel effectiveness. Options: revised messaging, narrower ICP, different channel.
+- **INVALID:** Fewer than 15 conversions AND fewer than 800 sessions. Extend or relaunch.
+
+### When to Use
+
+- **Use when:** You want a higher-fidelity demand signal than a fake door. The product concept is concrete enough to describe features and benefits. You want to build an early audience for launch. Discovery interviews confirmed the problem but you need quantitative demand data.
+- **Do not use when:** You have no prior demand signal (start with `fake_door`). You need to validate pricing (use `priced_waitlist`). The product already exists and has paying users.
+
+### Worked Example
+
+> **Venture:** MealPrepPro — AI-generated weekly meal plans for busy families
+>
+> **Hypothesis Card excerpt:** "We believe dual-income parents with children under 12 spend 3+ hours weekly planning meals and grocery shopping, and would use an AI tool to cut that to 15 minutes."
+>
+> **Discovery Summary:** 7/10 interviews confirmed the problem. Pain severity 4/5. All interviewees currently use a combination of Pinterest, spreadsheets, and memory.
+>
+> **Test setup:** Instagram/Facebook campaign targeting parents 28-45 with interests in meal planning, healthy eating. Landing page describes the AI meal planning concept with feature preview. CTA: "Join the Waitlist for Early Access." Budget: $400 over 14 days.
+>
+> **Results:** 2,100 sessions, 84 signups. CVR = 4.0%. CPL = $4.76. CTR = 2.1%.
+>
+> **Decision:** GO — strong demand signal. Proceed to `priced_waitlist` to validate WTP at $9.99/mo.
+
+---
+
+## 3.3 `content_magnet` — Demand Signal
+
+**Description:** A content magnet test offers a free resource (guide, checklist, template, mini-course, tool) in exchange for an email signup. The content is directly related to the problem the venture solves, so capturing the lead validates both interest in the problem space and willingness to engage with content around it. The content itself is a lightweight deliverable — not the full product.
+
+**What it validates:** Problem awareness and engagement intent. People who download a guide about a problem are likely experiencing that problem. Higher intent signal than a fake door (they want to consume content), but lower commitment than a waitlist (they get something immediately rather than waiting).
+
+**Signal capture:** Email submission to receive the content resource. The visitor sees a description of the free resource, submits their email, and receives the resource via email or immediate download.
+
+### Metrics & Thresholds
+
+| Metric                     | Target (GO) | Amber (Investigate) | Kill           |
+| -------------------------- | ----------- | ------------------- | -------------- |
+| CVR (sessions to download) | >= 5%       | 2% - 5%             | < 2%           |
+| CPL (cost per lead)        | <= $10      | $10 - $25           | > $25          |
+| CTR (ad click-through)     | >= 1.5%     | 0.5% - 1.5%         | < 0.5%         |
+| Min. conversions           | >= 25       | 15 - 25             | < 15 (INVALID) |
+
+### Kill Criteria JSON
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "metric": "cvr_bp",
+      "operator": "lt",
+      "threshold": 200,
+      "label": "Conversion rate below 2%"
+    },
+    {
+      "metric": "cpl_cents",
+      "operator": "gt",
+      "threshold": 2500,
+      "label": "Cost per lead exceeds $25"
+    },
+    {
+      "metric": "total_spend_cents",
+      "operator": "gte",
+      "threshold": 40000,
+      "label": "Total spend reaches $400 budget cap"
+    },
+    {
+      "metric": "days_elapsed",
+      "operator": "gt",
+      "threshold": 14,
+      "label": "Test duration exceeds 14 days"
+    }
+  ]
+}
+```
+
+### Budget & Duration
+
+| Parameter                         | Value       |
+| --------------------------------- | ----------- |
+| Budget range                      | $200 - $400 |
+| Duration                          | 14 days     |
+| Min. sample (sessions)            | 1,000       |
+| Min. conversions for valid result | 25          |
+
+### Landing Page Spec
+
+- **Template:** Content-focused landing page with resource preview
+- **Sections:** Headline (what the resource teaches), resource preview (table of contents, sample page, or key takeaways), 3 bullet points on what the reader will learn, author/brand credibility blurb, CTA, footer
+- **CTA:** "Download Free Guide" / "Get the Checklist" / "Access the Template"
+- **Post-CTA:** Immediate delivery — either inline download link or email with attachment/link
+- **Resource format:** PDF, Google Doc, or hosted web page — must be ready before launch
+- **Email sequence:** Delivery email + 1-2 follow-up emails gauging problem severity
+
+### CopyPack Requirements
+
+- `headline` — focused on the resource value, not the product
+- `subheadline` — what the reader will learn or gain
+- `value_props` — 3 learning outcomes or takeaways from the resource
+- `cta_primary` — download/access CTA
+- `ad_headlines`, `ad_descriptions` — 3-5 variants emphasizing the free resource
+- `meta_title`, `meta_description`, `og_title`, `og_description`
+- `urgency_hook` — optional ("Free for a limited time" or "Updated for 2026")
+
+**Additional requirement:** The content resource itself must be created before launch. Budget 2-4 hours of content creation time. AI agents can draft the resource from Hypothesis Card fields.
+
+### Buildability Rating
+
+**Buildability: 2/5** — Requires content creation beyond just a landing page.
+
+| Checklist Item                          | Required? |
+| --------------------------------------- | --------- |
+| Landing page (content-focused template) | Yes       |
+| Email capture form                      | Yes       |
+| Content resource (PDF/guide/template)   | Yes       |
+| Email delivery sequence (Kit)           | Yes       |
+| Ad account + campaign                   | Yes       |
+| Payment integration                     | No        |
+| Backend service / fulfillment           | No        |
+| Custom development                      | No        |
+
+### Decision Criteria
+
+- **GO:** CVR >= 5% AND CPL <= $10 AND min. 25 conversions AND no INVALID flags. Problem awareness confirmed. Proceed to WTP test or deeper demand test depending on Discovery Summary signals.
+- **KILL:** CVR < 2% after 1,000+ sessions OR CPL > $25.
+- **PIVOT:** CVR in amber range (2% - 5%) with 15+ conversions. The problem resonates but the content offer may not match. Options: different resource format, revised targeting, different problem angle.
+- **INVALID:** Fewer than 15 conversions AND fewer than 500 sessions.
+
+### When to Use
+
+- **Use when:** The problem space lends itself to educational content. You want to validate problem awareness while building an engaged audience. Discovery interviews revealed that the target audience actively seeks information about the problem. You can produce a quality resource quickly.
+- **Do not use when:** The problem is not information-oriented (e.g., pure convenience plays). You cannot create a quality resource before launch. You need to validate pricing, not demand.
+
+### Worked Example
+
+> **Venture:** TaxNav — AI-powered tax optimization for freelancers
+>
+> **Hypothesis Card excerpt:** "We believe freelancers earning $50K-$200K annually overpay taxes by $3K-$12K because they don't know which deductions apply to their situation."
+>
+> **Test setup:** Facebook/Instagram campaign targeting freelancers and self-employed individuals. Content magnet: "The Freelancer's Tax Deduction Checklist: 47 Deductions You're Probably Missing." Landing page previews 5 of the 47 deductions with estimated savings. CTA: "Download the Full Checklist." Budget: $300 over 14 days.
+>
+> **Results:** 1,800 sessions, 126 downloads. CVR = 7.0%. CPL = $2.38. CTR = 2.4%.
+>
+> **Decision:** GO — exceptional demand signal. Problem resonance is strong. Proceed to `priced_waitlist` to validate WTP for the full AI tax optimization service.
+
+---
+
+## 3.4 `priced_waitlist` — Willingness to Pay
+
+**Description:** A priced waitlist test shows the product's intended price point alongside the value proposition and asks visitors to join a waitlist knowing the price they will pay. Unlike a standard waitlist, the visitor sees the price before committing — so the signup signal includes implicit price acceptance. No payment is collected at this stage.
+
+**What it validates:** Willingness to pay at a specific price point. The visitor knows the price and still signs up, which is a stronger signal than demand alone. Does not validate actual purchase behavior (that requires `presale`).
+
+**Signal capture:** Email submission on a page that prominently displays pricing. The visitor sees the product, sees the price, and still chooses to join the waitlist. Optional: pricing tier selection to gauge price sensitivity across segments.
+
+### Metrics & Thresholds
+
+| Metric                   | Target (GO) | Amber (Investigate) | Kill           |
+| ------------------------ | ----------- | ------------------- | -------------- |
+| CVR (sessions to signup) | >= 1.5%     | 0.5% - 1.5%         | < 0.5%         |
+| CPL (cost per lead)      | <= $30      | $30 - $50           | > $50          |
+| CTR (ad click-through)   | >= 0.8%     | 0.4% - 0.8%         | < 0.4%         |
+| Min. conversions         | >= 20       | 10 - 20             | < 10 (INVALID) |
+
+### Kill Criteria JSON
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "metric": "cvr_bp",
+      "operator": "lt",
+      "threshold": 50,
+      "label": "Conversion rate below 0.5%"
+    },
+    {
+      "metric": "cpl_cents",
+      "operator": "gt",
+      "threshold": 5000,
+      "label": "Cost per lead exceeds $50"
+    },
+    {
+      "metric": "total_spend_cents",
+      "operator": "gte",
+      "threshold": 50000,
+      "label": "Total spend reaches $500 budget cap"
+    },
+    {
+      "metric": "days_elapsed",
+      "operator": "gt",
+      "threshold": 14,
+      "label": "Test duration exceeds 14 days"
+    }
+  ]
+}
+```
+
+### Budget & Duration
+
+| Parameter                         | Value       |
+| --------------------------------- | ----------- |
+| Budget range                      | $300 - $500 |
+| Duration                          | 14 days     |
+| Min. sample (sessions)            | 1,500       |
+| Min. conversions for valid result | 20          |
+
+### Landing Page Spec
+
+- **Template:** Product page with pricing section
+- **Sections:** Headline, subheadline, problem/solution overview, feature list (3-5 items), **pricing section** (prominently displayed), social proof (if available from prior tests), CTA, FAQ (especially pricing-related), footer
+- **CTA:** "Join the Waitlist — $X/mo" / "Reserve Your Spot at $X" / "Get Early Access at Launch Price"
+- **Pricing display:** Clear, unambiguous. If testing tiers, show all tiers. The price must be visible before the CTA.
+- **Post-CTA:** Thank-you page confirming the price they will pay and estimated launch timeline
+- **Email sequence:** Welcome email reiterating price, 1-2 follow-ups with product development updates
+
+### CopyPack Requirements
+
+All standard CopyPack fields required, plus:
+
+- `headline` — must reference the transformation, not just the product
+- `value_props` — 3-5 bullets that justify the price point
+- `cta_primary` — must include or reference the price
+- `social_proof` — leverage waitlist numbers from prior demand tests if available
+- `urgency_hook` — "Early-bird pricing" or "Founding member rate" to anchor the price
+- `ad_headlines`, `ad_descriptions` — variants should mention price or value-for-money
+- Price-specific ad variant: at least 1 ad headline that includes the dollar amount
+
+### Buildability Rating
+
+**Buildability: 2/5** — Same as waitlist, plus pricing design.
+
+| Checklist Item                          | Required? |
+| --------------------------------------- | --------- |
+| Landing page (pricing-focused template) | Yes       |
+| Email capture form                      | Yes       |
+| Pricing page design / tier layout       | Yes       |
+| Email welcome sequence (Kit)            | Yes       |
+| Ad account + campaign                   | Yes       |
+| Payment integration                     | No        |
+| Backend service / fulfillment           | No        |
+| Custom development                      | No        |
+
+### Decision Criteria
+
+- **GO:** CVR >= 1.5% AND CPL <= $30 AND min. 20 conversions AND no INVALID flags. WTP validated at the tested price point. Proceed to `presale` for actual payment validation, or skip directly to build if confidence is high.
+- **KILL:** CVR < 0.5% after 1,500+ sessions OR CPL > $50. Price point is wrong or demand does not survive price exposure.
+- **PIVOT:** CVR in amber range (0.5% - 1.5%) with 10+ conversions. Options: test a lower price point, reframe value proposition to justify price, test different audience segment with higher WTP.
+- **INVALID:** Fewer than 10 conversions AND fewer than 800 sessions.
+
+### When to Use
+
+- **Use when:** Demand has been validated (via `fake_door`, `waitlist`, or `content_magnet`). You have a specific price point to test. You want to filter demand signal by price sensitivity before collecting actual payments.
+- **Do not use when:** Demand has not been validated (run a Demand Signal test first). You want to collect actual revenue (use `presale`). The pricing model is complex (usage-based, custom quotes) and cannot be displayed simply.
+
+### Worked Example
+
+> **Venture:** CompetitorPulse — automated competitor tracking for B2B marketers
+>
+> **Prior test:** `fake_door` returned GO (CVR 3.0%, CPL $4.76, 42 signups).
+>
+> **Test setup:** LinkedIn campaign targeting the same B2B marketing manager segment. Landing page now includes full feature overview and pricing: "$99/mo for up to 10 competitor profiles, $199/mo for unlimited." CTA: "Join the Waitlist — Starting at $99/mo." Budget: $500 over 14 days.
+>
+> **Results:** 1,800 sessions, 34 signups. CVR = 1.9%. CPL = $14.71. 28 chose the $99 tier, 6 chose $199.
+>
+> **Decision:** GO — CVR and CPL both exceed thresholds. Strong signal that $99/mo is acceptable. The 18% selection rate for the $199 tier suggests upsell potential. Proceed to `presale` or directly to build.
+
+---
+
+## 3.5 `presale` — Willingness to Pay
+
+**Description:** A presale test collects actual payment (or binding payment commitment) for a product that does not yet exist. This is the strongest WTP signal possible without building the product. Visitors see the product concept, see the price, and pay real money. Refund policy must be clear and generous — this is a validation test, not a revenue play.
+
+**What it validates:** Actual purchase behavior — the highest-fidelity WTP signal. People part with money, which eliminates the "I would buy it" vs. "I did buy it" gap. Also validates that the payment flow and pricing presentation work.
+
+**Signal capture:** Stripe payment completion. The visitor submits payment through Stripe Checkout. The conversion event is a successful charge. Refund rate is tracked as a secondary metric.
+
+### Metrics & Thresholds
+
+| Metric                     | Target (GO) | Amber (Investigate) | Kill          |
+| -------------------------- | ----------- | ------------------- | ------------- |
+| CVR (sessions to purchase) | >= 1%       | 0.3% - 1%           | < 0.3%        |
+| ROAS (return on ad spend)  | >= 100%     | 30% - 100%          | < 30%         |
+| Refund rate                | < 10%       | 10% - 25%           | > 25%         |
+| CTR (ad click-through)     | >= 0.8%     | 0.4% - 0.8%         | < 0.4%        |
+| Min. conversions           | >= 15       | 8 - 15              | < 8 (INVALID) |
+
+### Kill Criteria JSON
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "metric": "cvr_bp",
+      "operator": "lt",
+      "threshold": 30,
+      "label": "Conversion rate below 0.3%"
+    },
+    {
+      "metric": "roas_bp",
+      "operator": "lt",
+      "threshold": 3000,
+      "label": "ROAS below 30%"
+    },
+    {
+      "metric": "total_spend_cents",
+      "operator": "gte",
+      "threshold": 50000,
+      "label": "Total spend reaches $500 budget cap"
+    },
+    {
+      "metric": "days_elapsed",
+      "operator": "gt",
+      "threshold": 21,
+      "label": "Test duration exceeds 21 days"
+    }
+  ]
+}
+```
+
+### Budget & Duration
+
+| Parameter                         | Value        |
+| --------------------------------- | ------------ |
+| Budget range                      | $300 - $500  |
+| Duration                          | 14 - 21 days |
+| Min. sample (sessions)            | 1,500        |
+| Min. conversions for valid result | 15           |
+
+### Landing Page Spec
+
+- **Template:** Sales page with Stripe Checkout integration
+- **Sections:** Headline, subheadline, problem/solution narrative (longer-form), feature list with benefit descriptions, pricing with Stripe Buy button, social proof, testimonials or waitlist count (from prior tests), guarantee/refund policy, FAQ, footer
+- **CTA:** "Buy Now — $X" / "Pre-Order for $X" / "Get Lifetime Access for $X"
+- **Payment:** Stripe Checkout session. Requires `stripe_price_id` and `stripe_product_id` configured on the experiment.
+- **Refund policy:** Prominently displayed. "Full refund within 30 days, no questions asked." This is validation, not a trap.
+- **Post-purchase:** Confirmation page with receipt, expected delivery timeline, and "what happens next" explanation
+- **Email sequence:** Purchase confirmation, onboarding preview, periodic updates on build progress
+
+### CopyPack Requirements
+
+All standard CopyPack fields required, plus:
+
+- `headline` — transformation-focused, high urgency
+- `value_props` — 5 bullets that justify parting with money
+- `cta_primary` — must include the price
+- `social_proof` — leverage prior test numbers ("500+ people on the waitlist, now accepting pre-orders")
+- `urgency_hook` — required ("Pre-launch pricing ends March 31" / "First 100 customers get founding member rate")
+- `ad_headlines`, `ad_descriptions` — purchase-oriented variants
+- Price justification copy needed in ad descriptions
+
+### Buildability Rating
+
+**Buildability: 3/5** — Requires Stripe integration and payment handling.
+
+| Checklist Item                       | Required?                                     |
+| ------------------------------------ | --------------------------------------------- |
+| Landing page (sales page template)   | Yes                                           |
+| Stripe product + price configuration | Yes                                           |
+| Stripe Checkout integration          | Yes                                           |
+| Payment webhook handling (sc-api)    | Yes                                           |
+| Refund policy page                   | Yes                                           |
+| Email confirmation sequence (Kit)    | Yes                                           |
+| Ad account + campaign                | Yes                                           |
+| Backend service / fulfillment        | No (product not built yet)                    |
+| Custom development                   | Minimal (Stripe integration exists in sc-api) |
+
+### Decision Criteria
+
+- **GO:** CVR >= 1% AND ROAS >= 100% AND refund rate < 10% AND min. 15 purchases AND no INVALID flags. People are paying real money. Strongest possible validation signal. Proceed to build.
+- **KILL:** CVR < 0.3% after 1,500+ sessions OR ROAS < 30% OR refund rate > 25%.
+- **PIVOT:** CVR in amber range (0.3% - 1%) with 8+ purchases. Options: lower price point, different value framing, add guarantee to reduce purchase friction. High refund rate (10-25%) suggests expectation mismatch — revisit product description.
+- **INVALID:** Fewer than 8 purchases AND fewer than 800 sessions.
+
+### When to Use
+
+- **Use when:** WTP has been validated via `priced_waitlist` and you want to confirm with actual payment behavior. You have Stripe integration ready. You have a clear refund policy. You want revenue data, not just intent data.
+- **Do not use when:** Demand has not been validated. You have not tested price sensitivity. Legal/regulatory constraints prevent pre-selling an unbuilt product. The product requires significant upfront build before any payment is ethical.
+
+### Worked Example
+
+> **Venture:** MealPrepPro — AI-generated weekly meal plans for busy families
+>
+> **Prior tests:** `waitlist` GO (CVR 4.0%, 84 signups), `priced_waitlist` GO (CVR 2.1%, 31 signups at $9.99/mo).
+>
+> **Test setup:** Facebook/Instagram campaign retargeting waitlist audience + lookalike audience. Sales page with detailed feature descriptions, sample meal plan screenshot, and Stripe Checkout for "$9.99/mo — Cancel Anytime, Full Refund in First 30 Days." Budget: $400 over 14 days.
+>
+> **Results:** 1,600 sessions, 22 purchases. CVR = 1.4%. ROAS = 55% (during test — recurring revenue improves this over time). Revenue: $219.78. Refund rate: 4.5% (1 refund). CPL = $18.18.
+>
+> **Decision:** GO — CVR exceeds threshold, refund rate is low. ROAS is below 100% but this is a subscription product — LTV will exceed CAC within 2 months at current churn estimates. Proceed to build with confidence.
+
+---
+
+## 3.6 `concierge` — Solution Validation
+
+**Description:** A concierge test delivers the promised solution manually to a small number of customers. Instead of building automated software or a scalable product, the founder (or a small team) delivers the service by hand — using existing tools, spreadsheets, personal expertise, or manual processes. The customer receives the outcome they were promised; they just do not know (or care) that it is being delivered manually.
+
+**What it validates:** Solution-market fit — does the actual delivered solution solve the customer's problem? Does the customer value the outcome enough to continue paying? Reveals the operational reality of the service before investing in automation.
+
+**Signal capture:** Lead capture + manual service delivery. The visitor signs up (with or without payment), receives the service manually, and their satisfaction/retention is measured. Conversion event is the signup; secondary metrics are satisfaction score and retention.
+
+### Metrics & Thresholds
+
+| Metric                             | Target (GO) | Amber (Investigate) | Kill          |
+| ---------------------------------- | ----------- | ------------------- | ------------- |
+| CVR (sessions to signup)           | >= 2%       | 0.5% - 2%           | < 0.5%        |
+| CPL (cost per lead)                | <= $50      | $50 - $100          | > $100        |
+| Customer satisfaction (NPS or 1-5) | >= 4/5      | 3 - 4/5             | < 3/5         |
+| Retention (week 2 engagement)      | >= 60%      | 30% - 60%           | < 30%         |
+| Min. conversions                   | >= 10       | 5 - 10              | < 5 (INVALID) |
+
+### Kill Criteria JSON
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "metric": "cvr_bp",
+      "operator": "lt",
+      "threshold": 50,
+      "label": "Conversion rate below 0.5%"
+    },
+    {
+      "metric": "cpl_cents",
+      "operator": "gt",
+      "threshold": 10000,
+      "label": "Cost per lead exceeds $100"
+    },
+    {
+      "metric": "total_spend_cents",
+      "operator": "gte",
+      "threshold": 50000,
+      "label": "Total spend reaches $500 budget cap"
+    },
+    {
+      "metric": "days_elapsed",
+      "operator": "gt",
+      "threshold": 21,
+      "label": "Test duration exceeds 21 days"
+    }
+  ]
+}
+```
+
+### Budget & Duration
+
+| Parameter                         | Value                      |
+| --------------------------------- | -------------------------- |
+| Budget range (ad spend)           | $300 - $500                |
+| Duration                          | 21 days                    |
+| Min. sample (sessions)            | 1,000                      |
+| Min. conversions for valid result | 10                         |
+| Operational time per customer     | 2-5 hours (founder's time) |
+
+### Landing Page Spec
+
+- **Template:** Service-focused landing page with application/signup flow
+- **Sections:** Headline (outcome-focused), problem narrative, how it works (3-step process), what the customer gets (deliverables list), pricing (if charged), social proof, CTA, FAQ, footer
+- **CTA:** "Apply Now" / "Get Started" / "Book Your Spot" — can include qualification questions
+- **Qualification:** Optional intake form to screen for ICP fit (role, company size, specific need)
+- **Post-signup:** Personal welcome email from the founder. Onboarding call or questionnaire to begin service delivery.
+- **Service delivery:** Via email, Loom video, shared Google Doc, or whatever is simplest. No custom tooling.
+
+### CopyPack Requirements
+
+- `headline` — outcome-focused ("Get X Without Doing Y")
+- `subheadline` — how the service works at a high level
+- `value_props` — 3-5 deliverables the customer receives
+- `cta_primary` — application/signup CTA
+- `social_proof` — prior test numbers or personal credibility
+- `ad_headlines`, `ad_descriptions` — service-oriented, emphasizing done-for-you value
+- `meta_title`, `meta_description`, `og_title`, `og_description`
+
+**Additional requirement:** A documented service delivery playbook — even if informal. The founder must know what they will deliver, how, and the time commitment per customer.
+
+### Buildability Rating
+
+**Buildability: 4/5** — Requires significant founder time for manual delivery.
+
+| Checklist Item                                         | Required?                                  |
+| ------------------------------------------------------ | ------------------------------------------ |
+| Landing page (service-focused template)                | Yes                                        |
+| Email capture / application form                       | Yes                                        |
+| Service delivery playbook                              | Yes                                        |
+| Manual delivery tools (email, Loom, Google Docs, etc.) | Yes                                        |
+| Founder time commitment (2-5 hrs/customer)             | Yes                                        |
+| Email sequence (Kit)                                   | Yes                                        |
+| Ad account + campaign                                  | Yes                                        |
+| Payment integration                                    | Optional (can be free for first customers) |
+| Satisfaction survey / feedback mechanism               | Yes                                        |
+| Custom development                                     | No                                         |
+
+### Decision Criteria
+
+- **GO:** CVR >= 2% AND CPL <= $50 AND customer satisfaction >= 4/5 AND week-2 retention >= 60% AND min. 10 customers served. Solution works. Customer values the outcome. Proceed to `service_pilot` for scalability testing or directly to build.
+- **KILL:** CVR < 0.5% OR CPL > $100 OR satisfaction < 3/5 OR retention < 30%.
+- **PIVOT:** Metrics in amber range. Options: adjust the deliverable, change the delivery format, narrow the ICP to the highest-satisfaction segment, adjust pricing.
+- **INVALID:** Fewer than 5 customers served.
+
+### When to Use
+
+- **Use when:** You have validated demand and WTP but are unsure if the solution actually works. The service can be delivered manually by the founder. You want to learn what customers actually need before building automation. Discovery interviews surfaced uncertainty about the right solution approach.
+- **Do not use when:** Demand has not been validated (run Demand Signal tests first). The solution cannot be delivered manually (requires software/hardware from day one). You do not have the operational capacity to serve 10-15 customers by hand.
+
+### Worked Example
+
+> **Venture:** CompetitorPulse — automated competitor tracking for B2B marketers
+>
+> **Prior tests:** `fake_door` GO, `priced_waitlist` GO (34 signups at $99/mo).
+>
+> **Test setup:** LinkedIn campaign targeting the same segment. Landing page describes: "We track your top 5 competitors weekly and deliver a concise report every Monday." Price: $99/mo with first month free. Application form asks: company name, top 5 competitors, what decisions they make based on competitive intel. Budget: $400 over 21 days.
+>
+> **Results:** 1,200 sessions, 18 applications. CVR = 1.5% (below target but within amber). 12 qualified and onboarded. Founder spent ~3 hours per customer per week using manual Google Alerts + LinkedIn monitoring + a custom spreadsheet. Satisfaction: 4.3/5. Week-2 retention: 83%.
+>
+> **Decision:** PIVOT — CVR in amber range, but satisfaction and retention are excellent. The customers who sign up love it. Pivot approach: narrower targeting to the exact ICP that converts, and test whether the application form is creating unnecessary friction. Re-run with simplified signup.
+
+---
+
+## 3.7 `service_pilot` — Solution Validation
+
+**Description:** A service pilot is a small-scale, time-limited delivery of the actual service to a cohort of customers. Unlike a concierge test (which delivers manually), a service pilot uses early versions of actual tooling, processes, or automation. It operates as a "beta" — the customer knows they are an early adopter and provides feedback in exchange for a discounted rate or enhanced support.
+
+**What it validates:** Operational viability — can the solution be delivered at reasonable cost and quality as it begins to scale beyond pure manual effort? Validates the transition from concierge to product.
+
+**Signal capture:** Lead capture + onboarding + service delivery over a defined pilot period. Conversion is signup; secondary metrics are satisfaction, retention, operational cost per customer, and NPS.
+
+### Metrics & Thresholds
+
+| Metric                             | Target (GO) | Amber (Investigate) | Kill          |
+| ---------------------------------- | ----------- | ------------------- | ------------- |
+| CVR (sessions to signup)           | >= 1.5%     | 0.5% - 1.5%         | < 0.5%        |
+| CPL (cost per lead)                | <= $50      | $50 - $100          | > $100        |
+| Customer satisfaction (NPS or 1-5) | >= 4/5      | 3 - 4/5             | < 3/5         |
+| Retention (end of pilot)           | >= 50%      | 25% - 50%           | < 25%         |
+| Operational cost per customer      | Sustainable | Marginal            | Unsustainable |
+| Min. conversions                   | >= 10       | 5 - 10              | < 5 (INVALID) |
+
+### Kill Criteria JSON
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "metric": "cvr_bp",
+      "operator": "lt",
+      "threshold": 50,
+      "label": "Conversion rate below 0.5%"
+    },
+    {
+      "metric": "cpl_cents",
+      "operator": "gt",
+      "threshold": 10000,
+      "label": "Cost per lead exceeds $100"
+    },
+    {
+      "metric": "total_spend_cents",
+      "operator": "gte",
+      "threshold": 50000,
+      "label": "Total spend reaches $500 budget cap"
+    },
+    {
+      "metric": "days_elapsed",
+      "operator": "gt",
+      "threshold": 30,
+      "label": "Test duration exceeds 30 days"
+    }
+  ]
+}
+```
+
+### Budget & Duration
+
+| Parameter                         | Value                           |
+| --------------------------------- | ------------------------------- |
+| Budget range (ad spend)           | $300 - $500                     |
+| Duration                          | 21 - 30 days                    |
+| Min. sample (sessions)            | 1,000                           |
+| Min. conversions for valid result | 10                              |
+| Operational commitment            | Pilot cohort of 10-15 customers |
+
+### Landing Page Spec
+
+- **Template:** Beta/pilot program landing page
+- **Sections:** Headline (beta program framing), what the pilot includes, pilot timeline and commitment, what the customer gets (deliverables + pricing), what we ask in return (feedback, survey participation), application form, FAQ, footer
+- **CTA:** "Apply for the Beta" / "Join the Pilot Program" / "Become a Founding Member"
+- **Qualification:** Application form with screening questions. Pilot capacity is limited — communicate scarcity honestly.
+- **Post-signup:** Personal outreach, onboarding call, pilot agreement (informal or formal depending on price point)
+- **Service delivery:** Using early tooling, semi-automated processes, or hybrid manual/automated approach
+
+### CopyPack Requirements
+
+- `headline` — beta/pilot program framing with value emphasis
+- `subheadline` — what makes the pilot special (early access, discounted rate, direct founder access)
+- `value_props` — 3-5 pilot deliverables
+- `cta_primary` — application CTA with scarcity signal
+- `social_proof` — prior validation numbers, concierge customer testimonials if available
+- `urgency_hook` — required ("Limited to 15 pilot members" / "Applications close March 31")
+- `ad_headlines`, `ad_descriptions` — beta/early-access oriented variants
+- `meta_title`, `meta_description`, `og_title`, `og_description`
+
+### Buildability Rating
+
+**Buildability: 5/5** — Highest buildability requirement. Requires early tooling and operational infrastructure.
+
+| Checklist Item                                                 | Required?                   |
+| -------------------------------------------------------------- | --------------------------- |
+| Landing page (pilot program template)                          | Yes                         |
+| Application / screening form                                   | Yes                         |
+| Early-version tooling or semi-automated delivery               | Yes                         |
+| Onboarding process / documentation                             | Yes                         |
+| Feedback collection mechanism (survey, interviews)             | Yes                         |
+| Operational playbook (who does what, when)                     | Yes                         |
+| Email sequences (Kit) — onboarding, updates, feedback requests | Yes                         |
+| Ad account + campaign                                          | Yes                         |
+| Payment integration (Stripe)                                   | Recommended                 |
+| Customer support channel (email, Slack, etc.)                  | Yes                         |
+| Custom development                                             | Yes (early product version) |
+
+### Decision Criteria
+
+- **GO:** CVR >= 1.5% AND CPL <= $50 AND satisfaction >= 4/5 AND pilot retention >= 50% AND operational cost is sustainable AND min. 10 pilot customers. The venture works. Proceed to full product build and launch.
+- **KILL:** CVR < 0.5% OR CPL > $100 OR satisfaction < 3/5 OR retention < 25% OR operational cost is unsustainable (cannot serve customers without losing money even at scale pricing).
+- **PIVOT:** Metrics in amber range. Options: adjust the product scope, change the delivery model, narrow to the highest-value segment, revise pricing to cover operational cost.
+- **INVALID:** Fewer than 5 pilot customers completing the full pilot period.
+
+### When to Use
+
+- **Use when:** Concierge test validated solution-market fit and you need to test operational viability at slightly larger scale. You have early tooling or automation to reduce per-customer effort. You want to validate the transition from manual to product before investing in full build.
+- **Do not use when:** You have not validated the solution manually (run `concierge` first). You do not have any tooling or automation ready. The product is purely digital and can be built directly (skip to build after `presale` or `concierge`).
+
+### Worked Example
+
+> **Venture:** CompetitorPulse — automated competitor tracking for B2B marketers
+>
+> **Prior tests:** `fake_door` GO, `priced_waitlist` GO, `concierge` PIVOT (narrowed ICP, improved signup flow).
+>
+> **Test setup:** LinkedIn campaign targeting VP Marketing and Head of Marketing at B2B SaaS companies (100-500 employees) — the narrowed ICP from the concierge pivot. Landing page: "Join the CompetitorPulse Beta — 15 Spots Available." Pilot terms: $49/mo for 3 months (50% off launch price), weekly competitor report, direct Slack channel with founder, monthly strategy call. Application form asks about team size, number of competitors tracked, current process.
+>
+> **Results:** 900 sessions, 22 applications, 14 accepted into pilot. CVR = 2.4%. CPL = $28.57. After 30-day pilot: satisfaction 4.6/5, retention 86% (12 of 14 still active), NPS 72. Operational cost: ~1.5 hours per customer per week using a combination of custom scripts and manual review. At scale pricing ($99/mo) with 50% automation, unit economics work.
+>
+> **Decision:** GO — all metrics exceed thresholds. Strong satisfaction and retention. Operational cost is sustainable with planned automation. Proceed to full product build.
+
+---
+
+# 4. Hypothesis Card to Test Type Selection
+
+The Hypothesis Card's **Key Assumptions** are the primary driver for test type selection. Each assumption is categorized by what it needs to validate, which maps to a category on the Validation Ladder.
+
+## Assumption Type Mapping
+
+| Assumption Type       | Question Being Asked                                     | Validation Ladder Category | Starting Archetype                    |
+| --------------------- | -------------------------------------------------------- | -------------------------- | ------------------------------------- |
+| Demand                | "Do people have this problem and care about solving it?" | Demand Signal              | `fake_door`                           |
+| Problem awareness     | "Do people know they have this problem?"                 | Demand Signal              | `content_magnet`                      |
+| Willingness to pay    | "Will people pay $X for this solution?"                  | Willingness to Pay         | `priced_waitlist`                     |
+| Price sensitivity     | "What price point maximizes conversion?"                 | Willingness to Pay         | `priced_waitlist` (with tier testing) |
+| Solution fit          | "Does our solution actually solve the problem?"          | Solution Validation        | `concierge`                           |
+| Operational viability | "Can we deliver this at reasonable cost?"                | Solution Validation        | `service_pilot`                       |
+
+## Within-Category Selection Criteria
+
+When the assumption type maps to a category with multiple archetypes, use these criteria to select the starting archetype:
+
+### Demand Signal: `fake_door` vs. `waitlist` vs. `content_magnet`
+
+| Criterion                  | `fake_door`             | `waitlist`                         | `content_magnet`                |
+| -------------------------- | ----------------------- | ---------------------------------- | ------------------------------- |
+| Prior demand signal exists | No                      | No or some                         | Any                             |
+| Product concept clarity    | Vague                   | Clear                              | Problem-clear, solution-vague   |
+| Budget available           | < $300                  | $300-500                           | $200-400                        |
+| Time to launch             | 1-2 days                | 3-5 days                           | 5-7 days (content creation)     |
+| Best when                  | First test, zero signal | Concept is concrete, want audience | Problem is information-oriented |
+
+### Willingness to Pay: `priced_waitlist` vs. `presale`
+
+| Criterion                      | `priced_waitlist` | `presale`                                        |
+| ------------------------------ | ----------------- | ------------------------------------------------ |
+| Stripe integration ready       | Not required      | Required                                         |
+| Price point confidence         | Testing price     | Price validated or strong hypothesis             |
+| Legal comfort with pre-selling | N/A               | Must be comfortable collecting payment pre-build |
+| Refund infrastructure          | N/A               | Required                                         |
+| Best when                      | First WTP test    | Strong WTP signal, want actual payment data      |
+
+### Solution Validation: `concierge` vs. `service_pilot`
+
+| Criterion                 | `concierge`                                 | `service_pilot`                           |
+| ------------------------- | ------------------------------------------- | ----------------------------------------- |
+| Early tooling exists      | No                                          | Yes                                       |
+| Founder time available    | 2-5 hrs/customer                            | 1-2 hrs/customer (tooling reduces effort) |
+| Prior solution validation | None                                        | Concierge confirmed solution fit          |
+| Best when                 | First solution test, want to learn by doing | Transitioning from manual to product      |
+
+## Decision Tree Walkthrough
+
+1. **Read the Hypothesis Card's Key Assumptions.** Identify the highest-risk assumption.
+2. **Categorize the assumption** using the Assumption Type Mapping table.
+3. **Select the category** on the Validation Ladder (Demand Signal, WTP, Solution Validation).
+4. **Within the category**, use the selection criteria to pick the starting archetype.
+5. **Check the Discovery Gate** (see below).
+6. **Generate the Test Blueprint** with the selected archetype's defaults.
+
+## Discovery Gate Check
+
+Before entering any test, verify the Discovery Summary meets minimum requirements:
+
+| Gate Criterion       | Requirement                     | If Not Met                                |
+| -------------------- | ------------------------------- | ----------------------------------------- |
+| Interviews completed | >= 5                            | Return to Step 2                          |
+| Problem confirmed    | >= 3/5 interviewees confirm     | Return to Step 2 or Step 1                |
+| Pain severity        | >= 3/5 average                  | Return to Step 2 or reconsider venture    |
+| ICP specificity      | Can find 5 real people matching | Return to Step 1, refine Customer Segment |
+
+Exception: A `fake_door` test can run with fewer than 5 interviews if the Hypothesis Card confidence is "Proceed" and the venture is in rapid screening mode. This exception must be explicitly noted in the Test Blueprint.
+
+---
+
+# 5. The Test Blueprint — Artifact Specification
+
+The Test Blueprint is the Step 3 output artifact. It fully specifies the experiment design, metrics, thresholds, and decision criteria for a single validation test.
+
+## Field Specification
+
+| Field                      | Description                                 | Source                                 |
+| -------------------------- | ------------------------------------------- | -------------------------------------- |
+| `experiment_id`            | SC experiment ID (format: SC-YYYY-NNN)      | System-generated                       |
+| `hypothesis_card_ref`      | Reference to the source Hypothesis Card     | From Step 1                            |
+| `discovery_summary_ref`    | Reference to the Discovery Summary          | From Step 2                            |
+| `archetype`                | Selected test archetype                     | Test type selection (Section 4)        |
+| `category`                 | Validation Ladder category                  | Derived from archetype                 |
+| `assumption_under_test`    | The specific Key Assumption being tested    | From Hypothesis Card                   |
+| `primary_metric`           | The metric used for GO/KILL decision        | Archetype default                      |
+| `target_threshold`         | GO threshold for primary metric             | Archetype default (overridable)        |
+| `kill_threshold`           | KILL threshold for primary metric           | Archetype default (overridable)        |
+| `secondary_metrics`        | Additional metrics tracked                  | Archetype default                      |
+| `kill_criteria`            | Full kill criteria JSON                     | Archetype default (overridable)        |
+| `budget_cents`             | Ad spend budget in cents                    | Archetype range, specific value chosen |
+| `duration_days`            | Test duration                               | Archetype default                      |
+| `min_conversions`          | Minimum conversions for valid result        | Archetype default                      |
+| `landing_page_template`    | Which landing page template to use          | Archetype default                      |
+| `copy_pack_requirements`   | Required CopyPack fields for this archetype | Archetype default                      |
+| `buildability_rating`      | 1-5 buildability score                      | Archetype default                      |
+| `buildability_checklist`   | Items needed before launch                  | Archetype default                      |
+| `build_cost_estimate`      | Estimated cost/time to prepare the test     | Assessed per-experiment                |
+| `technical_risks`          | Known technical risks or dependencies       | Assessed per-experiment                |
+| `decision_criteria`        | GO/KILL/PIVOT/INVALID rules                 | Archetype default (overridable)        |
+| `discovery_gate_exception` | Whether Discovery Gate was waived (and why) | Assessed per-experiment                |
+| `sequence_position`        | Which rung on the Validation Ladder         | Derived from test history              |
+| `prior_test_ref`           | Reference to prior test in the sequence     | From test history                      |
+
+## Two Completion Stages
+
+### Stage 1: Draft Blueprint
+
+Generated automatically when archetype is selected. All archetype defaults are populated. Fields requiring human input are flagged as incomplete.
+
+**Auto-populated from archetype defaults:**
+
+- `archetype`, `category`, `primary_metric`, `target_threshold`, `kill_threshold`, `secondary_metrics`, `kill_criteria`, `duration_days`, `min_conversions`, `landing_page_template`, `copy_pack_requirements`, `buildability_rating`, `buildability_checklist`, `decision_criteria`
+
+**Require human input:**
+
+- `assumption_under_test`, `budget_cents` (within archetype range), `build_cost_estimate`, `technical_risks`, `discovery_gate_exception` (if applicable)
+
+### Stage 2: Final Blueprint
+
+Reviewed and approved by the founder. All fields complete. Threshold overrides documented with rationale. Build checklist items verified. Ready to hand off to Step 4 (Campaign Package).
+
+**Approval checklist:**
+
+- All fields populated
+- Budget within archetype range (or override documented)
+- Threshold overrides justified (if any)
+- Discovery Gate met (or exception documented)
+- Buildability checklist items available or scheduled
+- Technical risks acknowledged
+
+---
+
+# 5.5. Test Blueprint Schema Sketch
+
+Field specification for the `test_blueprint` JSONB column, to minimize interpretation during implementation:
+
+```json
+{
+  "experiment_id": { "type": "string", "required": true, "pattern": "^SC-\\d{4}-\\d{3}[a-z]?$" },
+  "hypothesis_card_ref": { "type": "string", "required": true },
+  "discovery_summary_ref": { "type": "string", "required": false },
+  "archetype": {
+    "type": "string",
+    "required": true,
+    "enum": [
+      "fake_door",
+      "waitlist",
+      "content_magnet",
+      "priced_waitlist",
+      "presale",
+      "concierge",
+      "service_pilot"
+    ]
+  },
+  "category": {
+    "type": "string",
+    "required": true,
+    "enum": ["demand_signal", "willingness_to_pay", "solution_validation"]
+  },
+  "assumption_under_test": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "claim": { "type": "string", "required": true },
+      "evidence": { "type": "string" },
+      "risk": { "type": "string", "enum": ["high", "medium", "low"] },
+      "basis": { "type": "string" }
+    }
+  },
+  "metrics": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "primary_metric": { "type": "string", "enum": ["cvr_bp", "cpl_cents", "roas_bp"] },
+      "target_threshold": { "type": "integer", "required": true },
+      "kill_threshold": { "type": "integer", "required": true },
+      "secondary_metrics": {
+        "type": "array",
+        "items": {
+          "metric": "string",
+          "target": "integer",
+          "kill": "integer"
+        }
+      }
+    }
+  },
+  "kill_criteria": {
+    "type": "object",
+    "required": true,
+    "description": "KillCriteriaSchema from tech spec Section 3.4"
+  },
+  "budget_cents": { "type": "integer", "required": true, "min": 10000, "max": 100000 },
+  "duration_days": { "type": "integer", "required": true, "min": 7, "max": 30 },
+  "min_conversions": { "type": "integer", "required": true, "min": 5 },
+  "landing_page": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "template": { "type": "string", "required": true },
+      "sections": { "type": "array", "items": { "type": "string" } },
+      "cta_text": { "type": "string" },
+      "post_cta_behavior": { "type": "string" }
+    }
+  },
+  "copy_pack_requirements": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "required_fields": { "type": "array", "items": { "type": "string" } },
+      "optional_fields": { "type": "array", "items": { "type": "string" } },
+      "additional_requirements": { "type": "array", "items": { "type": "string" } }
+    }
+  },
+  "buildability": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "rating": { "type": "integer", "min": 1, "max": 5 },
+      "checklist": {
+        "type": "array",
+        "items": {
+          "item": "string",
+          "required": "boolean",
+          "status": { "type": "string", "enum": ["ready", "pending", "not_needed"] }
+        }
+      }
+    }
+  },
+  "build_cost_estimate": { "type": "string", "required": false, "maxLength": 500 },
+  "technical_risks": {
+    "type": "array",
+    "required": false,
+    "items": { "type": "string" },
+    "maxItems": 5
+  },
+  "decision_criteria": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "go": { "type": "string", "required": true },
+      "kill": { "type": "string", "required": true },
+      "pivot": { "type": "string", "required": true },
+      "invalid": { "type": "string", "required": true }
+    }
+  },
+  "discovery_gate": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "met": { "type": "boolean", "required": true },
+      "exception": { "type": "boolean", "default": false },
+      "exception_rationale": { "type": "string" }
+    }
+  },
+  "sequence": {
+    "type": "object",
+    "required": false,
+    "properties": {
+      "position": { "type": "integer", "min": 1 },
+      "prior_test_ref": { "type": "string" },
+      "prior_test_outcome": { "type": "string", "enum": ["go", "pivot"] }
+    }
+  },
+  "threshold_overrides": {
+    "type": "array",
+    "required": false,
+    "items": {
+      "metric": "string",
+      "default_value": "integer",
+      "override_value": "integer",
+      "rationale": "string"
+    }
+  },
+  "stage": { "type": "string", "enum": ["draft", "final"], "required": true }
+}
+```
+
+---
+
+# 6. Test Sequencing — The Validation Ladder in Practice
+
+The Validation Ladder is not just a taxonomy — it is a **sequence**. Ventures climb the ladder rung by rung, with each test building on the signal from the previous one. Each rung requires a GO verdict (or a justified skip) before proceeding to the next.
+
+## Standard Sequence (3 Rungs)
+
+The default validation sequence for a new venture hypothesis:
+
+**Rung 1: Demand Signal** — Does anyone care?
+
+- Start with `fake_door` (cheapest, fastest) or `content_magnet` (if problem is information-oriented)
+- Requires: Hypothesis Card (Tier 1) + Discovery Summary
+- Budget: $150-$400
+- Duration: 7-14 days
+
+**Rung 2: Willingness to Pay** — Will they pay?
+
+- `priced_waitlist` (if testing price) or `presale` (if collecting payment)
+- Requires: Rung 1 GO + Hypothesis Card (Tier 2)
+- Budget: $300-$500
+- Duration: 14-21 days
+
+**Rung 3: Solution Validation** — Does it work?
+
+- `concierge` (manual delivery) then `service_pilot` (early tooling)
+- Requires: Rung 2 GO
+- Budget: $300-$500 + operational time
+- Duration: 21-30 days
+
+**Total standard sequence:** $750-$1,400 in ad spend, 6-10 weeks, 3-4 tests.
+
+## Accelerated Sequence
+
+For ventures with strong prior signal (e.g., founder domain expertise, existing audience, competitor validation):
+
+**Skip Rung 1** if the Discovery Summary shows pain severity >= 4/5 AND the founder has direct domain experience AND the Hypothesis Card confidence is "Proceed." Enter directly at Rung 2.
+
+**Combine Rungs 2 + 3** if the service can be delivered immediately after purchase. Run a `presale` that transitions into `concierge` delivery for buyers. One test validates both WTP and solution fit.
+
+**Accelerated total:** $300-$500 in ad spend, 3-4 weeks, 1-2 tests.
+
+## Entry Point Determination
+
+| Signal Available                                   | Recommended Entry                         |
+| -------------------------------------------------- | ----------------------------------------- |
+| Zero — new idea, no validation                     | Rung 1: `fake_door`                       |
+| Problem confirmed in interviews only               | Rung 1: `waitlist` or `content_magnet`    |
+| Demand validated (prior test or existing audience) | Rung 2: `priced_waitlist`                 |
+| Demand + WTP validated                             | Rung 3: `concierge`                       |
+| Demand + WTP + solution validated (concierge)      | Rung 3: `service_pilot`                   |
+| All validated                                      | Exit Validation Ladder — proceed to build |
+
+## Budget Allocation Across the Ladder
+
+The strategy session established a $1,500 total spend cap across pivots. Here is the recommended allocation for a standard 3-rung sequence:
+
+| Rung    | Test(s)                         | Budget Allocation | Cumulative  |
+| ------- | ------------------------------- | ----------------- | ----------- |
+| 1       | `fake_door` or `content_magnet` | $150-$300         | $150-$300   |
+| 2       | `priced_waitlist`               | $300-$500         | $450-$800   |
+| 3       | `concierge` + `service_pilot`   | $300-$500         | $750-$1,300 |
+| Reserve | Pivot budget (1 retry)          | $200-$300         | $950-$1,500 |
+
+If a venture reaches $1,500 cumulative spend without a clear GO at Rung 2 or above, a forced kill-or-park decision is required per the strategy session's Pivot Rules.
+
+## Confidence Score Interaction
+
+The Hypothesis Card's confidence score affects budget allocation:
+
+| Confidence    | Effect on Budget                                          |
+| ------------- | --------------------------------------------------------- |
+| **Proceed**   | Standard budget allocation per archetype                  |
+| **Uncertain** | Minimum budget per archetype; save more for pivot reserve |
+| **Abandon**   | No test. Kill at Step 1.                                  |
+
+"Uncertain" ventures get the minimum end of each archetype's budget range, preserving more of the $1,500 cap for potential pivots. "Proceed" ventures get standard allocation.
+
+---
+
+# 7. Kill Criteria Defaults & Calibration
+
+## Summary Table — All Archetypes
+
+| Archetype         | Primary Metric | GO      | Kill   | CPL Target   | CPL Kill   | Budget   | Duration   |
+| ----------------- | -------------- | ------- | ------ | ------------ | ---------- | -------- | ---------- |
+| `fake_door`       | CVR            | >= 2%   | < 0.5% | <= $8        | > $20      | $150-300 | 7 days     |
+| `waitlist`        | CVR            | >= 3%   | < 1%   | <= $15       | > $30      | $300-500 | 14 days    |
+| `content_magnet`  | CVR            | >= 5%   | < 2%   | <= $10       | > $25      | $200-400 | 14 days    |
+| `priced_waitlist` | CVR            | >= 1.5% | < 0.5% | <= $30       | > $50      | $300-500 | 14 days    |
+| `presale`         | CVR            | >= 1%   | < 0.3% | ROAS >= 100% | ROAS < 30% | $300-500 | 14-21 days |
+| `concierge`       | CVR            | >= 2%   | < 0.5% | <= $50       | > $100     | $300-500 | 21 days    |
+| `service_pilot`   | CVR            | >= 1.5% | < 0.5% | <= $50       | > $100     | $300-500 | 21-30 days |
+
+## Override Mechanics
+
+Archetype defaults are starting points. Threshold overrides are permitted with documented rationale in the Test Blueprint. Common override scenarios:
+
+| Scenario                      | Override                    | Rationale                                                                 |
+| ----------------------------- | --------------------------- | ------------------------------------------------------------------------- |
+| B2B with high ACV             | Increase CPL kill threshold | Higher customer lifetime value justifies higher acquisition cost          |
+| Low-price consumer product    | Decrease CPL target         | Unit economics require cheap leads                                        |
+| Niche market with small TAM   | Decrease min. conversions   | Total addressable traffic is limited                                      |
+| Seasonal product              | Extend duration             | Need to account for day-of-week and seasonal traffic patterns             |
+| Platform with network effects | Decrease CVR threshold      | Initial conversion is expected to be low; value comes from network growth |
+
+**Override rules:**
+
+1. Every override must include a written rationale in the `threshold_overrides` array
+2. Overrides cannot weaken a kill threshold by more than 50% (e.g., CVR kill of 0.5% cannot be lowered below 0.25%)
+3. Budget overrides above the archetype range require explicit founder approval
+4. Duration overrides beyond 30 days are not permitted — long-running tests indicate a different archetype is needed
+
+## Hard Kill vs. Soft Kill
+
+The strategy session defined Hard Kill and Soft Kill criteria. Here is how they interact with archetype-specific thresholds:
+
+### Hard Kill (Immediate — No Second Chance)
+
+These criteria apply universally across all archetypes:
+
+- CTR < 0.4% after 1,000+ impressions — the ad is not compelling enough to click
+- Zero conversions after full budget spend — complete failure to convert
+- 0 out of 5+ interviews confirming the problem exists — the problem is not real
+
+A Hard Kill triggers an immediate Decision Memo with KILL verdict. No messaging swap, no budget extension, no second chance.
+
+### Soft Kill (After One Creative/Messaging Swap)
+
+These criteria trigger a "last chance" creative rotation before final kill:
+
+- Primary metric below 50% of target threshold — signals are weak but not zero
+- CPL exceeds 2x the kill threshold — costs are out of control
+- All viable audience segments tested with no segment clearing threshold
+
+After a creative swap, if metrics do not improve above the kill threshold within 50% of the remaining budget, the test is killed.
+
+## Calibration Plan
+
+The current thresholds are based on industry benchmarks and Lean Startup literature. They will be calibrated over time as SC accumulates validation data.
+
+### Phase 1: Industry Defaults (Now)
+
+Use the thresholds defined in this document. They are deliberately conservative — it is better to kill ventures that might have worked than to invest further in ventures that probably will not.
+
+### Phase 2: Internal Benchmarking (After 10+ Tests)
+
+After 10 completed tests across the portfolio:
+
+- Calculate actual median CVR, CPL, and ROAS per archetype
+- Adjust thresholds to reflect SC's actual performance distribution
+- Set GO threshold at p75 (top quartile performance) and KILL at p25 (bottom quartile)
+
+### Phase 3: Dynamic Calibration (After 50+ Tests)
+
+After 50 completed tests:
+
+- Category-specific and industry-specific thresholds
+- Bayesian updating of thresholds based on new test results
+- Confidence intervals on GO/KILL decisions
+- This is Deep Dive #6 territory — covered there in detail
+
+## Relationship to Decision Framework
+
+The kill criteria defined here plug directly into the strategy session's Decision Framework:
+
+- **Archetype kill thresholds** map to the "Soft Kill" criteria in the Decision Framework
+- **Hard Kill criteria** are universal and override archetype-specific thresholds
+- **Amber ranges** (between GO and KILL thresholds) map to the PIVOT routing logic
+- **INVALID** outcomes trigger re-run or redesign, not a kill decision
+- **Pivot Routing Table** uses the signal pattern (which metrics failed) to determine re-entry point
+
+---
+
+# 8. Answering the Six Questions
+
+The strategy session identified six questions for this deep dive. Here are the answers:
+
+**1. What are the standard test types Silicon Crane should offer?**
+
+Seven archetypes organized into three categories: **Demand Signal** (`fake_door`, `waitlist`, `content_magnet`), **Willingness to Pay** (`priced_waitlist`, `presale`), and **Solution Validation** (`concierge`, `service_pilot`). The `interview` archetype is removed — customer discovery is now a foundational step, not a test type.
+
+**2. How do you map from a story framework output to the right test type?**
+
+The Hypothesis Card's **Key Assumptions** drive test type selection. Each assumption is categorized by type (demand, WTP, solution fit, operational viability), which maps to a Validation Ladder category. Within-category selection uses criteria including prior signal, budget, product concept clarity, and time to launch. See Section 4.
+
+**3. What metrics and thresholds define pass/pivot/kill for each type?**
+
+Each archetype has a full metrics table with GO, Amber, and Kill thresholds for primary and secondary metrics. The primary metric for all demand tests is CVR; for presale it is CVR + ROAS; for solution validation it adds satisfaction and retention. See Section 3 for per-archetype details and Section 7 for the summary table.
+
+**4. How does this relate to the 7 archetypes already defined in the functional spec?**
+
+Six of the seven original archetypes are retained with enhanced specifications. `interview` is removed (elevated to Step 2). `fake_door` is added. The archetypes are organized into three categories with explicit sequencing. The archetype CHECK constraint in the database schema requires a migration.
+
+**5. Should we simplify, expand, or restructure the existing archetype system?**
+
+Restructure. The count changed from 7 to 7 (one removed, one added), but the organization is fundamentally different. The three-category structure (Demand Signal / WTP / Solution Validation) and the ladder sequencing concept are new. The archetype definitions are significantly more detailed — each now has full metrics, kill criteria JSON, landing page spec, CopyPack requirements, buildability rating, and decision criteria.
+
+**6. How are buildability fields (feasibility, cost, technical risks) assessed per archetype?**
+
+Each archetype has a **buildability rating** (1/5 to 5/5) and a **buildability checklist** of items needed before launch. Ratings range from 1/5 for `fake_door` and `waitlist` (just a landing page and ad campaign) to 5/5 for `service_pilot` (early tooling, operational playbook, customer support channel). Build cost estimate and technical risks are assessed per-experiment in the Test Blueprint, not per-archetype. See the buildability sections in each archetype specification.
+
+---
+
+# 8.5. Answering DD#1's Open Questions
+
+Deep Dive #1 concluded with four open questions for DD#2. Here are the answers:
+
+**1. How do Key Assumptions map to specific test archetypes?**
+
+Through the **Assumption Type Mapping** in Section 4. Each Key Assumption is categorized by type (demand, problem awareness, WTP, price sensitivity, solution fit, operational viability), which maps to a Validation Ladder category and a starting archetype. High-risk demand assumptions start at `fake_door`. High-risk WTP assumptions start at `priced_waitlist`. High-risk solution assumptions start at `concierge`.
+
+**2. Does each archetype have a recommended Hypothesis Card template?**
+
+No — the Hypothesis Card is archetype-agnostic by design. The card captures the hypothesis; the archetype captures the test design. However, certain Hypothesis Card fields are more relevant for certain archetypes. The **assumption_under_test** field in the Test Blueprint creates the explicit link between a specific Key Assumption and the archetype selected to test it.
+
+**3. How does Competitive Landscape inform channel selection?**
+
+Competitive Landscape (a Tier 2 Hypothesis Card field) informs channel selection through the Campaign Package (Step 4, Deep Dive #4), not through test type selection. However, if the Competitive Landscape reveals that competitors are already saturating a specific channel (e.g., Facebook ads for meal prep), the Test Blueprint can note this as a technical risk and recommend alternative channels.
+
+**4. How does the confidence score interact with test budget allocation?**
+
+Directly. See Section 6 (Confidence Score Interaction). "Proceed" ventures get standard budget allocation per archetype. "Uncertain" ventures get minimum budget per archetype, preserving more of the $1,500 total cap for potential pivots. "Abandon" triggers a Step 1 kill — no test budget is allocated.
+
+---
+
+# 9. Recommendations for Functional Spec v2.0
+
+1. **Update the archetype CHECK constraint** to replace `interview` with `fake_door` and reorder to match the Validation Ladder sequence: `('fake_door','waitlist','content_magnet','priced_waitlist','presale','concierge','service_pilot')`.
+
+2. **Add a `test_blueprint` JSONB column** to the experiments table, using the schema sketch in Section 5.5. This column stores the full Test Blueprint artifact.
+
+3. **Add a `category` column** to the experiments table: `CHECK(category IN ('demand_signal','willingness_to_pay','solution_validation'))`. Derived from archetype but stored explicitly for query performance.
+
+4. **Add a `sequence_position` INTEGER column** to track which rung of the Validation Ladder this experiment occupies. Combined with `prior_test_ref`, this enables sequencing queries.
+
+5. **Add a `prior_test_ref` TEXT column** (nullable foreign key to experiments.id) to link sequential tests on the same venture hypothesis.
+
+6. **Migrate existing `interview` experiments** to an archived status. Provide a migration script that sets `archetype = 'fake_door'` for any interview experiments that were actually demand tests, or archives them if they were true discovery exercises.
+
+7. **Update the KillCriteria schema** to include Hard Kill vs. Soft Kill classification. Add a `severity` field (`hard` | `soft`) to each rule in the `rules` array.
+
+8. **Add archetype defaults to the API** — when creating an experiment with a specified archetype, the API should auto-populate the `kill_criteria`, `max_duration_days`, and `max_spend_cents` fields from the archetype defaults defined in this document. Overrides are permitted but must include rationale.
+
+9. **Define the Discovery Gate** as a pre-launch validation in the experiment lifecycle. Before an experiment can transition from `preflight` to `build` status, the system should verify that the Discovery Summary reference exists and meets minimum criteria (or that a gate exception is documented).
+
+---
+
+# 10. Open Questions for Deep Dive #3
+
+1. How does the Discovery Summary artifact get populated from AI-conducted interview data? What is the schema?
+
+2. What is the minimum viable interview process for a solopreneur — how many interviews, what structure, what tools?
+
+3. Can AI agents conduct preliminary discovery interviews, and how does that data feed into the Discovery Summary?
+
+4. How does interview data quality compare between AI-conducted and human-conducted interviews?
+
+5. What screening criteria ensure interview candidates match the Hypothesis Card's Customer Segment?
+
+6. How does the Discovery Gate (Section 4) interact with the Discovery Summary schema — what specific fields must be populated to pass the gate?

--- a/docs/methodology/03-deep-dive-discovery-engine.md
+++ b/docs/methodology/03-deep-dive-discovery-engine.md
@@ -1,0 +1,1423 @@
+# Deep Dive #3: AI-Scaled Customer Discovery — The Discovery Engine
+
+> **Source:** Notion page `318786f4-e365-81af-bcc1-e8bb13b576ff`
+> **Document Type:** Deep Dive Working Document
+> **Series:** SC Validation Methodology
+> **Date:** March 2, 2026
+> **Status:** Complete — pending functional spec integration
+> **Parent:** SC Validation Methodology — Strategy Session (March 2026)
+> **Prior:** Deep Dive #2: Test Type Taxonomy — The Validation Ladder
+
+---
+
+# 1. Purpose & Scope
+
+This deep dive defines the **Discovery Engine** — the Step 2 system in the SC validation workflow that transforms customer discovery interviews from a manual bottleneck into an AI-scalable process. It specifies three interview modes, four interview protocols, a pain severity scoring rubric, the Discovery Summary artifact, the Discovery Gate mechanism, and the AI agent workflow for orchestrating the entire discovery process.
+
+**What this document covers:**
+
+- The solopreneur scaling problem and why AI assistance is necessary for customer discovery
+- Three interview modes (AI-Moderated, Human-Led, Hybrid) with per-mode specifications
+- Four interview protocols mapped to Hypothesis Card fields (Problem Discovery, Solution Fit, Willingness to Pay, ICP Validation)
+- A 3-dimensional pain severity scoring rubric (Functional Pain, Emotional Cost, Opportunity Cost)
+- The Discovery Summary artifact specification and schema sketch
+- The Discovery Gate — revised criteria with mode-weighted interview counting
+- Minimum interview counts and saturation detection
+- Assumption type classification from interview signals
+- Technology landscape for AI-conducted interviews (build vs. buy)
+- Trust and quality considerations for Validation-as-a-Service (VaaS)
+- The 6-step AI agent workflow for discovery orchestration
+
+**Relationship to DD#1 (The Venture Narrative):**
+
+The Hypothesis Card (DD#1) is the primary input to discovery. The Venture Narrative's five elements — Hero, Struggle, Stakes, Breakthrough, Moment — directly map to interview protocol questions. The three-dimensional problem taxonomy (Functional Pain / Emotional Cost / Opportunity Cost) from DD#1 Section 2 becomes the foundation for pain severity scoring in this document. Discovery interviews enrich the Hypothesis Card from Tier 1 (Draft) to Tier 2 (Full), populating Current Alternatives, Market Sizing, Competitive Landscape, and Key Assumptions with real customer evidence.
+
+**Relationship to DD#2 (The Validation Ladder):**
+
+The Discovery Summary (this document's output artifact) feeds into the Discovery Gate defined in DD#2 Section 4. DD#2 established three gate checks (>=5 interviews, pain severity >=3/5, assumption informed by interview data) and left six open questions (DD#2 Section 10) that this document answers directly in Section 13.5.
+
+**Questions this document answers:**
+
+1. Can AI agents help source and screen interview candidates?
+2. Can AI conduct preliminary discovery interviews?
+3. What is the trade-off between AI interviews and human intuition for catching real pain points?
+4. If offered as VaaS, do customers trust AI-conducted interviews?
+5. What technology exists today to enable this?
+6. How does the Discovery Summary artifact get populated from interview data?
+7. How do AI-scaled discovery interviews feed into the discovery gate?
+8. What interview protocols map to each Hypothesis Card field?
+9. What minimum interview count is needed before each test category?
+10. How does pain severity scoring work in AI-conducted interviews?
+11. What interview signals specifically inform the assumption type classification used in test selection?
+
+---
+
+# 2. The Discovery Bottleneck — Why AI is Necessary
+
+## The Solopreneur Scaling Problem
+
+Customer discovery is the most important and least scalable step in lean validation. The math is brutal for a solopreneur or small team:
+
+- **Minimum viable discovery:** 5-15 interviews per venture hypothesis
+- **Time per interview:** 3-5 hours (sourcing + scheduling + conducting + notes + analysis)
+- **Calendar time:** 2-4 weeks to complete a discovery sprint
+- **Cognitive load:** After 5-8 interviews in a week, a solo founder's ability to detect novel patterns degrades
+
+For Ventracrane validating multiple ventures, or for SC offered as VaaS to external clients, this creates an impossible constraint. A single operator cannot run discovery sprints for 3-5 ventures simultaneously without quality collapse.
+
+## Where the Bottleneck Actually Lives
+
+The discovery process has four phases, and the bottleneck is not evenly distributed:
+
+| Phase          | Activity                                      | Time per Interview | Bottleneck Severity                                        |
+| -------------- | --------------------------------------------- | ------------------ | ---------------------------------------------------------- |
+| **Sourcing**   | Finding qualified candidates matching the ICP | 30-90 min          | High — most time-consuming, lowest success rate            |
+| **Scheduling** | Coordinating calendars, sending reminders     | 15-30 min          | Medium — administrative, automatable                       |
+| **Conducting** | Running the actual interview                  | 30-60 min          | Low — the core value activity                              |
+| **Analysis**   | Extracting signals, scoring, synthesizing     | 45-90 min          | High — cognitively demanding, quality degrades with volume |
+
+The counterintuitive insight: **conducting the interview is not the bottleneck**. Sourcing candidates and analyzing results are. This means AI can deliver the most value by automating the bookends (sourcing + analysis) even if human-led interviews remain the gold standard for the middle.
+
+## The Quality-Quantity Tradeoff
+
+Research on AI-conducted interviews (Outset AI, Listen Labs, academic studies) reveals a consistent pattern:
+
+- **Human saturation:** A skilled interviewer reaches thematic saturation at 5-15 interviews. Beyond 15, marginal insight per interview drops sharply.
+- **AI scale advantage:** AI-moderated interviews can reach 30+ participants in the same calendar time, with consistent protocol adherence across all sessions.
+- **Emotional depth gap:** AI interviews show approximately 26% lower emotional connection scores compared to skilled human interviewers, based on participant self-reports.
+- **Disclosure paradox:** Multiple studies show participants disclose more to AI interviewers on sensitive or embarrassing topics — the absence of human judgment reduces social desirability bias.
+- **Protocol adherence:** AI interviewers follow the protocol 100% of the time. Human interviewers drift, skip questions under time pressure, and introduce unconscious framing biases.
+
+The tradeoff is not "AI vs. human" — it is "consistent breadth vs. empathetic depth." SC's Discovery Engine is designed to capture both.
+
+---
+
+# 3. The Discovery Engine — SC's Interview Framework
+
+## Three Interview Modes
+
+| Attribute              | AI-Moderated                                                 | Human-Led                                                | Hybrid                                                        |
+| ---------------------- | ------------------------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------- |
+| **Modality**           | Asynchronous text/voice via AI platform                      | Synchronous video/phone call                             | Human conducts, AI assists in real-time + analyzes            |
+| **Conductor**          | AI agent following protocol                                  | Founder or trained interviewer                           | Human interviewer with AI co-pilot                            |
+| **Depth**              | Moderate — follows protocol precisely, limited improvisation | High — can pursue unexpected threads, read body language | High — human improvisation with AI ensuring protocol coverage |
+| **Scale**              | High — 10-30+ interviews per week                            | Low — 3-5 interviews per week                            | Medium — 5-10 interviews per week                             |
+| **Cost per Interview** | \$5-15 (platform fee + AI compute)                           | \$50-150 (interviewer time + scheduling)                 | \$30-75 (reduced prep/analysis time)                          |
+| **Best For**           | ICP validation, broad pattern detection, sensitive topics    | Problem discovery, emotional depth, complex B2B          | Default mode — balanced quality and throughput                |
+
+**Default mode: Hybrid.** Human-led interviews with AI-powered preparation, real-time protocol tracking, and automated post-interview analysis. This captures the depth of human conversation with the consistency and scale of AI processing.
+
+### AI-Moderated Mode
+
+The AI agent conducts the interview independently, following the selected protocol. The interview happens asynchronously (the participant responds at their own pace) or synchronously via voice AI. The agent handles follow-up probing, enforces time boundaries, and extracts signals in real-time.
+
+**Strengths:** Scale, consistency, lower cost, reduced social desirability bias, 24/7 availability across time zones.
+
+**Weaknesses:** Cannot read body language or vocal micro-expressions, limited ability to pursue truly unexpected threads, lower emotional rapport.
+
+**When to use:** ICP validation at scale (need 20+ data points on demographics/firmographics), sensitive topics where anonymity helps disclosure, early-stage screening before committing to human interviews.
+
+### Human-Led Mode
+
+A human interviewer (founder, trained researcher, or VaaS operator) conducts the interview. AI assists with preparation (generating the protocol from the Hypothesis Card) and post-interview analysis (transcript processing, signal extraction, pain scoring).
+
+**Strengths:** Deepest emotional insight, ability to follow unexpected threads, builds personal relationships with potential early adopters, body language and tonal cues.
+
+**Weaknesses:** Lowest throughput, highest cost, interviewer bias and fatigue, inconsistent protocol adherence.
+
+**When to use:** Problem discovery for novel/ambiguous problem spaces, B2B enterprise interviews where relationships matter, when the founder needs to personally hear customer pain.
+
+### Hybrid Mode
+
+The human conducts the interview while an AI agent operates as a co-pilot: monitoring protocol coverage in real-time, suggesting follow-up questions, flagging when key topics have not been explored, and performing real-time signal extraction. Post-interview, the AI generates the full analysis automatically.
+
+**Strengths:** Human depth + AI consistency, reduced interviewer cognitive load, real-time gap detection, automated analysis.
+
+**Weaknesses:** Requires technology integration (transcript streaming + AI overlay), higher per-interview cost than pure AI, interviewer must be comfortable with AI assistance.
+
+**When to use:** Default mode for all discovery sprints. The best balance of quality and efficiency.
+
+## The Trust Disclosure Principle
+
+> **When using AI-Moderated mode, the participant must always be informed they are interacting with an AI.** No deception. The disclosure should be upfront, clear, and normalized: "This interview is conducted by an AI research assistant. Your responses are confidential and will be used to understand [problem space]." Studies show that upfront disclosure does not significantly reduce participation rates and may increase disclosure on sensitive topics.
+
+## Phase 1 Focus
+
+SC's Phase 1 implementation focuses on **human-led interviews with AI-powered analysis**. The AI agent handles:
+
+1. Generating interview protocols from the Hypothesis Card
+2. Assisting with candidate sourcing (search queries, outreach templates, screening criteria)
+3. Post-interview transcript analysis (signal extraction, pain scoring, Discovery Summary population)
+
+Full AI-Moderated interviews are a Phase 2 capability, dependent on the maturity of conversational AI platforms and SC's own trust calibration data from Phase 1 human interviews.
+
+---
+
+# 4. Interview Protocols — Mapping to Hypothesis Card Fields
+
+## Protocol Overview
+
+Each protocol is designed to extract specific information that maps directly to Hypothesis Card fields and Discovery Summary outputs.
+
+| Protocol               | Purpose                                                               | Primary HC Fields Tested                                      | Discovery Summary Fields Populated                                          | Typical Duration |
+| ---------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------- | ---------------- |
+| **Problem Discovery**  | Validate problem existence, severity, and current coping mechanisms   | Problem Statement, Stakes (Failure/Success), Customer Segment | problem_confirmed, pain_severity, top_quotes, current_alternatives_observed | 30-45 min        |
+| **Solution Fit**       | Test whether the proposed solution resonates and what features matter | Solution Hypothesis, Why Now                                  | solution_resonance, feature_priorities, objections                          | 20-30 min        |
+| **Willingness to Pay** | Explore price sensitivity and value perception                        | Solution Hypothesis, Market Sizing                            | wtp_signal, price_range_observed, value_anchors                             | 15-25 min        |
+| **ICP Validation**     | Refine the customer segment with real demographic/firmographic data   | Customer Segment                                              | icp_refinements, segment_characteristics, disqualification_patterns         | 15-20 min        |
+
+## 4.1 Problem Discovery Protocol
+
+The foundational protocol. Every discovery sprint begins here. No interview should skip problem discovery — it is the minimum viable protocol even when time is constrained.
+
+### Opening Questions
+
+These questions are asked in order. They are designed to be open-ended, non-leading, and to let the participant's natural language reveal pain points.
+
+1. "Tell me about your role and what a typical [day/week] looks like."
+2. "What are the biggest challenges you face in [problem domain]?"
+3. "Can you walk me through the last time you dealt with [problem]? What happened?"
+4. "How are you handling [problem] today? What tools or workarounds do you use?"
+5. "What happens when [problem] doesn't get solved? What's the impact?"
+
+### Probing Follow-Ups
+
+The interviewer (human or AI) selects from these follow-ups based on participant responses:
+
+- **Functional depth:** "How much time does that take you? How often does it happen?"
+- **Emotional depth:** "How does that make you feel when [situation] happens?"
+- **Opportunity cost:** "What would you be doing instead if this wasn't a problem?"
+- **Severity calibration:** "On a scale of 1-10, how much of a pain point is this for you?"
+- **Frequency and recency:** "When was the last time this happened? How often?"
+- **Current alternatives:** "Have you tried any solutions for this? What worked and what didn't?"
+- **Switching cost:** "What would it take for you to switch from your current approach?"
+
+### Closing Questions
+
+6. "If you could wave a magic wand and fix one thing about [problem domain], what would it be?"
+7. "Is there anything else about [problem] that I should have asked about but didn't?"
+
+### Signal Extraction Rules
+
+After the interview, the following signals are extracted:
+
+| Signal                         | Extraction Method                                                          | Maps To                         |
+| ------------------------------ | -------------------------------------------------------------------------- | ------------------------------- |
+| Problem confirmed (Y/N)        | Participant describes the problem unprompted OR confirms it when described | `problem_confirmed`             |
+| Pain severity (1-5)            | Scored across 3 dimensions using rubric (Section 5)                        | `pain_severity`                 |
+| Current alternatives           | Participant describes existing solutions/workarounds                       | `current_alternatives_observed` |
+| Frequency and recency          | Explicit statements about how often/recently the problem occurs            | `frequency_indicator`           |
+| Emotional language             | Direct quotes expressing frustration, anxiety, relief, etc.                | `top_quotes`                    |
+| Willingness to discuss further | Participant asks for follow-up, offers to connect others                   | `engagement_signal`             |
+
+### Red Flag Patterns
+
+These patterns suggest the problem may not be real or severe enough to validate:
+
+- Participant cannot describe a specific recent instance of the problem
+- Pain is acknowledged but described as "not a big deal" or "I've gotten used to it"
+- Current alternatives are described as "fine" or "good enough" without frustration
+- Participant redirects to a different problem repeatedly (the stated problem may not be the real one)
+- Excessive agreement without specifics (acquiescence bias — see Section 11)
+
+## 4.2 Solution Fit Protocol
+
+Run after Problem Discovery has confirmed the problem. Presents the solution concept (from the Hypothesis Card's Solution Hypothesis and Breakthrough narrative element) and measures resonance.
+
+### Opening Questions
+
+1. "Based on what you've told me about [problem], I'd like to describe a possible solution and get your reaction."
+2. [Present the solution concept in 2-3 sentences, adapted from the Solution Hypothesis field]
+3. "What's your initial reaction to that?"
+4. "What would this need to do for you to actually use it?"
+5. "What concerns or objections come to mind?"
+
+### Probing Follow-Ups
+
+- **Feature priority:** "Of the things I described, which is the most important to you? Which could you live without?"
+- **Competitive comparison:** "How does this compare to what you use today?"
+- **Adoption friction:** "What would make it hard for you to switch to something like this?"
+- **Timing:** "If this existed today, would you try it? What would you need to see first?"
+- **Social proof need:** "Would you need to see other people using this before you tried it?"
+
+### Closing Questions
+
+6. "If this existed exactly as I described it, would you want to be notified when it launches?"
+7. "Who else in your [company/network] would benefit from something like this?"
+
+### Signal Extraction Rules
+
+| Signal                   | Extraction Method                                                    | Maps To              |
+| ------------------------ | -------------------------------------------------------------------- | -------------------- |
+| Solution resonance (1-5) | Enthusiasm level: 1=dismissive, 3=interested, 5=desperate to have it | `solution_resonance` |
+| Feature priorities       | Ranked list of features/capabilities mentioned as important          | `feature_priorities` |
+| Objections               | Specific concerns or reasons they would not use it                   | `objections`         |
+| Referral willingness     | Offers to connect others or asks for follow-up                       | `engagement_signal`  |
+| Adoption timeline        | Expressed urgency or lack thereof                                    | `urgency_indicator`  |
+
+## 4.3 Willingness to Pay Protocol
+
+Run after Solution Fit has confirmed resonance. Explores price sensitivity without anchoring the participant to a specific number prematurely.
+
+### Opening Questions
+
+1. "You mentioned [solution] would be valuable for you. I'd like to understand what that value looks like in terms of cost."
+2. "How much does [problem] cost you today — in time, money, or missed opportunities?"
+3. "If a solution like this saved you [time/money/pain described], what would that be worth to you per month?"
+4. "At what price would this feel like a no-brainer? At what price would you say 'no way'?"
+
+### Probing Follow-Ups
+
+- **Value anchoring:** "You mentioned it costs you [X hours/dollars] today. If this cut that in half, what would you pay?"
+- **Comparison pricing:** "What do you pay for similar tools/services today?"
+- **Budget reality:** "Is this something you'd pay for out of pocket, or would it need organizational approval?"
+- **Payment model preference:** "Would you prefer monthly, annual, or one-time pricing?"
+- **Free vs. paid threshold:** "What would it need to do for you to pay for it vs. expecting it for free?"
+
+### Closing Questions
+
+5. "If I told you this was [specific price], what would your reaction be?"
+6. "Would you pre-order this today at [price]? What would make you say yes?"
+
+### Signal Extraction Rules
+
+| Signal                   | Extraction Method                                            | Maps To                |
+| ------------------------ | ------------------------------------------------------------ | ---------------------- |
+| WTP signal (Y/N/Maybe)   | Participant expresses willingness to pay at some price point | `wtp_signal`           |
+| Price range              | Stated acceptable range (no-brainer to no-way)               | `price_range_observed` |
+| Value anchors            | Specific comparisons to existing spend or cost-of-problem    | `value_anchors`        |
+| Budget authority         | Whether participant controls the purchase decision           | `budget_authority`     |
+| Payment model preference | Monthly/annual/one-time preference                           | `payment_model_pref`   |
+
+## 4.4 ICP Validation Protocol
+
+Run in parallel with any other protocol, or as a standalone for demographic/firmographic data collection at scale. This protocol is the best candidate for AI-Moderated mode because it requires breadth over depth.
+
+### Opening Questions
+
+1. "Tell me about yourself and your [role/business/situation]."
+2. "How large is your [team/company/operation]?"
+3. "What tools/platforms do you use for [relevant activity]?"
+4. "How did you first become aware of [problem]?"
+5. "Who else in your [company/network] deals with this problem?"
+
+### Probing Follow-Ups
+
+- **Demographic precision:** "How long have you been in this role? What's your background?"
+- **Firmographic detail:** "What industry? How many employees? Annual revenue range?"
+- **Behavioral patterns:** "How do you typically discover new tools/services? What channels?"
+- **Decision-making:** "Who makes the buying decision for tools like this? Is it you, a team, a committee?"
+- **Segmentation signals:** "Would you describe yourself as [segment characteristic]?"
+
+### Closing Questions
+
+6. "If I wanted to find more people like you who have this problem, where would I look?"
+7. "What communities, publications, or events are relevant to people in your situation?"
+
+### Signal Extraction Rules
+
+| Signal                    | Extraction Method                                                              | Maps To                     |
+| ------------------------- | ------------------------------------------------------------------------------ | --------------------------- |
+| Segment match (Y/N)       | Participant matches the Hypothesis Card's Customer Segment description         | `segment_match`             |
+| ICP refinements           | Demographic/firmographic details that refine or challenge the Customer Segment | `icp_refinements`           |
+| Discovery channels        | Where this person can be found for marketing (feeds campaign targeting)        | `discovery_channels`        |
+| Decision dynamics         | Solo vs. committee, budget authority, approval process                         | `decision_dynamics`         |
+| Disqualification patterns | Characteristics that correlate with non-customers                              | `disqualification_patterns` |
+
+## Protocol Selection Logic
+
+Not every interview needs all four protocols. Selection depends on the current state of the Hypothesis Card and what has already been validated.
+
+| Current State                         | Required Protocols                 | Optional Protocols                |
+| ------------------------------------- | ---------------------------------- | --------------------------------- |
+| Tier 1 card, no interviews yet        | Problem Discovery + ICP Validation | —                                 |
+| Problem confirmed, solution undefined | Problem Discovery + Solution Fit   | ICP Validation                    |
+| Problem + solution confirmed          | Willingness to Pay                 | Solution Fit (refinement)         |
+| All protocols run, enriching Tier 2   | ICP Validation (at scale via AI)   | Any protocol for saturation check |
+
+**Rule:** Problem Discovery is always the first protocol in any discovery sprint. Never skip directly to Solution Fit or WTP without confirming the problem first.
+
+## Worked Example
+
+> **Scenario:** SC is validating a B2B SaaS idea — AI-powered competitor tracking for marketing managers at mid-size companies (50-200 employees).
+>
+> **Hypothesis Card (Tier 1):**
+>
+> - Customer Segment: Marketing managers at B2B SaaS companies, 50-200 employees
+> - Problem Statement: Tracking competitors manually in spreadsheets takes 5+ hours/week and misses real-time changes
+> - Solution Hypothesis: Automated competitor monitoring dashboard with AI-generated insight summaries
+>
+> **Discovery Sprint Plan:**
+>
+> - Week 1: 5 Hybrid interviews using Problem Discovery + ICP Validation protocols
+> - Week 2: If problem confirmed, 3 Hybrid interviews adding Solution Fit protocol
+> - Week 2 (parallel): 10 AI-Moderated ICP Validation interviews for demographic breadth
+> - Week 3: 3 Hybrid interviews adding WTP protocol for confirmed problem-holders
+>
+> **Total:** 21 interviews over 3 weeks — 11 Hybrid, 10 AI-Moderated. Weighted count: 11 x 0.75 + 10 x 0.5 = 13.25 (see Section 7 for mode weighting).
+
+---
+
+# 5. Pain Severity Scoring Rubric
+
+## Three-Dimensional Pain Assessment
+
+Pain severity uses the same three dimensions from DD#1's Venture Narrative problem taxonomy (The Struggle). Each dimension is scored independently on a 1-5 scale.
+
+### Functional Pain
+
+| Score | Label      | Description                                                     | Interview Signal                   |
+| ----- | ---------- | --------------------------------------------------------------- | ---------------------------------- |
+| 1     | Negligible | Minor inconvenience, barely noticed                             | "It's not really a problem"        |
+| 2     | Mild       | Noticeable friction, easy workaround exists                     | "I deal with it, it's fine"        |
+| 3     | Moderate   | Regular time/effort drain, workaround is tolerable but annoying | "It's frustrating but I manage"    |
+| 4     | Severe     | Significant daily/weekly impact, workaround is painful          | "I waste hours on this every week" |
+| 5     | Critical   | Blocking or crisis-level, no acceptable workaround              | "This is killing our business"     |
+
+### Emotional Cost
+
+| Score | Label          | Description                                                  | Interview Signal                                 |
+| ----- | -------------- | ------------------------------------------------------------ | ------------------------------------------------ |
+| 1     | Unbothered     | No emotional reaction to the problem                         | Neutral tone, no affect                          |
+| 2     | Mildly annoyed | Slight frustration, quickly dismissed                        | "It's a bit annoying"                            |
+| 3     | Frustrated     | Clear negative emotion, recurring dissatisfaction            | Audible sighing, repeated "frustrating"          |
+| 4     | Stressed       | Anxiety, dread, or anger associated with the problem         | "I dread doing this" / "It keeps me up at night" |
+| 5     | Overwhelmed    | The problem causes significant emotional distress or burnout | "I'm at my breaking point" / visible distress    |
+
+### Opportunity Cost
+
+| Score | Label       | Description                                             | Interview Signal                                     |
+| ----- | ----------- | ------------------------------------------------------- | ---------------------------------------------------- |
+| 1     | Minimal     | Problem doesn't prevent anything meaningful             | Cannot name what they would do instead               |
+| 2     | Minor       | Small opportunities missed, low value                   | "I could probably do [low-value task] instead"       |
+| 3     | Moderate    | Meaningful activities displaced by the problem          | "I should be doing [specific valuable task] instead" |
+| 4     | Major       | High-value activities blocked, competitive disadvantage | "We're losing to competitors who have solved this"   |
+| 5     | Existential | Business viability or career progression threatened     | "If we don't fix this, we won't survive"             |
+
+## Composite Score Calculation
+
+The composite pain severity score is the **weighted average** of the three dimensions:
+
+```
+composite_pain = (functional_pain + emotional_cost + opportunity_cost) / 3
+```
+
+Rounded to one decimal place. Range: 1.0 to 5.0.
+
+**Example:** Functional Pain = 4, Emotional Cost = 3, Opportunity Cost = 5 --> Composite = (4 + 3 + 5) / 3 = 4.0
+
+## The Peak Dimension Rule
+
+> **Any single dimension scoring >= 4.0 (averaged across interviews) meets the Discovery Gate threshold, regardless of the composite score.** A problem that is functionally minor but existentially threatening (Opportunity Cost = 5) is still a validated pain point. The composite score captures breadth; the peak dimension captures depth.
+
+## The Polarization Flag
+
+When the standard deviation across the three dimensions exceeds 1.5, the Discovery Summary flags the pain as **polarized**. This means the pain is intense in one dimension but weak in others — a signal that messaging and solution positioning should emphasize the peak dimension.
+
+**Example:** Functional = 2, Emotional = 2, Opportunity = 5. Std dev = 1.73. Polarization flag = true. Messaging should emphasize the existential risk, not the daily friction.
+
+## AI Scoring Method (3-Step)
+
+When AI is performing the scoring (in AI-Moderated or Hybrid post-analysis mode):
+
+1. **Extract verbatim quotes** from the transcript that relate to each pain dimension. Tag each quote with the dimension it maps to.
+2. **Score each quote** against the rubric descriptions above. Use the interview signal column as calibration anchors.
+3. **Average the per-quote scores** within each dimension to produce the dimension score. If multiple quotes exist for a dimension, weight longer/more detailed quotes higher (they indicate the participant spent more time on that dimension, suggesting greater salience).
+
+**Quality guard:** If fewer than 2 quotes are extracted for any dimension, score that dimension as "insufficient data" rather than defaulting to 1. Insufficient data in a dimension does not count toward the composite or peak evaluation.
+
+## Threshold Significance
+
+The pain severity score feeds directly into two gates:
+
+- **Discovery Gate (DD#2 Section 4):** Composite pain severity >= 3.0 OR any peak dimension >= 4.0
+- **Accelerate (GO) Criteria (Strategy Session):** Discovery Summary showed pain severity >= 3/5
+
+A score below 3.0 with no peak dimension >= 4.0 means the problem is real but not painful enough to drive purchasing behavior. This is the most common discovery outcome and the primary mechanism for cheap kills before campaign spend.
+
+---
+
+# 6. The Discovery Summary — Artifact Specification
+
+The **Discovery Summary** is the Step 2 output artifact. It bridges the Hypothesis Card (what we believe) and the Test Blueprint (how we test it). It is the structured output of the discovery sprint — populated from interview data, not from founder opinion.
+
+## Field Specification
+
+| Field                           | Type          | Description                                                                                                 | Source Protocol    | Required                 |
+| ------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------ |
+| `experiment_id`                 | string        | References the parent experiment                                                                            | System             | Yes                      |
+| `hypothesis_card_version`       | string        | "draft" or "full" — which tier was used as input                                                            | System             | Yes                      |
+| `interview_count`               | integer       | Total number of completed interviews                                                                        | System             | Yes                      |
+| `interview_count_weighted`      | number        | Mode-weighted count (see Section 7)                                                                         | Calculated         | Yes                      |
+| `mode_breakdown`                | object        | Count per mode: `{ ai: N, hybrid: N, human: N }`                                                            | System             | Yes                      |
+| `problem_confirmed`             | boolean       | Did interviews confirm the problem exists?                                                                  | Problem Discovery  | Yes                      |
+| `pain_severity`                 | object        | `{ functional: N, emotional: N, opportunity: N, composite: N, peak_dimension: string, polarized: boolean }` | Problem Discovery  | Yes                      |
+| `current_alternatives_observed` | array[string] | Actual solutions/workarounds participants described                                                         | Problem Discovery  | Yes                      |
+| `top_quotes`                    | array[object] | `{ quote: string, participant_id: string, dimension: string, protocol: string }` — max 10                   | All protocols      | Yes                      |
+| `solution_resonance`            | number (1-5)  | Average enthusiasm for the proposed solution                                                                | Solution Fit       | No (if protocol not run) |
+| `feature_priorities`            | array[string] | Ranked features/capabilities by interview frequency                                                         | Solution Fit       | No                       |
+| `objections`                    | array[string] | Common objections or concerns raised                                                                        | Solution Fit       | No                       |
+| `wtp_signal`                    | string        | "strong" / "moderate" / "weak" / "none"                                                                     | Willingness to Pay | No                       |
+| `price_range_observed`          | object        | `{ low: cents, mid: cents, high: cents, currency: string }`                                                 | Willingness to Pay | No                       |
+| `value_anchors`                 | array[string] | What participants compared the value to                                                                     | Willingness to Pay | No                       |
+| `icp_refinements`               | object        | Refined segment characteristics from real data                                                              | ICP Validation     | No                       |
+| `segment_characteristics`       | object        | Demographics/firmographics observed across participants                                                     | ICP Validation     | No                       |
+| `disqualification_patterns`     | array[string] | Characteristics that correlate with non-customers                                                           | ICP Validation     | No                       |
+| `discovery_channels`            | array[string] | Where to find more customers like the ones interviewed                                                      | ICP Validation     | No                       |
+| `assumption_updates`            | array[object] | `{ assumption: string, original_risk: string, updated_risk: string, evidence: string }`                     | All protocols      | Yes                      |
+| `gate_status`                   | object        | See structure below                                                                                         | Calculated         | Yes                      |
+| `saturation_reached`            | boolean       | Whether thematic saturation was detected (see Section 8)                                                    | Calculated         | Yes                      |
+| `analyst_notes`                 | string        | Free-text observations from the interviewer or AI analyst                                                   | All protocols      | No                       |
+
+## Gate Status Structure
+
+```json
+{
+  "gate_status": {
+    "passed": true,
+    "checks": {
+      "minimum_interviews": { "passed": true, "value": 13.25, "threshold": 5 },
+      "pain_severity": { "passed": true, "value": 3.8, "threshold": 3.0 },
+      "peak_dimension": {
+        "passed": true,
+        "dimension": "opportunity_cost",
+        "value": 4.2,
+        "threshold": 4.0
+      },
+      "assumption_evidence": { "passed": true, "evidence_type": "direct_quote", "count": 7 },
+      "problem_confirmed": { "passed": true },
+      "saturation_reached": { "passed": true, "consecutive_no_new_themes": 3 }
+    },
+    "override": null,
+    "override_rationale": null
+  }
+}
+```
+
+## Two Completion Stages
+
+### Draft Summary
+
+Populated automatically after each interview. The agent updates running tallies (interview count, mode breakdown), appends new quotes, recalculates pain severity averages, and updates the gate status. The Draft Summary is a living document during the discovery sprint.
+
+### Final Summary
+
+Locked after the discovery sprint completes (either saturation is reached, minimum interviews are met, or the sprint time-box expires). The Final Summary includes the analyst notes, final gate status, and assumption updates. It becomes the input to Test Blueprint creation (Step 3).
+
+## Relationship to Hypothesis Card
+
+The Discovery Summary **enriches** the Hypothesis Card from Tier 1 to Tier 2:
+
+| Discovery Summary Field                       | Enriches HC Field                                       |
+| --------------------------------------------- | ------------------------------------------------------- |
+| `current_alternatives_observed`               | Current Alternatives                                    |
+| `icp_refinements` + `segment_characteristics` | Customer Segment (refined)                              |
+| `assumption_updates`                          | Key Assumptions (evidence-based risk updates)           |
+| `pain_severity`                               | Problem Statement (validated severity)                  |
+| `discovery_channels`                          | Competitive Landscape (indirect — channel intelligence) |
+
+## Relationship to Test Blueprint
+
+The Discovery Summary provides concrete inputs to DD#2's test selection logic:
+
+| Discovery Summary Field    | Test Blueprint Field                                                          |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `gate_status`              | `discovery_gate`                                                              |
+| `pain_severity.composite`  | Gate check #2 (pain severity >= 3.0)                                          |
+| `interview_count_weighted` | Gate check #1 (>= 5 weighted interviews)                                      |
+| `assumption_updates`       | `riskiest_assumption` + `assumption_type` selection                           |
+| `wtp_signal`               | Category routing (if strong WTP signal, may skip to Willingness to Pay tests) |
+
+## Worked Example
+
+> **Scenario:** Discovery sprint for the B2B competitor tracking tool. 11 Hybrid + 10 AI-Moderated interviews completed.
+>
+> **Discovery Summary (Final):**
+>
+> ```json
+> {
+>   "experiment_id": "SC-2026-007",
+>   "hypothesis_card_version": "draft",
+>   "interview_count": 21,
+>   "interview_count_weighted": 13.25,
+>   "mode_breakdown": { "ai": 10, "hybrid": 11, "human": 0 },
+>   "problem_confirmed": true,
+>   "pain_severity": {
+>     "functional": 4.1,
+>     "emotional": 3.2,
+>     "opportunity": 3.6,
+>     "composite": 3.6,
+>     "peak_dimension": "functional",
+>     "polarized": false
+>   },
+>   "current_alternatives_observed": [
+>     "Manual spreadsheet tracking (mentioned by 14/21)",
+>     "Google Alerts (mentioned by 9/21)",
+>     "Occasional competitor website visits (mentioned by 7/21)",
+>     "Asking sales team for anecdotal intel (mentioned by 5/21)"
+>   ],
+>   "top_quotes": [
+>     {
+>       "quote": "I spend at least 5 hours a week just checking competitor websites and updating my spreadsheet. It's the worst part of my job.",
+>       "participant_id": "P003",
+>       "dimension": "functional",
+>       "protocol": "problem_discovery"
+>     },
+>     {
+>       "quote": "Our CEO asked me last week what Competitor X launched and I had no idea. That was embarrassing.",
+>       "participant_id": "P007",
+>       "dimension": "emotional",
+>       "protocol": "problem_discovery"
+>     },
+>     {
+>       "quote": "If I could automate this, I'd spend that time on actual campaigns instead of detective work.",
+>       "participant_id": "P011",
+>       "dimension": "opportunity",
+>       "protocol": "problem_discovery"
+>     }
+>   ],
+>   "solution_resonance": 4.1,
+>   "feature_priorities": [
+>     "Real-time alerts when competitors change pricing or messaging",
+>     "Weekly AI-generated summary of competitor activity",
+>     "Integration with Slack for team notifications"
+>   ],
+>   "objections": [
+>     "How accurate is the AI analysis? (mentioned by 6/21)",
+>     "Does it track social media or just websites? (mentioned by 4/21)",
+>     "Concern about data freshness — how often does it scan? (mentioned by 3/21)"
+>   ],
+>   "wtp_signal": "strong",
+>   "price_range_observed": { "low": 4900, "mid": 9900, "high": 19900, "currency": "usd" },
+>   "value_anchors": [
+>     "Comparable to SEMrush competitive module ($99-199/mo)",
+>     "Less than one hour of a marketing manager's time per week"
+>   ],
+>   "icp_refinements": {
+>     "company_size": "50-200 employees confirmed. Below 50: problem exists but budget is DIY. Above 200: dedicated competitive intelligence role exists.",
+>     "role": "Marketing Manager or VP Marketing. Not individual contributors — they don't own the competitive tracking task.",
+>     "industry": "B2B SaaS confirmed. B2B services also showed signal but weaker."
+>   },
+>   "segment_characteristics": {
+>     "avg_company_size": 120,
+>     "common_tools": ["HubSpot", "SEMrush", "Google Analytics", "Slack"],
+>     "decision_authority": "Can approve up to $200/mo without VP sign-off"
+>   },
+>   "disqualification_patterns": [
+>     "Companies under 30 employees — no dedicated marketing role",
+>     "Enterprise (500+) — have dedicated CI team, different buying process"
+>   ],
+>   "discovery_channels": [
+>     "LinkedIn Marketing Manager groups",
+>     "SaaStr community",
+>     "HubSpot User Groups",
+>     "r/marketing on Reddit"
+>   ],
+>   "assumption_updates": [
+>     {
+>       "assumption": "Marketing managers track competitors manually in spreadsheets",
+>       "original_risk": "medium",
+>       "updated_risk": "low",
+>       "evidence": "14/21 participants confirmed spreadsheet tracking. Direct quotes from P003, P008, P015."
+>     },
+>     {
+>       "assumption": "Managers will pay $99/mo for automation",
+>       "original_risk": "high",
+>       "updated_risk": "medium",
+>       "evidence": "WTP signal strong. Mid-range anchor at $99. But 4/21 expected it to be free or <$50."
+>     }
+>   ],
+>   "gate_status": {
+>     "passed": true,
+>     "checks": {
+>       "minimum_interviews": { "passed": true, "value": 13.25, "threshold": 5 },
+>       "pain_severity": { "passed": true, "value": 3.6, "threshold": 3.0 },
+>       "peak_dimension": {
+>         "passed": true,
+>         "dimension": "functional",
+>         "value": 4.1,
+>         "threshold": 4.0
+>       },
+>       "assumption_evidence": { "passed": true, "evidence_type": "direct_quote", "count": 14 },
+>       "problem_confirmed": { "passed": true },
+>       "saturation_reached": { "passed": true, "consecutive_no_new_themes": 4 }
+>     },
+>     "override": null,
+>     "override_rationale": null
+>   },
+>   "saturation_reached": true,
+>   "analyst_notes": "Strong problem signal with functional pain as the peak dimension. Solution resonance is high but price sensitivity exists — the $99 anchor is accepted by the majority but a significant minority (19%) expects cheaper. Recommend priced_waitlist test at $99/mo with a secondary variant at $49/mo."
+> }
+> ```
+
+---
+
+# 6.5. Discovery Summary Schema Sketch
+
+Field specification for the `discovery_summary` JSONB column, following the same pattern as DD#1's `hypothesis_card` and DD#2's `test_blueprint` schemas:
+
+```json
+{
+  "experiment_id": {
+    "type": "string",
+    "required": true,
+    "description": "References parent experiment ID (SC-YYYY-NNN)"
+  },
+  "hypothesis_card_version": {
+    "type": "string",
+    "enum": ["draft", "full"],
+    "required": true,
+    "description": "Which tier of the Hypothesis Card was used as input"
+  },
+  "interview_count": {
+    "type": "integer",
+    "required": true,
+    "minimum": 0,
+    "description": "Total completed interviews (raw count)"
+  },
+  "interview_count_weighted": {
+    "type": "number",
+    "required": true,
+    "minimum": 0,
+    "description": "Mode-weighted count: AI=0.5x, Hybrid=0.75x, Human=1.0x"
+  },
+  "mode_breakdown": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "ai": { "type": "integer", "minimum": 0 },
+      "hybrid": { "type": "integer", "minimum": 0 },
+      "human": { "type": "integer", "minimum": 0 }
+    }
+  },
+  "problem_confirmed": {
+    "type": "boolean",
+    "required": true,
+    "description": "Whether interviews confirmed the stated problem exists"
+  },
+  "pain_severity": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "functional": { "type": "number", "minimum": 1, "maximum": 5 },
+      "emotional": { "type": "number", "minimum": 1, "maximum": 5 },
+      "opportunity": { "type": "number", "minimum": 1, "maximum": 5 },
+      "composite": { "type": "number", "minimum": 1, "maximum": 5 },
+      "peak_dimension": { "type": "string", "enum": ["functional", "emotional", "opportunity"] },
+      "polarized": { "type": "boolean" }
+    }
+  },
+  "current_alternatives_observed": {
+    "type": "array",
+    "required": true,
+    "items": { "type": "string" },
+    "description": "Workarounds and existing solutions described by participants"
+  },
+  "top_quotes": {
+    "type": "array",
+    "required": true,
+    "maxItems": 10,
+    "items": {
+      "quote": { "type": "string", "maxLength": 500 },
+      "participant_id": { "type": "string" },
+      "dimension": {
+        "type": "string",
+        "enum": ["functional", "emotional", "opportunity", "solution", "wtp", "icp"]
+      },
+      "protocol": {
+        "type": "string",
+        "enum": ["problem_discovery", "solution_fit", "willingness_to_pay", "icp_validation"]
+      }
+    }
+  },
+  "solution_resonance": {
+    "type": "number",
+    "required": false,
+    "minimum": 1,
+    "maximum": 5,
+    "description": "Average enthusiasm for proposed solution. Null if Solution Fit protocol not run."
+  },
+  "feature_priorities": {
+    "type": "array",
+    "required": false,
+    "items": { "type": "string" },
+    "description": "Ranked features by interview mention frequency"
+  },
+  "objections": {
+    "type": "array",
+    "required": false,
+    "items": { "type": "string" },
+    "description": "Common objections or concerns about the solution"
+  },
+  "wtp_signal": {
+    "type": "string",
+    "enum": ["strong", "moderate", "weak", "none"],
+    "required": false,
+    "description": "Aggregate willingness-to-pay signal. Null if WTP protocol not run."
+  },
+  "price_range_observed": {
+    "type": "object",
+    "required": false,
+    "properties": {
+      "low": { "type": "integer", "description": "No-brainer price in cents" },
+      "mid": { "type": "integer", "description": "Acceptable price in cents" },
+      "high": { "type": "integer", "description": "Too-expensive price in cents" },
+      "currency": { "type": "string", "default": "usd" }
+    }
+  },
+  "value_anchors": {
+    "type": "array",
+    "required": false,
+    "items": { "type": "string" },
+    "description": "What participants compared the value to (existing tools, time saved, etc.)"
+  },
+  "icp_refinements": {
+    "type": "object",
+    "required": false,
+    "description": "Free-form refinements to customer segment based on interview data",
+    "additionalProperties": { "type": "string" }
+  },
+  "segment_characteristics": {
+    "type": "object",
+    "required": false,
+    "description": "Observed demographics/firmographics across participants",
+    "additionalProperties": true
+  },
+  "disqualification_patterns": {
+    "type": "array",
+    "required": false,
+    "items": { "type": "string" },
+    "description": "Characteristics correlated with non-customers"
+  },
+  "discovery_channels": {
+    "type": "array",
+    "required": false,
+    "items": { "type": "string" },
+    "description": "Where to find more customers — feeds campaign targeting"
+  },
+  "assumption_updates": {
+    "type": "array",
+    "required": true,
+    "items": {
+      "assumption": { "type": "string" },
+      "original_risk": { "type": "string", "enum": ["high", "medium", "low"] },
+      "updated_risk": { "type": "string", "enum": ["high", "medium", "low"] },
+      "evidence": { "type": "string", "maxLength": 500 }
+    },
+    "description": "Updates to Hypothesis Card Key Assumptions based on interview evidence"
+  },
+  "gate_status": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "passed": { "type": "boolean" },
+      "checks": {
+        "type": "object",
+        "properties": {
+          "minimum_interviews": {
+            "type": "object",
+            "properties": {
+              "passed": { "type": "boolean" },
+              "value": { "type": "number" },
+              "threshold": { "type": "number" }
+            }
+          },
+          "pain_severity": {
+            "type": "object",
+            "properties": {
+              "passed": { "type": "boolean" },
+              "value": { "type": "number" },
+              "threshold": { "type": "number" }
+            }
+          },
+          "peak_dimension": {
+            "type": "object",
+            "properties": {
+              "passed": { "type": "boolean" },
+              "dimension": { "type": "string" },
+              "value": { "type": "number" },
+              "threshold": { "type": "number" }
+            }
+          },
+          "assumption_evidence": {
+            "type": "object",
+            "properties": {
+              "passed": { "type": "boolean" },
+              "evidence_type": { "type": "string" },
+              "count": { "type": "integer" }
+            }
+          },
+          "problem_confirmed": {
+            "type": "object",
+            "properties": {
+              "passed": { "type": "boolean" }
+            }
+          },
+          "saturation_reached": {
+            "type": "object",
+            "properties": {
+              "passed": { "type": "boolean" },
+              "consecutive_no_new_themes": { "type": "integer" }
+            }
+          }
+        }
+      },
+      "override": { "type": "boolean | null" },
+      "override_rationale": { "type": "string | null" }
+    }
+  },
+  "saturation_reached": {
+    "type": "boolean",
+    "required": true,
+    "description": "Whether thematic saturation was detected"
+  },
+  "analyst_notes": {
+    "type": "string",
+    "required": false,
+    "maxLength": 2000,
+    "description": "Free-text observations from interviewer or AI analyst"
+  },
+  "stage": {
+    "type": "string",
+    "enum": ["draft", "final"],
+    "required": true,
+    "description": "Draft = in-progress during sprint. Final = locked after sprint completes."
+  }
+}
+```
+
+---
+
+# 7. Discovery Gate Integration
+
+DD#2 (Section 4) established three Discovery Gate checks. This document revises and expands the gate to six checks, adds mode-weighted counting, and defines override mechanics.
+
+## Revised Gate Criteria
+
+The Discovery Gate now has six checks. All six must pass for the gate to be "passed." If any fail, the gate can be overridden with rationale.
+
+| #   | Check                            | Threshold                                                                             | Source                      |
+| --- | -------------------------------- | ------------------------------------------------------------------------------------- | --------------------------- |
+| 1   | Minimum weighted interview count | >= 5.0 (weighted)                                                                     | `interview_count_weighted`  |
+| 2   | Composite pain severity          | >= 3.0                                                                                | `pain_severity.composite`   |
+| 3   | Peak dimension severity          | >= 4.0 in any dimension (OR with check #2)                                            | `pain_severity.[dimension]` |
+| 4   | Problem confirmed                | `true`                                                                                | `problem_confirmed`         |
+| 5   | Assumption evidence              | At least 1 Key Assumption updated with "direct_quote" or "observed_behavior" evidence | `assumption_updates`        |
+| 6   | Saturation reached               | 3 consecutive interviews with no new themes (OR time-box expired with minimum met)    | `saturation_reached`        |
+
+**Gate logic:** Checks 1, 4, and 5 are required. Checks 2 and 3 are OR'd — either composite >= 3.0 OR any peak dimension >= 4.0 satisfies the pain threshold. Check 6 is recommended but not blocking — the gate can pass without saturation if the minimum interview count is met.
+
+## Mode-Weighted Counting
+
+Not all interview modes produce equal evidence quality. Mode weighting ensures that an operator cannot game the gate by running 5 cheap AI interviews and calling discovery complete.
+
+| Mode         | Weight | Rationale                                                            |
+| ------------ | ------ | -------------------------------------------------------------------- |
+| AI-Moderated | 0.5x   | Consistent but lower depth, no body language, limited improvisation  |
+| Hybrid       | 0.75x  | Human depth with AI consistency, but some signal loss vs. pure human |
+| Human-Led    | 1.0x   | Full depth, the gold standard for qualitative research               |
+
+**Calculation:** `interview_count_weighted = (ai_count * 0.5) + (hybrid_count * 0.75) + (human_count * 1.0)`
+
+**Examples:**
+
+| Interview Mix      | Raw Count | Weighted Count | Meets Minimum (>= 5.0)? |
+| ------------------ | --------- | -------------- | ----------------------- |
+| 10 AI-only         | 10        | 5.0            | Yes (barely)            |
+| 5 Human-only       | 5         | 5.0            | Yes                     |
+| 7 Hybrid-only      | 7         | 5.25           | Yes                     |
+| 3 Human + 4 AI     | 7         | 5.0            | Yes                     |
+| 8 AI-only          | 8         | 4.0            | No                      |
+| 2 Human + 2 Hybrid | 4         | 3.5            | No                      |
+
+The weighting creates a natural incentive to include human-led or hybrid interviews in the mix. Pure AI discovery is possible but requires roughly twice the interview count to pass the gate.
+
+## Override Mechanics
+
+Any gate check can be overridden by the operator with a rationale. Overrides are recorded in the Discovery Summary's `gate_status` field and persist through the experiment lifecycle.
+
+**Common override scenarios:**
+
+- **Niche market with limited candidates:** Cannot reach 5 weighted interviews because the addressable population is tiny. Override with rationale: "Total addressable market is ~200 companies. 3 human interviews represent 1.5% coverage."
+- **Time pressure:** Sprint time-box expired before saturation. Override with rationale: "7 weighted interviews completed, clear pattern established, saturation not formally reached but themes are consistent."
+- **Pivot from prior experiment:** Discovery from a related experiment transfers. Override with rationale: "8 interviews from SC-2026-003 covered the same ICP. 3 new interviews confirmed the same pain for the revised hypothesis."
+
+**Override tracking:** Over time, the ratio of overridden gates to total gates — and the correlation between overrides and experiment outcomes — provides calibration data for adjusting gate thresholds.
+
+## Outcome Tracking
+
+Every experiment records its gate status. After decisions (GO/KILL/PIVOT/INVALID) are made, the system can correlate:
+
+- **Passed gate + GO:** Expected outcome. Validates the gate thresholds.
+- **Passed gate + KILL:** Gate may be too lenient, or post-discovery execution failed.
+- **Overridden gate + GO:** Override was justified. Consider loosening the gate check that was overridden.
+- **Overridden gate + KILL:** Override was not justified. Evidence that the gate check matters.
+
+This feedback loop is the calibration mechanism for gate thresholds over time (see Deep Dive #6).
+
+---
+
+# 8. Minimum Interview Counts & Saturation
+
+## Mode-Weighted Minimums by Test Category
+
+Different test categories (from DD#2's Validation Ladder) require different levels of discovery evidence. Solution Validation tests require the deepest discovery because they commit the most resources.
+
+| Test Category       | Minimum Weighted Count | Minimum Human/Hybrid Count | Rationale                                                                                                          |
+| ------------------- | ---------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Demand Signal       | 5.0                    | 2                          | Lightest commitment. Need to confirm problem exists, not deep understanding.                                       |
+| Willingness to Pay  | 8.0                    | 3                          | Price sensitivity requires nuanced conversation. AI interviews alone miss tonal cues on pricing discomfort.        |
+| Solution Validation | 10.0                   | 5                          | Highest commitment. Solution design requires deep understanding of workflows, pain points, and feature priorities. |
+
+**Rule:** The minimum human/hybrid count ensures that at least some interviews include the depth that AI-Moderated mode cannot provide. You can exceed the weighted minimum with all-AI interviews for ICP Validation breadth, but you cannot enter Solution Validation without at least 5 human or hybrid interviews.
+
+## Saturation Detection — The "3 in a Row" Rule
+
+Thematic saturation is reached when **3 consecutive interviews produce no new themes**. A "new theme" is defined as:
+
+- A problem dimension, workaround, or pain point not previously mentioned by any participant
+- A significant contradiction of an established pattern (e.g., first participant to report the problem as "not a big deal" after 8 participants called it "critical")
+- A new ICP characteristic that changes the segment definition
+
+**How it works:**
+
+1. After each interview, the AI analyst compares extracted themes against the running theme inventory.
+2. If no new themes are detected, a counter increments. If a new theme is detected, the counter resets to zero.
+3. When the counter reaches 3, saturation is flagged.
+
+**Saturation does not automatically end the sprint.** It signals that additional interviews of the same type are unlikely to produce new information. The operator may:
+
+- End the discovery sprint and finalize the Discovery Summary
+- Switch to a different protocol (e.g., from Problem Discovery to Solution Fit)
+- Expand to a different segment to test whether the problem exists beyond the initial ICP
+
+## Confidence Score Interaction
+
+The Hypothesis Card confidence score (DD#1, Section 3.5) interacts with minimum interview counts:
+
+- **Proceed:** Standard minimums apply.
+- **Uncertain:** Add 50% to the minimum weighted count (e.g., Demand Signal: 5.0 --> 7.5). The uncertainty warrants deeper investigation.
+- **Abandon:** No discovery sprint. The idea was killed at Step 1.
+
+---
+
+# 9. Assumption Type Classification from Interview Signals
+
+Interview data feeds directly into the assumption type classification that DD#2 uses for test selection. This section specifies how raw interview signals map to structured assumption types.
+
+## Signal to Assumption Type Mapping
+
+| Interview Signal                                                                  | Assumption Type    | Classification Rule                                                    | Recommended Test Category                                   |
+| --------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Problem not confirmed OR pain severity < 2.0                                      | `problem_exists`   | Fewer than 50% of participants confirm the problem                     | Back to Step 2 (more interviews with different ICP)         |
+| Problem confirmed but solution resonance < 2.5                                    | `solution_desired` | Problem is real but proposed solution does not excite                  | Demand Signal (test different solution framings)            |
+| Solution resonance >= 3.0 but WTP signal = "weak" or "none"                       | `will_pay`         | People want it but balk at paying                                      | Willingness to Pay (test pricing)                           |
+| WTP signal = "strong" or "moderate" but objections center on delivery/feasibility | `solution_works`   | People will pay but doubt you can deliver                              | Solution Validation (prove it works)                        |
+| All signals positive, no dominant risk                                            | `solution_desired` | Default to Demand Signal — validate with market data before committing | Demand Signal (validate at scale what interviews suggested) |
+
+## Evidence Quality Rubric
+
+Not all evidence is created equal. The assumption type classification should weight higher-quality evidence more heavily.
+
+| Evidence Type     | Quality Level | Weight | Description                                                                                                                                                                                   |
+| ----------------- | ------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Founder Intuition | 1 (lowest)    | 0.25x  | "I think customers have this problem" — no external validation                                                                                                                                |
+| Indirect Signal   | 2             | 0.5x   | Market research, competitor analysis, survey data — evidence exists but is not from direct conversation                                                                                       |
+| Direct Quote      | 3             | 1.0x   | Participant stated something relevant in an interview — primary source evidence                                                                                                               |
+| Observed Behavior | 4 (highest)   | 1.5x   | Participant demonstrated the behavior (showed their spreadsheet, walked through their process, showed frustration in real-time) — behavioral evidence is more reliable than stated preference |
+
+**Application:** When updating Key Assumptions in the `assumption_updates` field, the `evidence` field should note the evidence type. The assumption type classification uses the highest-quality evidence available for each assumption.
+
+## Worked Example
+
+> **Scenario:** After the B2B competitor tracking discovery sprint (21 interviews):
+>
+> **Assumption:** "Marketing managers at B2B SaaS companies (50-200 employees) will pay \$99/mo for automated competitor tracking."
+>
+> **Evidence inventory:**
+>
+> - Founder Intuition: "I think this is a real problem." (0.25x)
+> - Direct Quote: "I spend at least 5 hours a week just checking competitor websites." (1.0x) -- 14 participants confirmed
+> - Observed Behavior: P003 shared their actual tracking spreadsheet during the interview (1.5x)
+> - Direct Quote: "I'd pay \$99/mo for this." (1.0x) -- 11 participants in WTP range
+> - Direct Quote: "That's too expensive, maybe \$49." (1.0x) -- 4 participants below range
+>
+> **Classification:** The riskiest remaining assumption is `will_pay` — the problem is confirmed (strong evidence) and the solution resonates (direct quotes + observed behavior), but WTP has mixed signals (strong for majority, weak for a significant minority). Route to **Willingness to Pay** test category.
+>
+> **Updated assumption risk:** High --> Medium (evidence: 11/21 direct quotes confirming \$99/mo acceptable, 4/21 below range, observed behavior from P003 showing spreadsheet workaround confirms functional pain severity).
+
+---
+
+# 10. Technology Landscape & Build vs. Buy
+
+## AI Interview Platforms
+
+The market for AI-conducted user research is emerging rapidly. Key players as of early 2026:
+
+| Platform                  | Funding        | Core Capability                                     | Interview Mode            | Pricing Model           | Developer API                |
+| ------------------------- | -------------- | --------------------------------------------------- | ------------------------- | ----------------------- | ---------------------------- |
+| **Outset**                | \$21M Series A | AI-moderated video/text interviews                  | AI-Moderated              | Per-interview (\$15-30) | No public API                |
+| **Listen Labs**           | \$69M total    | AI research assistant for qual research             | AI-Moderated + analysis   | Enterprise subscription | No public API                |
+| **Strella**               | \$14M Seed     | AI-powered customer interviews at scale             | AI-Moderated (voice)      | Per-interview           | Limited API (beta)           |
+| **Keplar**                | Undisclosed    | Synthetic audience simulation (not real interviews) | AI-Simulated              | Per-project             | No public API                |
+| **Maze**                  | \$75M+ total   | Product research platform with AI analysis          | Human-Led + AI analysis   | Subscription            | REST API (surveys only)      |
+| **UserCall**              | Bootstrapped   | AI phone interviews                                 | AI-Moderated (phone)      | Per-minute              | No public API                |
+| **Anthropic Interviewer** | N/A (build)    | Custom Claude-based interview agent                 | AI-Moderated (text/voice) | API usage costs         | Full API access (Claude API) |
+
+## API Maturity Assessment
+
+**The critical finding: no major AI interview platform offers a production-ready developer API for programmatic interview orchestration.** Outset, Listen Labs, and Strella are GUI-first products designed for UX researchers, not for integration into automated validation pipelines. Their value proposition is the platform experience, not the API.
+
+This means SC cannot buy an off-the-shelf interview API and integrate it into the validation workflow today. The options are:
+
+1. **Use a platform's GUI manually** — the operator runs interviews through Outset/Strella's web interface, then manually exports transcripts for SC's analysis pipeline. This works for Phase 1 but does not scale.
+2. **Build a custom interview agent** — use the Claude API (or similar LLM API) to build SC's own interview agent that follows the four protocols defined in Section 4. This requires more upfront development but produces a fully integrated, automatable system.
+3. **Hybrid approach** — use a platform for AI-Moderated interviews (their strength), build custom analysis pipeline for transcript processing, signal extraction, and Discovery Summary population.
+
+## SC's Phased Approach
+
+| Phase                  | Interview Capability                                                                             | Analysis Capability                                                                          | Integration                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Phase 1 (now)**      | Human-led interviews. Manual transcript import.                                                  | AI-powered analysis: transcript --> signal extraction --> pain scoring --> Discovery Summary | Custom-built analysis pipeline using Claude API |
+| **Phase 2 (Q3 2026)**  | Add Hybrid mode: real-time AI co-pilot during human interviews                                   | Same as Phase 1, plus real-time protocol tracking                                            | Streaming transcript integration                |
+| **Phase 3 (Q4 2026+)** | Add AI-Moderated mode: custom SC interview agent OR integration with platform API (if available) | Fully automated: interview --> analysis --> Discovery Summary                                | End-to-end automated pipeline                   |
+
+## Cost Comparison
+
+| Approach                     | Cost per Interview              | Setup Cost                        | Ongoing Cost                             | Scale Ceiling  |
+| ---------------------------- | ------------------------------- | --------------------------------- | ---------------------------------------- | -------------- |
+| Manual (founder interviews)  | \$50-150 (time value)           | \$0                               | \$0                                      | 5-8 per week   |
+| Platform (Outset/Strella)    | \$15-30 (platform fee)          | \$0-500 (onboarding)              | \$200-500/mo subscription                | 30+ per week   |
+| Custom SC agent (Claude API) | \$5-15 (API compute)            | \$5,000-15,000 (development)      | \$50-200/mo (API costs at modest volume) | 100+ per week  |
+| Hybrid (human + SC analysis) | \$30-75 (reduced prep/analysis) | \$2,000-5,000 (analysis pipeline) | \$50-100/mo (API costs)                  | 10-15 per week |
+
+**Phase 1 recommendation:** Build the analysis pipeline first (the high-value, lower-cost component). This immediately helps human-led interviews by automating the analysis bottleneck identified in Section 2. Interview conducting is not the bottleneck — sourcing and analysis are.
+
+## Candidate Sourcing Platforms
+
+AI can assist with finding interview candidates even before it conducts interviews:
+
+| Platform                     | Approach                                   | Cost                      | SC Integration                                                   |
+| ---------------------------- | ------------------------------------------ | ------------------------- | ---------------------------------------------------------------- |
+| **LinkedIn Sales Navigator** | Search by title, company size, industry    | \$80-130/mo               | Manual search, export contacts                                   |
+| **Apollo.io**                | Contact database with email/phone          | \$49-99/mo                | API available for programmatic search                            |
+| **Respondent.io**            | Recruit pre-screened research participants | \$100-300 per participant | Manual recruiting, scheduled interviews                          |
+| **User Interviews**          | Similar to Respondent.io                   | \$50-200 per participant  | Manual recruiting                                                |
+| **Reddit / Communities**     | Post in relevant subreddits/communities    | Free (time cost)          | AI can draft outreach posts                                      |
+| **Warm network**             | Founder's existing contacts                | Free                      | AI can help identify relevant contacts from LinkedIn connections |
+
+**Phase 1 sourcing strategy:** AI agent generates search criteria from the Hypothesis Card's Customer Segment field, creates outreach templates, and suggests sourcing channels from the `discovery_channels` field. The human operator executes the actual outreach.
+
+---
+
+# 11. Trust & Quality — VaaS Considerations
+
+## AI Disclosure
+
+When SC operates as a Validation-as-a-Service provider, the trust equation includes three parties: SC (the operator), the VaaS client (the entrepreneur), and the interview participant.
+
+**Disclosure requirements:**
+
+- **To participants:** Always disclose AI involvement. For AI-Moderated interviews: "This interview is conducted by an AI research assistant." For Hybrid mode: "This interview includes AI-powered analysis." No deception.
+- **To VaaS clients:** Always disclose the interview mode mix. Clients must understand which interviews were AI-moderated vs. human-led, and how mode weighting affects the evidence count.
+- **In the Discovery Summary:** The `mode_breakdown` field provides transparent accounting of the interview mix.
+
+## Quality Comparison Statistics
+
+Based on published research and platform benchmarks:
+
+| Metric                                | AI-Moderated | Human-Led | Hybrid        |
+| ------------------------------------- | ------------ | --------- | ------------- |
+| Protocol adherence                    | 100%         | 60-80%    | 85-95%        |
+| Average interview duration            | 15-25 min    | 30-60 min | 25-45 min     |
+| Participant completion rate           | 85-90%       | 70-80%    | 80-85%        |
+| Emotional depth score (self-reported) | 3.2/5        | 4.3/5     | 3.9/5         |
+| Disclosure on sensitive topics        | Higher       | Lower     | Moderate      |
+| Interviewer bias introduced           | None         | Moderate  | Low           |
+| Unexpected theme discovery rate       | Low          | High      | Moderate-High |
+
+## Where AI Excels vs. Humans
+
+**AI advantages:**
+
+- **Consistency:** Every interview follows the protocol identically. No fatigue, no mood effects, no rushing through the last interview of the day.
+- **Scale:** Can run 10-30+ interviews in the time a human runs 3-5.
+- **Sensitive topics:** Participants disclose more about embarrassing problems, failures, or socially undesirable behaviors when talking to AI.
+- **Analysis speed:** Transcript processing and signal extraction happen in real-time, not hours later.
+- **Availability:** 24/7 across time zones. No scheduling coordination needed for asynchronous modes.
+
+**Human advantages:**
+
+- **Empathy and rapport:** Humans build trust through micro-expressions, vocal tone, and genuine curiosity that AI cannot replicate.
+- **Improvisation:** A skilled interviewer pursues unexpected threads that may reveal insights the protocol did not anticipate.
+- **Body language:** Video interviews give humans access to non-verbal cues (posture shifts, facial expressions, hesitation) that reveal unspoken feelings.
+- **Relationship building:** Interviewees can become early adopters, beta testers, or champions. AI interviews do not build personal relationships.
+- **Judgment under ambiguity:** When a response is contradictory or confusing, humans can probe with nuance that AI may miss.
+
+## VaaS Trust Model
+
+For external VaaS clients, trust in the discovery process depends on:
+
+1. **Transparency:** Full disclosure of methods, mode mix, and limitations.
+2. **Calibration data:** Over time, SC builds a track record of discovery-to-outcome correlations. "Discovery sprints using our methodology have a 72% GO accuracy rate" is compelling.
+3. **Human-in-the-loop guarantee:** Phase 1 ensures every discovery sprint includes human-led interviews. No VaaS client receives a Discovery Summary based purely on AI interviews.
+4. **Audit trail:** Every quote, score, and classification is traceable to a specific interview and timestamp.
+
+## Dog-Fooding Requirement
+
+> **SC must use its own Discovery Engine for every Ventracrane venture before offering it as VaaS.** This is non-negotiable. The methodology must be proven internally before it is sold externally. Dog-fooding provides calibration data, reveals edge cases, and builds credibility.
+
+**Minimum dog-fooding threshold:** 5 completed discovery sprints across different ventures before VaaS launch. Each sprint must include all three interview modes (AI, Hybrid, Human) to calibrate the mode weighting and quality comparison data.
+
+## Acquiescence Bias Mitigation
+
+Acquiescence bias — the tendency for participants to agree with the interviewer's framing — is the most dangerous bias in customer discovery. It produces false positives that waste campaign budget.
+
+**Mitigation strategies:**
+
+- **Ask about behavior, not opinion.** "Walk me through the last time you dealt with [problem]" vs. "Do you have [problem]?"
+- **Use disconfirming questions.** "What's working well about your current approach?" (not just "What's broken?")
+- **Avoid leading language.** "Tell me about your experience with [domain]" vs. "How frustrated are you with [problem]?"
+- **Triangulate.** Cross-reference stated pain with behavioral evidence. If someone says the problem is "critical" but has never searched for a solution, the stated severity may be inflated.
+- **AI advantage:** AI interviewers do not unconsciously nod, lean forward, or express excitement when hearing confirming evidence. Their neutral delivery reduces acquiescence bias compared to a passionate founder interviewing about their own idea.
+
+---
+
+# 12. AI Agent Workflow for Discovery
+
+The Discovery Engine's AI agent orchestrates the entire discovery process in 6 steps. In Phase 1, some steps require human execution; the agent handles preparation and analysis.
+
+## Step 1: Parse Hypothesis Card
+
+**Input:** Hypothesis Card (Tier 1 or Tier 2)
+
+**Agent actions:**
+
+- Extract the Customer Segment to define the interview target profile
+- Extract the Problem Statement to identify the three pain dimensions (functional, emotional, opportunity cost)
+- Extract Stakes (Failure/Success) to calibrate expected severity signals
+- Extract Solution Hypothesis and Why Now for Solution Fit and WTP protocol preparation
+- Identify Key Assumptions and their risk levels to prioritize protocol selection
+
+**Output:** Interview target profile + protocol priority list
+
+**Phase 1 automation:** Fully automated. The agent generates all outputs from the Hypothesis Card without human intervention.
+
+## Step 2: Generate Interview Protocol
+
+**Input:** Interview target profile + protocol priority list
+
+**Agent actions:**
+
+- Select the appropriate protocol(s) based on current discovery state (see Section 4 Protocol Selection Logic)
+- Customize opening questions using the Hypothesis Card's specific language (e.g., replace "[problem]" with the actual problem statement)
+- Generate follow-up probing questions tailored to the three pain dimensions
+- Set signal extraction rules for post-interview analysis
+- Produce a printable interview guide for Human-Led and Hybrid modes
+
+**Output:** Customized interview protocol document
+
+**Phase 1 automation:** Fully automated. The agent generates a complete protocol that the human interviewer can use directly.
+
+## Step 3: Assist Candidate Sourcing
+
+**Input:** Interview target profile + Customer Segment from Hypothesis Card
+
+**Agent actions:**
+
+- Generate search queries for LinkedIn Sales Navigator, Apollo.io, and community platforms based on the Customer Segment description
+- Draft personalized outreach messages (email, LinkedIn message, community post)
+- Define screening criteria: must-have characteristics (matches ICP) and disqualifiers
+- Suggest sourcing channels based on the Customer Segment's likely online presence
+- Track outreach status and response rates
+
+**Output:** Sourcing plan with search queries, outreach templates, and screening criteria
+
+**Phase 1 automation:** Partially automated. The agent generates the plan; the human operator executes outreach and scheduling.
+
+## Step 4: Conduct Interviews
+
+**Input:** Customized interview protocol + scheduled participants
+
+**Agent actions (varies by mode):**
+
+- **AI-Moderated:** Agent conducts the interview independently, following the protocol, generating follow-up probes, recording the session, and extracting signals in real-time.
+- **Hybrid:** Agent operates as co-pilot during the human-led interview — monitoring protocol coverage, suggesting follow-up questions via a side channel, and flagging when key topics have not been explored.
+- **Human-Led:** Agent is not active during the interview. The human interviewer uses the protocol document from Step 2.
+
+**Output:** Interview transcript (text) + real-time signal extraction (AI-Moderated and Hybrid modes)
+
+**Phase 1 automation:** Human-Led only. The agent provides the protocol document; the human conducts and records the interview. Transcripts are imported manually (recording --> transcription service --> text import).
+
+## Step 5: Extract & Score
+
+**Input:** Interview transcript
+
+**Agent actions:**
+
+- Extract verbatim quotes and tag each with the relevant pain dimension and protocol
+- Score pain severity using the 3-step method (Section 5): extract quotes --> score per rubric --> average within dimensions
+- Identify new themes and update the theme inventory for saturation tracking
+- Classify signals against the assumption type mapping (Section 9)
+- Update the running Discovery Summary (draft stage)
+- Flag red patterns (acquiescence bias indicators, contradictions, insufficient data)
+
+**Output:** Per-interview signal extraction report + updated Discovery Summary (draft)
+
+**Phase 1 automation:** Fully automated. The agent processes transcripts through the Claude API and produces structured signal extraction. Human review is recommended but not required.
+
+## Step 6: Synthesize Discovery Summary
+
+**Input:** All per-interview signal extraction reports
+
+**Agent actions:**
+
+- Aggregate pain severity scores across all interviews (weighted by evidence quality)
+- Calculate composite and peak dimension scores
+- Check polarization flag (std dev > 1.5)
+- Run saturation detection (3-in-a-row rule)
+- Evaluate all 6 gate checks and produce the gate status
+- Select top 10 quotes (prioritize Observed Behavior > Direct Quote > Indirect Signal)
+- Generate assumption updates with evidence citations
+- Write analyst notes summarizing key findings and recommendations
+- Lock the Discovery Summary to "final" stage
+
+**Output:** Final Discovery Summary artifact
+
+**Phase 1 automation:** Fully automated. The agent synthesizes all interview data into the structured Discovery Summary. The operator reviews and can override gate status or adjust analyst notes before locking.
+
+## Integration with Event Log
+
+All discovery activities are logged to the `event_log` table for audit and analysis:
+
+| Event Type                    | Trigger                | Event Data                                                                                        |
+| ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------- |
+| `discovery_sprint_started`    | Sprint initiated       | `{ mode: string, target_count: number, protocols: string[] }`                                     |
+| `interview_scheduled`         | Participant confirmed  | `{ participant_id: string, mode: string, scheduled_at: number }`                                  |
+| `interview_completed`         | Interview finished     | `{ participant_id: string, mode: string, duration_minutes: number, protocols_covered: string[] }` |
+| `interview_analyzed`          | AI extraction complete | `{ participant_id: string, new_themes: number, pain_scores: object }`                             |
+| `saturation_detected`         | 3-in-a-row triggered   | `{ consecutive_count: 3, total_interviews: number }`                                              |
+| `discovery_gate_evaluated`    | Gate check run         | `{ checks: object, passed: boolean, override: boolean }`                                          |
+| `discovery_summary_finalized` | Summary locked         | `{ interview_count: number, weighted_count: number, gate_passed: boolean }`                       |
+
+## Quality Criteria for Discovery Sprints
+
+A discovery sprint meets quality criteria when:
+
+1. Minimum weighted interview count is met for the target test category (Section 8)
+2. At least 2 protocols were used (Problem Discovery is always one)
+3. Pain severity scores have sufficient data (>= 2 quotes per dimension for at least 2 dimensions)
+4. No more than 50% of interviews show acquiescence bias red flags
+5. The Discovery Summary has been reviewed by a human (not just AI-generated and auto-locked)
+6. All interviews are logged to `event_log` with complete metadata
+
+---
+
+# 13. Answering the Six Strategy Session Questions
+
+The strategy session (Deep Dive #3 section) identified six questions. Here are the answers:
+
+**1. Can AI agents help source and screen interview candidates?**
+
+Yes. The AI agent generates search queries, outreach templates, and screening criteria from the Hypothesis Card's Customer Segment field (Section 12, Step 3). In Phase 1, the agent produces the plan and the human executes. In later phases, API integrations with Apollo.io or LinkedIn allow programmatic candidate sourcing. Screening criteria are derived from the ICP Validation protocol's disqualification patterns.
+
+**2. Can AI conduct preliminary discovery interviews?**
+
+Yes, with caveats. AI-Moderated interviews (Section 3) can conduct full protocol-adherent interviews independently. They excel at ICP Validation and broad pattern detection. However, they show approximately 26% lower emotional depth scores and are weaker at pursuing unexpected threads. SC's Phase 1 starts with human-led interviews and AI-powered analysis; full AI-Moderated interviews are Phase 3.
+
+**3. What's the trade-off between AI interviews and human intuition for catching real pain points?**
+
+The tradeoff is consistent breadth (AI) vs. empathetic depth (human). AI interviews follow protocols perfectly, run at 5-10x the throughput, and reduce acquiescence and social desirability bias. Human interviews catch non-verbal cues, pursue unexpected threads, and build relationships with potential early adopters. The Hybrid mode (Section 3) captures both. Mode weighting (Section 7) ensures the evidence quality difference is reflected in the gate calculations.
+
+**4. If offered as VaaS, do customers trust AI-conducted interviews?**
+
+Trust depends on transparency and track record (Section 11). Upfront disclosure of AI involvement does not significantly reduce participation rates and may increase disclosure on sensitive topics. VaaS trust requires: (a) full mode breakdown transparency, (b) human-in-the-loop guarantee for Phase 1, (c) calibration data showing discovery-to-outcome accuracy, and (d) the dog-fooding requirement — SC uses its own methodology on Ventracrane ventures before selling it externally.
+
+**5. What technology exists today to enable this?**
+
+The AI interview platform market (Outset, Listen Labs, Strella, UserCall) is funded but API-immature (Section 10). No platform offers a production developer API for programmatic interview orchestration. SC's phased approach builds the analysis pipeline first (custom, using Claude API), adds Hybrid co-pilot capability second, and either builds a custom interview agent or integrates with a platform API when available for Phase 3.
+
+**6. How does the Discovery Summary artifact get populated from interview data?**
+
+Through the 6-step AI agent workflow (Section 12): Parse Hypothesis Card --> Generate Protocol --> Assist Sourcing --> Conduct Interviews --> Extract & Score --> Synthesize Discovery Summary. Each interview produces a signal extraction report. The agent aggregates these reports into the Discovery Summary fields using the pain severity rubric (Section 5), assumption type classification (Section 9), and saturation detection (Section 8). The schema is specified in Section 6.5.
+
+---
+
+# 13.5. Answering DD#2's Open Questions
+
+DD#2 (Section 10) identified six open questions for this deep dive. Here are the answers, numbered 7-11 to continue the sequence from Section 13:
+
+**7. How do AI-scaled discovery interviews feed into the discovery gate?**
+
+Through mode-weighted counting (Section 7). Each interview mode has a weight (AI=0.5x, Hybrid=0.75x, Human=1.0x) that reflects evidence quality. The weighted count must reach >= 5.0 for the minimum interview check. Additionally, pain severity scoring (Section 5) from AI-analyzed transcripts feeds gate check #2 (composite >= 3.0) and #3 (peak dimension >= 4.0). The gate now has 6 checks instead of the original 3.
+
+**8. What interview protocols map to each Hypothesis Card field?**
+
+Four protocols (Section 4): Problem Discovery maps to Problem Statement, Stakes, and Customer Segment. Solution Fit maps to Solution Hypothesis and Why Now. Willingness to Pay maps to Solution Hypothesis and Market Sizing. ICP Validation maps to Customer Segment. Each protocol has specific opening questions, probing follow-ups, closing questions, and signal extraction rules that populate corresponding Discovery Summary fields.
+
+**9. How is the Discovery Summary artifact populated from interview data?**
+
+Via the 6-step AI agent workflow (Section 12). Per-interview signal extraction reports are aggregated: pain severity scores are averaged across participants per dimension, quotes are ranked and the top 10 selected, assumption risk levels are updated based on interview evidence, and the gate status is evaluated against the 6 checks. The schema (Section 6.5) specifies all fields and their data types.
+
+**10. What minimum interview count is needed before each test category?**
+
+Mode-weighted minimums (Section 8): Demand Signal requires 5.0 weighted with >= 2 human/hybrid. Willingness to Pay requires 8.0 weighted with >= 3 human/hybrid. Solution Validation requires 10.0 weighted with >= 5 human/hybrid. These minimums increase by 50% when the Hypothesis Card confidence score is "Uncertain."
+
+**11. How does pain severity scoring work in AI-conducted interviews?**
+
+The AI uses a 3-step method (Section 5): (1) extract verbatim quotes from the transcript and tag each with a pain dimension, (2) score each quote against the rubric anchors (1-5 per dimension), (3) average per-quote scores within each dimension, weighting longer/more detailed quotes higher. If fewer than 2 quotes exist for a dimension, it is marked "insufficient data." The composite score is the average of the three dimensions. Polarization is flagged when standard deviation exceeds 1.5.
+
+---
+
+# 14. Recommendations for Functional Spec v2.0
+
+1. **Add `discovery_summary` JSONB column** to the experiments table (see Schema Sketch in Section 6.5). This stores the complete Discovery Summary artifact as structured JSON, parallel to the `hypothesis_card` and `test_blueprint` columns recommended by DD#1 and DD#2.
+
+2. **Create an `interviews` table** to store individual interview records with per-interview metadata:
+
+   ```sql
+   CREATE TABLE IF NOT EXISTS interviews (
+     id INTEGER PRIMARY KEY AUTOINCREMENT,
+     experiment_id TEXT NOT NULL REFERENCES experiments(id),
+     participant_id TEXT NOT NULL,
+     mode TEXT NOT NULL CHECK(mode IN ('ai', 'hybrid', 'human')),
+     protocols_covered TEXT NOT NULL,     -- JSON array of protocol names
+     duration_minutes INTEGER,
+     pain_scores TEXT,                    -- JSON: { functional: N, emotional: N, opportunity: N }
+     signal_extraction TEXT,              -- JSON: full extraction report
+     transcript_ref TEXT,                 -- R2 reference to transcript file
+     new_themes_detected INTEGER DEFAULT 0,
+     created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+   );
+   ```
+
+3. **Add API endpoints** for discovery workflow:
+   - `POST /experiments/:id/discovery/start` — Initialize a discovery sprint
+   - `POST /experiments/:id/interviews` — Record a completed interview
+   - `GET /experiments/:id/discovery/summary` — Retrieve the current Discovery Summary
+   - `POST /experiments/:id/discovery/finalize` — Lock the Discovery Summary to "final"
+   - `GET /experiments/:id/discovery/gate` — Evaluate and return gate status
+
+4. **Implement mode-weighted counting** in the gate evaluation logic. The weighted count calculation (`ai * 0.5 + hybrid * 0.75 + human * 1.0`) should be computed server-side when the gate is evaluated, not stored as a static value.
+
+5. **Add event types to `event_log`** for discovery activities (Section 12): `discovery_sprint_started`, `interview_scheduled`, `interview_completed`, `interview_analyzed`, `saturation_detected`, `discovery_gate_evaluated`, `discovery_summary_finalized`.
+
+6. **Extend the `experiments.status` CHECK constraint** to include a `discovery` status between `preflight` and `build`: `('draft','preflight','discovery','build','launch','run','decide','archive')`. This explicitly represents the discovery sprint as a workflow stage.
+
+7. **Store interview transcripts in R2** (sc-assets bucket) with a reference in the interviews table. Transcripts contain PII and should follow the 90-day retention policy established in the strategy session.
+
+8. **Plan D1 migration** for: `discovery_summary` JSONB column on experiments, `interviews` table creation, status CHECK constraint update, new event types.
+
+---
+
+# 15. Open Questions for Deep Dive #4
+
+1. How does the Discovery Summary's `feature_priorities` field inform the Campaign Package's messaging hierarchy? Which discovered features become headlines vs. supporting copy?
+
+2. How do `top_quotes` from the Discovery Summary feed into ad copy generation? Can real customer language be adapted directly into campaign creative, and what are the ethical/consent considerations?
+
+3. How does the `discovery_channels` field inform campaign channel selection and targeting parameters? Is there a direct mapping from "where we found interviewees" to "where we run ads"?
+
+4. When the Discovery Summary shows polarized pain (one dominant dimension), how should the Campaign Package's creative strategy reflect this? Should all variants emphasize the peak dimension, or should A/B testing explore multiple dimensions?
+
+5. How does the `wtp_signal` and `price_range_observed` from discovery inform the pricing presentation in campaign creative and landing pages for `priced_waitlist` and `presale` archetypes?

--- a/docs/methodology/04-deep-dive-campaign-factory.md
+++ b/docs/methodology/04-deep-dive-campaign-factory.md
@@ -1,0 +1,1310 @@
+# Deep Dive #4: AI-Generated Marketing Content at Scale — The Campaign Factory
+
+> **Source:** New document (DD#4)
+> **Document Type:** Deep Dive Working Document
+> **Series:** SC Validation Methodology
+> **Date:** March 2, 2026
+> **Status:** Complete — pending functional spec integration
+> **Parent:** SC Validation Methodology — Strategy Session (March 2026)
+> **Prior:** Deep Dive #3: AI-Scaled Customer Discovery — The Discovery Engine
+
+---
+
+## 1. Purpose & Scope
+
+This deep dive defines the **Campaign Package** — the Step 4 output artifact in the SC validation workflow — and establishes SC's framework for generating marketing content at scale using AI while maintaining brand consistency and ethical compliance. The framework is branded **The Campaign Factory**.
+
+**What this document covers:**
+
+- The Campaign Factory — SC's branded content generation framework with a 7-step async pipeline
+- The Messaging Matrix mapping Venture Narrative elements to ad copy
+- Two-tier generation model: Tier 1 (Hypothesis Card only) vs. Tier 2 (+ Discovery Summary)
+- Per-archetype content specifications for all 7 test archetypes
+- AI image generation tool assessment and recommended API stack
+- BrandProfile specification with multi-venture VaaS support and versioning
+- Ethical framework addressing FTC, copyright, platform policies, and truthfulness
+- The Campaign Package artifact specification and schema sketch
+- Quality gates with structured consistency checklists
+- Budget allocation model for $300–500 test ranges
+- Channel selection logic integrating with `metrics_daily.source`
+
+**Relationship to DD#1 (The Venture Narrative):**
+
+The Hypothesis Card is the primary input to content generation. DD#1's five narrative elements (Hero, Struggle, Stakes, Breakthrough, Moment) map directly to specific ad copy elements through the Messaging Matrix (Section 4). DD#1 Section 5 explicitly noted that CopyPack is generated FROM the Hypothesis Card — Stakes feed urgency_hook, Solution Hypothesis feeds value_props, Customer Segment feeds targeting. This document operationalizes that mapping.
+
+**Relationship to DD#2 (The Validation Ladder):**
+
+The Test Blueprint determines which archetype the campaign serves, and each archetype has different content requirements. Demand Signal tests need short-form ads and simple landing pages. Willingness to Pay tests need long-form copy with pricing. Solution Validation tests need relationship-building content. Section 7 defines per-archetype content specifications.
+
+**Relationship to DD#3 (The Discovery Engine):**
+
+The Discovery Summary enriches campaign content — when available. DD#3's pain severity scoring calibrates emotional tone, top quotes become social proof, ICP refinements sharpen targeting, and signal patterns inform messaging themes. Section 5 defines the two-tier generation model that handles both the presence and absence of discovery data.
+
+**The 11 questions this document answers:**
+
+From the Strategy Session (6):
+
+1. What AI tools can produce campaign-quality creative assets today?
+2. How do we maintain brand consistency across AI-generated content?
+3. What's the quality bar for social media campaign creative?
+4. Can we build a content pipeline that generates complete campaign packages from a hypothesis?
+5. What are the ethical considerations around AI-generated marketing content?
+6. How does the story framework output inform messaging and creative direction?
+
+From DD#3 (5):
+
+7. How does the Venture Narrative (DD#1) inform campaign messaging and creative direction?
+8. Which interview insights feed directly into ad copy generation?
+9. How are customer quotes from discovery interviews used as social proof on landing pages?
+10. What content formats work best for each test category?
+11. How does the Discovery Summary's pain severity scoring inform emotional tone in campaign creative?
+
+---
+
+## 2. The Content Bottleneck — Why AI is Necessary
+
+### The Solopreneur Creative Production Problem
+
+Producing marketing content is the second major bottleneck in the validation workflow (after customer discovery, addressed in DD#3). A solo founder running a validation test faces creative production costs that dwarf the test budget itself:
+
+- **Traditional agency creative:** $5,000–50,000 per campaign (strategy, copywriting, design, revisions)
+- **Freelance creative:** $500–2,000 for basic ad set + landing page copy
+- **DIY with design tools:** 10–20 hours of founder time per campaign (Canva, Figma, manual copywriting)
+
+For a $300–500 validation test, even freelance creative costs exceed the ad spend. This creates a perverse incentive: founders either skip professional creative (hobbling the test) or overspend on production (defeating the point of cheap validation).
+
+### The VaaS Scaling Dimension
+
+For SC as a Validation-as-a-Service platform, the bottleneck is existential. Manual content production per venture doesn't scale from one to many. If each campaign requires 5–10 hours of human creative work, SC's unit economics collapse at portfolio scale.
+
+### The AI Content Generation Opportunity
+
+> **The critical insight:** Unlike DD#3's interview space (where no platform offers developer-grade APIs for custom integration), the AI content generation space HAS mature, production-ready APIs. Text generation (Claude, GPT-4o), image generation (GPT Image 1, Ideogram, Stability AI), and soon video generation (Runway, Sora) are all accessible programmatically. This means SC can build a fully automated content pipeline from Day 1.
+
+### AI Content Generation Cost Model
+
+At current API pricing, generating a complete campaign package costs approximately $1–4:
+
+| Content Type                                     | Volume per Campaign | Per-Unit Cost    | Total          |
+| ------------------------------------------------ | ------------------- | ---------------- | -------------- |
+| Ad copy variants (headlines, descriptions, CTAs) | 50 variants         | $0.01–0.05 each  | $0.50–2.50     |
+| Static images (ads, hero images, social)         | 30 images           | $0.005–0.07 each | $0.70–2.00     |
+| Landing page copy                                | 1 set               | $0.10–0.30       | $0.10–0.30     |
+| **Total per campaign**                           |                     |                  | **$1.30–4.80** |
+
+Compare this to the $300–500 test budget: content generation is **less than 1%** of total spend. The economics are transformative — creative production is no longer a meaningful cost center.
+
+### The Quality-Speed Tradeoff
+
+Validation content has a specific quality bar: **"good enough that the creative itself is not the reason people don't convert."** This is deliberately lower than agency-grade creative. The goal is to test demand, not win design awards.
+
+- **Below the bar:** Obvious AI artifacts, mismatched messaging, broken layouts, unprofessional appearance that signals "scam" or "hobby project"
+- **At the bar:** Professional, clear, credible — the kind of content a competent marketing team would produce. Not award-winning, but not embarrassing.
+- **Above the bar (unnecessary):** Award-winning creative, custom photography, motion graphics — these are post-validation investments
+
+---
+
+## 3. The Campaign Factory — SC's Content Framework
+
+The **Campaign Factory** is SC's branded approach to marketing content generation — the fourth element of the SC validation methodology alongside The Venture Narrative (DD#1), The Validation Ladder (DD#2), and The Discovery Engine (DD#3).
+
+The naming progression conveys the methodology's arc: **Narrative** (story) → **Ladder** (testing) → **Engine** (discovery) → **Factory** (production).
+
+### Pipeline Architecture
+
+The Campaign Factory takes structured inputs (Hypothesis Card, Discovery Summary, Test Blueprint, BrandProfile) and produces a complete Campaign Package through a 7-step async pipeline:
+
+> **The Campaign Factory Pipeline**
+>
+> **Step 1:** Context Assembly — gather all input artifacts
+> **Step 2:** Copy Generation — Claude API produces all text content
+> **Step 3:** Creative Brief Generation — structured spec for visual assets
+> **Step 4:** Asset Generation — image APIs produce visual content
+> **Step 5:** Campaign Assembly — combine into CampaignPackage with channel variants
+> **Step 6:** Structured Consistency Check — automated quality validation
+> **Step 7:** Human Review Gate — operator approval before launch
+
+### Technology Stack
+
+| Layer            | Primary             | Secondary                                    | Purpose                                                            |
+| ---------------- | ------------------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| Text Generation  | Claude API          | OpenAI GPT-4o                                | All ad copy, landing page copy, email sequences                    |
+| Image Generation | OpenAI GPT Image 1  | Ideogram (text-heavy), Stability AI (volume) | Ad images, hero images, social media graphics                      |
+| Video Generation | Deferred to Phase 2 | Runway Gen-4, Synthesia                      | Video ads, explainers ($0.10–0.50/sec — too expensive for Phase 1) |
+| Optimization     | Deferred to Phase 2 | Anyword API, AdCreative.ai                   | Performance prediction, variant scoring                            |
+
+**No third-party marketing AI platforms** (Jasper, Writer, Copy.ai, etc.). They add cost ($125/mo+ minimum), vendor lock-in, and API dependencies for capabilities Claude handles natively at a fraction of the cost.
+
+### Phase 1 vs. Phase 2 Scope
+
+> **Phase 1 (scope of this deep dive):**
+> Text generation (Claude API) + static image generation (GPT Image 1 / Ideogram / Stability AI). Complete campaign packages for all 7 archetypes. Async pipeline via Cloudflare Queue. Human review gate before launch.
+>
+> **Phase 2 (deferred):**
+> Video generation (Runway Gen-4, Synthesia for avatar-based content). Performance prediction (Anyword API — 82% accuracy on predictive scoring). A/B variant auto-optimization. At $0.10–0.50 per second of video, a 30-second ad costs $3–15 per variant — this doesn't fit the $300–500 test budget.
+
+### Relationship to Existing CopyPack and CreativeBrief
+
+The existing codebase has `copy_pack` TEXT (JSON) and `creative_brief` TEXT (JSON) columns on the experiments table. The Campaign Package does **not** replace these — it wraps and extends them.
+
+> ⚠️ **Additive, not replacement.** When a CampaignPackage is generated, it populates all three columns:
+>
+> - `campaign_package` gets the full artifact (10–20KB estimated)
+> - `copy_pack` gets a backward-compatible subset extracted from it
+> - `creative_brief` gets a backward-compatible subset extracted from it
+>
+> The existing landing page template at `/e/[slug].astro` continues to work without modification — it reads from `copy_pack`, which is still populated.
+>
+> **Write invariant:** When `campaign_package` is present, `copy_pack` and `creative_brief` become read-only projections. The PATCH `/experiments/:id` endpoint must reject direct `copy_pack`/`creative_brief` updates when `campaign_package` is non-null. Edits go through the CampaignPackage, which re-extracts the projections. This prevents data drift between the three columns.
+
+---
+
+## 4. Messaging Architecture — The Messaging Matrix
+
+The Messaging Matrix is the bridge between DD#1's Venture Narrative and the Campaign Package's ad copy. It maps each of the five narrative elements to specific content outputs.
+
+### The Five-Element Mapping
+
+| Narrative Element    | Hypothesis Card Fields                               | CampaignPackage Target                                          |
+| -------------------- | ---------------------------------------------------- | --------------------------------------------------------------- |
+| **The Hero**         | Customer Segment                                     | Targeting spec, audience description, platform selection        |
+| **The Struggle**     | Problem Statement (functional/emotional/opportunity) | Pain-point headlines, problem-aware ad copy                     |
+| **The Stakes**       | Stakes: Failure, Stakes: Success                     | urgency_hook, fear-of-missing-out elements, transformation copy |
+| **The Breakthrough** | Solution Hypothesis                                  | value_props, headline, subheadline, benefit messaging           |
+| **The Moment**       | Why Now                                              | CTA framing, timeliness hooks, trend references                 |
+
+### Full Messaging Matrix: Narrative Elements × Archetypes
+
+Each archetype emphasizes different narrative elements. The matrix shows which elements are primary, secondary, or unused for each archetype:
+
+| Archetype         | Hero              | Struggle                        | Stakes                         | Breakthrough                        | Moment                        |
+| ----------------- | ----------------- | ------------------------------- | ------------------------------ | ----------------------------------- | ----------------------------- |
+| `fake_door`       | Targeting only    | **Primary** — headline          | Secondary — CTA urgency        | Implied only                        | Optional                      |
+| `waitlist`        | Targeting + copy  | **Primary** — problem narrative | **Primary** — urgency hook     | Secondary — solution tease          | Secondary                     |
+| `content_magnet`  | Targeting + copy  | **Primary** — problem framing   | Secondary                      | Embedded in content                 | Optional                      |
+| `priced_waitlist` | Targeting + copy  | **Primary** — pain point        | **Primary** — cost of inaction | **Primary** — value justifies price | **Primary** — why act now     |
+| `presale`         | Targeting + copy  | Secondary — assumed known       | **Primary** — transformation   | **Primary** — full product pitch    | **Primary** — scarcity/timing |
+| `concierge`       | Targeting + trust | **Primary** — empathy           | Secondary                      | **Primary** — service description   | Secondary                     |
+| `service_pilot`   | Targeting + trust | Secondary                       | Secondary                      | **Primary** — product capabilities  | **Primary** — early access    |
+
+### Worked Example: Hypothesis Card → Ad Copy
+
+> 💡 **Hypothesis Card (Tier 1) — Accessibility Auditor Venture:**
+>
+> - **Customer Segment (Hero):** Marketing managers at mid-size e-commerce companies (100–500 employees)
+> - **Problem Statement (Struggle):** Functional: manual accessibility audits take 40+ hours per site. Emotional: fear of ADA lawsuits. Opportunity: inaccessible sites lose 15–20% of potential customers.
+> - **Stakes: Failure:** ADA lawsuit (average settlement $25K), customer loss, brand damage
+> - **Stakes: Success:** Full compliance, expanded customer base, legal protection
+> - **Solution Hypothesis (Breakthrough):** AI-powered continuous accessibility monitoring with one-click remediation
+> - **Why Now (Moment):** DOJ issued final ADA web accessibility rules in 2025, enforcement ramping up
+>
+> **Generated Ad Copy (waitlist archetype):**
+>
+> - **Headline** (from Struggle): "Your Website Is Losing 20% of Customers — and Risking a Lawsuit"
+> - **Subheadline** (from Breakthrough): "AI-powered accessibility monitoring catches issues before regulators do"
+> - **Urgency Hook** (from Stakes): "ADA enforcement is ramping up. Average settlement: $25K."
+> - **CTA** (from Moment): "Get compliant before the new rules hit — join the waitlist"
+> - **Targeting** (from Hero): Marketing managers, e-commerce, 100–500 employees, Meta + Google
+
+This answers **Questions 6 and 7** — how the story framework and Venture Narrative inform messaging and creative direction.
+
+---
+
+## 5. Discovery-to-Copy Translation — Two-Tier Generation Model
+
+Early-stage ventures often run their first campaign (e.g., a `waitlist` Demand Signal test) before or in parallel with discovery interviews. The pipeline must produce usable output either way.
+
+### Tier 1 Generation (Hypothesis Card Only — Always Available)
+
+The Hypothesis Card is always present (it's the Step 1 output). When no Discovery Summary exists:
+
+- `social_proof` section is **omitted** (not fabricated)
+- `pain_severity` defaults to **3** (empathetic middle ground)
+- `pain_dimensions` are **derived from Problem Statement** on the Hypothesis Card (which articulates functional/emotional/opportunity cost per DD#1)
+- `icp_refinements` uses `customer_segment` verbatim
+- `wtp_signal` defaults to **"free/low-commitment"** CTA language (conservative)
+- `signal_patterns` is empty — no messaging themes from interviews
+
+### Tier 2 Generation (Hypothesis Card + Discovery Summary — Richer Output)
+
+When Discovery Summary is available, all fields feed directly:
+
+| Discovery Summary Field            | CampaignPackage Target                                                |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| `top_quotes` (3–5 verbatim)        | Social proof quotes, testimonial ad variants                          |
+| `pain_dimensions.functional`       | Rational ad copy — feature-focused, time/money savings                |
+| `pain_dimensions.emotional`        | Emotional ad copy — frustration hooks, anxiety resolution             |
+| `pain_dimensions.opportunity_cost` | Urgency hooks — "what you're missing" messaging                       |
+| `pain_severity` (composite)        | Emotional intensity dial: 1–2 rational, 3–4 empathetic, 5 urgent/fear |
+| `icp_refinements`                  | Targeting spec adjustments, audience narrowing                        |
+| `signal_patterns`                  | Messaging theme selection, keyword targeting                          |
+| `wtp_signal`                       | Price anchoring language, CTA specificity (free vs. paid)             |
+
+### Pain Severity → Emotional Register Mapping
+
+- **Score 1–2:** Rational tone. Feature benefits, time savings, efficiency. "Save 10 hours a week on manual audits."
+- **Score 3–4:** Empathetic tone. "We know this is frustrating" + solution positioning. "You shouldn't have to spend your weekends on spreadsheets."
+- **Score 5:** Urgent/fear tone. "You can't afford to keep doing this" + immediate CTA. "Every day you wait costs you $X."
+
+### Interview Quotes as Social Proof
+
+Customer quotes from `discovery_summary.top_quotes` are used as social proof on landing pages and in ad variants. Rules:
+
+- **Verbatim only** — no paraphrasing, no synthesis, no AI-generated quotes
+- **Anonymized attribution** — "Marketing Manager, B2B SaaS (50–200 employees)" not "Jane Smith, Acme Corp"
+- **Pain dimension tagged** — each quote is tagged with which pain dimension it primarily illustrates (functional, emotional, opportunity cost) so the pipeline can place it in the right context
+- **Consent-tracked** — the Discovery Summary records whether interview participants consented to quote usage
+
+### Worked Example: Tier 1 vs. Tier 2 CampaignPackage
+
+> 💡 **Venture: AI-Powered Competitor Intelligence for B2B Marketers**
+>
+> **Tier 1 (Hypothesis Card only):**
+>
+> - Headline: "Stop Guessing What Your Competitors Are Doing"
+> - Subheadline: "Automated competitor tracking for B2B marketing teams"
+> - Social proof: _omitted_ (no discovery data)
+> - Tone: Empathetic (pain_severity default 3)
+> - CTA: "Join the waitlist" (conservative, free commitment)
+>
+> **Tier 2 (+ Discovery Summary, pain severity 4.2):**
+>
+> - Headline: "You Spent 3 Hours Last Tuesday on a Spreadsheet That Was Already Stale"
+> - Subheadline: "Automated competitor intelligence that's always current — so you don't scramble before board meetings"
+> - Social proof: "I spent 3 hours last Tuesday updating a competitive spreadsheet that was 2 months stale." — Marketing Manager, B2B SaaS
+> - Tone: Urgent (pain_severity 4.2 → empathetic-to-urgent register)
+> - CTA: "Get real-time competitor intel — join the waitlist" (specific, benefit-driven)
+
+The CampaignPackage records its generation tier in `provenance.generation_tier: 1 | 2`. When a Discovery Summary becomes available after a Tier 1 generation, the operator can regenerate to upgrade to Tier 2.
+
+This answers **Questions 7, 8, 9, and 11** — how the Venture Narrative and Discovery Summary inform campaign content.
+
+---
+
+## 6. The Campaign Package — Artifact Specification
+
+The **Campaign Package** is the Step 4 output artifact. It contains everything needed to launch a test campaign: ad copy variants, creative assets, targeting specification, channel selection, budget allocation, and provenance metadata.
+
+### What the Campaign Package Contains
+
+| Field              | Type                         | Source                                                                       |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------------- |
+| `copy_pack`        | object (CopyPackSchema)      | Generated by Claude API from Hypothesis Card + Discovery Summary             |
+| `creative_brief`   | object (CreativeBriefSchema) | Generated — visual asset specifications                                      |
+| `social_proof`     | object                       | From Discovery Summary `top_quotes` (Tier 2 only)                            |
+| `tone`             | object                       | Derived from `pain_severity` → emotional register mapping                    |
+| `channel_variants` | array of objects             | Per-channel ad copy/creative formatted to platform specs                     |
+| `ab_variants`      | array of objects             | A/B test variants with hypothesis for each                                   |
+| `budget`           | object                       | Allocation: ad spend %, creative buffer %, generation cost %, reserve %      |
+| `targeting`        | object                       | From Customer Segment + ICP refinements, per-channel targeting spec          |
+| `provenance`       | object                       | Generation metadata: tier, model versions, brand_profile_version, timestamps |
+| `asset_references` | array of strings             | R2 keys for generated images — NOT image data                                |
+| `stage`            | enum: draft / approved       | Two stages, same pattern as prior artifacts                                  |
+
+### Relationship to CopyPack (Backward Compatible)
+
+The `copy_pack` field within the CampaignPackage is a full CopyPackSchema object — the same structure the existing landing page template consumes. When the CampaignPackage is saved, the `copy_pack` is also written to the experiments table's `copy_pack` column as a backward-compatible projection.
+
+### Relationship to CreativeBrief (Backward Compatible)
+
+The `creative_brief` field follows the same pattern — nested inside the CampaignPackage, projected to the experiments table's `creative_brief` column.
+
+### New Fields Beyond CopyPack and CreativeBrief
+
+- **`social_proof`**: Verbatim quotes from Discovery Summary, anonymized, pain-dimension tagged. Only present in Tier 2 generations.
+- **`tone`**: `{ pain_severity: number, register: "rational" | "empathetic" | "urgent", voice_notes: string }` — calibrated from Discovery Summary pain scoring.
+- **`channel_variants[]`**: Per-channel formatted content. Each entry: `{ channel: string, format: string, headline: string, description: string, cta: string, image_ref: string, specs: { char_limits, aspect_ratio } }`.
+- **`ab_variants[]`**: A/B test structures. Each entry: `{ variant_id: string, hypothesis: string, changes: object, copy_pack_override: object }`.
+- **`budget`**: `{ total_cents: number, ad_spend_pct: 75, creative_buffer_pct: 15, generation_pct: 5, reserve_pct: 5 }`.
+- **`targeting`**: `{ primary_channel: string, secondary_channel: string, audience_spec: object, geo: string | null, age_range: string | null }`.
+- **`provenance`**: `{ generation_tier: 1 | 2, brand_profile_version: number, text_model: string, image_model: string, generated_at: string, approved_at: string | null, approved_by: string | null }`.
+
+### Two Completion Stages
+
+#### Draft (Generated)
+
+The CampaignPackage is created by the pipeline and enters `draft` stage. All fields are populated, but the package has not been reviewed by a human.
+
+#### Approved (Human-Reviewed)
+
+The operator reviews the draft, may request regeneration of specific components, and marks the package as `approved`. This updates `provenance.approved_at` and `provenance.approved_by`. Only approved packages should be used to launch campaigns.
+
+### Write Invariant
+
+> ⚠️ When a `campaign_package` is present on an experiment, the `copy_pack` and `creative_brief` columns become **read-only projections**. The PATCH `/experiments/:id` endpoint must reject direct `copy_pack`/`creative_brief` updates when `campaign_package` is non-null — edits must go through the CampaignPackage, which re-extracts the projections. This prevents data drift between the three columns.
+
+### Worked Example: Fully Populated CampaignPackage
+
+> 💡 **Venture: Accessibility Auditor (SC-2026-001) — waitlist archetype, Tier 2**
+>
+> ```json
+> {
+>   "copy_pack": {
+>     "headline": "Your Website Is Losing 20% of Customers — and Risking a Lawsuit",
+>     "subheadline": "AI-powered accessibility monitoring catches issues before regulators do",
+>     "body_copy": "Manual accessibility audits take 40+ hours per site...",
+>     "cta_text": "Join the Waitlist",
+>     "urgency_hook": "ADA enforcement is ramping up. Average settlement: $25K.",
+>     "value_props": ["Continuous monitoring", "One-click remediation", "Full compliance reports"],
+>     "social_proof": "200+ e-commerce teams are waiting for launch"
+>   },
+>   "creative_brief": {
+>     "visual_style": "Professional, clean, trust-building",
+>     "color_palette": ["#1a365d", "#2b6cb0", "#e2e8f0"],
+>     "image_requirements": [
+>       "Hero: dashboard screenshot mockup",
+>       "Ad: accessibility score visualization"
+>     ],
+>     "typography": "Sans-serif, modern, high readability"
+>   },
+>   "social_proof": {
+>     "quotes": [
+>       {
+>         "text": "I spent 3 hours last Tuesday updating accessibility reports that were already outdated.",
+>         "attribution": "Marketing Manager, E-commerce (200 employees)",
+>         "pain_dimension": "functional",
+>         "consent": true
+>       }
+>     ]
+>   },
+>   "tone": {
+>     "pain_severity": 4.2,
+>     "register": "urgent",
+>     "voice_notes": "Lead with functional pain (time waste), escalate to stakes (legal risk)"
+>   },
+>   "channel_variants": [
+>     {
+>       "channel": "facebook",
+>       "format": "single_image",
+>       "headline": "Your Website Is Losing 20% of Customers",
+>       "description": "AI-powered accessibility monitoring. Join 200+ teams on the waitlist.",
+>       "cta": "Learn More",
+>       "image_ref": "assets/sc-2026-001/fb-hero-v1.png",
+>       "specs": { "headline_chars": 40, "description_chars": 125, "aspect_ratio": "1:1" }
+>     },
+>     {
+>       "channel": "google",
+>       "format": "responsive_search",
+>       "headlines": [
+>         "Accessibility Monitoring Tool",
+>         "Stop ADA Lawsuit Risk",
+>         "Automated Compliance"
+>       ],
+>       "descriptions": [
+>         "AI catches accessibility issues before regulators do. Join the waitlist."
+>       ],
+>       "specs": { "headline_chars": 30, "description_chars": 90 }
+>     }
+>   ],
+>   "ab_variants": [
+>     {
+>       "variant_id": "A",
+>       "hypothesis": "Pain-led headline converts better than solution-led",
+>       "changes": { "headline": "Your Website Is Losing 20% of Customers — and Risking a Lawsuit" }
+>     },
+>     {
+>       "variant_id": "B",
+>       "hypothesis": "Solution-led headline converts better for high-intent audience",
+>       "changes": {
+>         "headline": "AI-Powered Accessibility Monitoring — Full Compliance in Minutes"
+>       }
+>     }
+>   ],
+>   "budget": {
+>     "total_cents": 40000,
+>     "ad_spend_pct": 75,
+>     "creative_buffer_pct": 15,
+>     "generation_pct": 5,
+>     "reserve_pct": 5
+>   },
+>   "targeting": {
+>     "primary_channel": "facebook",
+>     "secondary_channel": "google",
+>     "audience_spec": {
+>       "job_titles": ["Marketing Manager", "Digital Marketing Director", "E-commerce Manager"],
+>       "company_size": "100-500",
+>       "industries": ["E-commerce", "Retail"]
+>     }
+>   },
+>   "provenance": {
+>     "generation_tier": 2,
+>     "brand_profile_version": 1,
+>     "text_model": "claude-sonnet-4-5-20250929",
+>     "image_model": "gpt-image-1",
+>     "generated_at": "2026-03-02T10:30:00Z",
+>     "approved_at": null,
+>     "approved_by": null
+>   },
+>   "asset_references": [
+>     "assets/sc-2026-001/fb-hero-v1.png",
+>     "assets/sc-2026-001/google-display-v1.png",
+>     "assets/sc-2026-001/lp-hero-v1.png"
+>   ],
+>   "stage": "draft"
+> }
+> ```
+
+---
+
+## 6.5. Campaign Package Schema Sketch
+
+Field specification for the `campaign_package` TEXT (JSON) column:
+
+```json
+{
+  "copy_pack": {
+    "type": "object",
+    "required": true,
+    "description": "Full CopyPackSchema — backward compatible with existing column",
+    "properties": {
+      "headline": { "type": "string", "required": true, "maxLength": 200 },
+      "subheadline": { "type": "string", "required": false, "maxLength": 300 },
+      "body_copy": { "type": "string", "required": false, "maxLength": 5000 },
+      "cta_text": { "type": "string", "required": true, "maxLength": 50 },
+      "urgency_hook": { "type": "string", "required": false, "maxLength": 200 },
+      "value_props": { "type": "array", "items": "string", "maxItems": 5 },
+      "social_proof": { "type": "string", "required": false, "maxLength": 500 },
+      "pricing_copy": { "type": "string", "required": false, "maxLength": 500 },
+      "feature_list": { "type": "array", "items": "string", "maxItems": 10 },
+      "refund_policy": { "type": "string", "required": false, "maxLength": 500 }
+    }
+  },
+  "creative_brief": {
+    "type": "object",
+    "required": true,
+    "description": "Full CreativeBriefSchema — backward compatible with existing column",
+    "properties": {
+      "visual_style": { "type": "string" },
+      "color_palette": { "type": "array", "items": "string" },
+      "image_requirements": { "type": "array", "items": "string" },
+      "typography": { "type": "string" }
+    }
+  },
+  "social_proof": {
+    "type": "object",
+    "required": false,
+    "description": "Only present in Tier 2 generations",
+    "properties": {
+      "quotes": {
+        "type": "array",
+        "items": {
+          "text": "string",
+          "attribution": "string",
+          "pain_dimension": {
+            "type": "string",
+            "enum": ["functional", "emotional", "opportunity_cost"]
+          },
+          "consent": "boolean"
+        },
+        "maxItems": 5
+      }
+    }
+  },
+  "tone": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "pain_severity": { "type": "number", "minimum": 1, "maximum": 5 },
+      "register": { "type": "string", "enum": ["rational", "empathetic", "urgent"] },
+      "voice_notes": { "type": "string", "maxLength": 500 }
+    }
+  },
+  "channel_variants": {
+    "type": "array",
+    "required": true,
+    "items": {
+      "channel": {
+        "type": "string",
+        "enum": ["facebook", "google", "tiktok", "linkedin", "reddit", "twitter", "email"]
+      },
+      "format": "string",
+      "headline": "string",
+      "description": "string",
+      "cta": "string",
+      "image_ref": "string",
+      "specs": {
+        "headline_chars": "number",
+        "description_chars": "number",
+        "aspect_ratio": "string"
+      }
+    }
+  },
+  "ab_variants": {
+    "type": "array",
+    "required": false,
+    "items": {
+      "variant_id": "string",
+      "hypothesis": "string",
+      "changes": "object"
+    },
+    "maxItems": 5
+  },
+  "budget": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "total_cents": { "type": "number" },
+      "ad_spend_pct": { "type": "number" },
+      "creative_buffer_pct": { "type": "number" },
+      "generation_pct": { "type": "number" },
+      "reserve_pct": { "type": "number" }
+    }
+  },
+  "targeting": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "primary_channel": "string",
+      "secondary_channel": "string",
+      "audience_spec": "object",
+      "geo": { "type": ["string", "null"] },
+      "age_range": { "type": ["string", "null"] }
+    }
+  },
+  "provenance": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "generation_tier": { "type": "number", "enum": [1, 2] },
+      "brand_profile_version": { "type": "number" },
+      "text_model": "string",
+      "image_model": "string",
+      "generated_at": "string",
+      "approved_at": { "type": ["string", "null"] },
+      "approved_by": { "type": ["string", "null"] }
+    }
+  },
+  "asset_references": {
+    "type": "array",
+    "required": false,
+    "items": { "type": "string" },
+    "description": "R2 keys for generated images — NOT image data"
+  },
+  "stage": {
+    "type": "string",
+    "enum": ["draft", "approved"],
+    "required": true
+  }
+}
+```
+
+---
+
+## 7. Per-Archetype Content Specifications
+
+Each of the 7 archetypes requires different content. This section defines the content requirements, ad formats, CTA patterns, and creative focus for each.
+
+### Content Requirements by Archetype
+
+| Archetype         | Category     | Primary Content                               | CTA Type              | Creative Focus   | Ad Format                  |
+| ----------------- | ------------ | --------------------------------------------- | --------------------- | ---------------- | -------------------------- |
+| `fake_door`       | Demand       | Minimal LP — headline + CTA                   | "Get Early Access"    | Curiosity-driven | Single image               |
+| `waitlist`        | Demand       | Email capture LP — problem/solution narrative | "Join the Waitlist"   | Aspirational     | Single image               |
+| `content_magnet`  | Demand       | Lead magnet LP — asset preview                | "Download Free Guide" | Content preview  | Single image + carousel    |
+| `priced_waitlist` | WTP          | LP with price anchor — feature breakdown      | "Reserve Spot ($X)"   | Value-focused    | Single image + carousel    |
+| `presale`         | WTP          | Full sales LP — payment flow                  | "Buy Now ($X)"        | Product mock-ups | Carousel + video (Phase 2) |
+| `service_pilot`   | Solution Val | Service description LP — process overview     | "Book a Call"         | Process/outcome  | Single image               |
+| `concierge`       | Solution Val | Service LP — team/approach                    | "Schedule Intro"      | People/team      | Single image               |
+
+### Content Formats by Test Category
+
+**Demand Signal** (fake_door, waitlist, content_magnet):
+
+- Short-form ads optimized for impressions and clicks
+- Simple landing pages with clear problem → solution → CTA flow
+- Email capture as the primary signal mechanism
+- Meta/Google optimized for broad reach
+- Copy emphasis: Problem awareness, curiosity, low-commitment CTA
+
+**Willingness to Pay** (priced_waitlist, presale):
+
+- Long-form landing pages with pricing section, trust signals, and (for presale) payment flow
+- Feature breakdowns, comparison tables, FAQ sections
+- Google Search for high-intent capture
+- Copy emphasis: Value justification, price anchoring, transformation promise, risk reversal (refund policy)
+
+**Solution Validation** (service_pilot, concierge):
+
+- Relationship-building content emphasizing expertise, process, and outcomes
+- Detailed service descriptions, case study templates, scheduling CTAs
+- LinkedIn/email for professional audiences
+- Copy emphasis: Credibility, process transparency, outcome specificity, personal connection
+
+### CopyPack Field Requirements by Archetype
+
+| Field           | fake_door    | waitlist     | content_magnet | priced_waitlist | presale      | concierge    | service_pilot |
+| --------------- | ------------ | ------------ | -------------- | --------------- | ------------ | ------------ | ------------- |
+| `headline`      | **Required** | **Required** | **Required**   | **Required**    | **Required** | **Required** | **Required**  |
+| `subheadline`   | Optional     | **Required** | **Required**   | **Required**    | **Required** | **Required** | **Required**  |
+| `body_copy`     | Not used     | **Required** | **Required**   | **Required**    | **Required** | **Required** | **Required**  |
+| `cta_text`      | **Required** | **Required** | **Required**   | **Required**    | **Required** | **Required** | **Required**  |
+| `urgency_hook`  | Not used     | Optional     | Not used       | Optional        | Optional     | Not used     | Not used      |
+| `value_props`   | Not used     | Optional     | Optional       | Optional        | **Required** | Optional     | **Required**  |
+| `social_proof`  | Not used     | Optional     | Optional       | Optional        | Optional     | Optional     | Optional      |
+| `pricing_copy`  | Not used     | Not used     | Not used       | **Required**    | **Required** | Optional     | **Required**  |
+| `feature_list`  | Not used     | Not used     | Optional       | Optional        | **Required** | Optional     | **Required**  |
+| `refund_policy` | Not used     | Not used     | Not used       | Not used        | **Required** | Not used     | Not used      |
+
+This answers **Question 10** — what content formats work best for each test category.
+
+---
+
+## 8. Visual Content Strategy
+
+### AI Image Generation Tool Assessment
+
+| Tool               | Quality     | API Maturity        | Cost per Image   | Commercial Safety                                          | Text Rendering           | Best For                                           |
+| ------------------ | ----------- | ------------------- | ---------------- | ---------------------------------------------------------- | ------------------------ | -------------------------------------------------- |
+| OpenAI GPT Image 1 | High        | Production-ready    | $0.005–0.25      | Good (OpenAI terms)                                        | Good                     | General purpose — primary tool                     |
+| Ideogram           | High        | Available           | $0.02–0.08       | Good                                                       | **Best** (~90% accuracy) | Text-heavy assets (banners, ads with text overlay) |
+| Stability AI       | Medium      | Self-hostable       | $0.002–0.006     | Good (open models)                                         | Moderate                 | High-volume, budget scenarios                      |
+| Adobe Firefly      | High        | Enterprise-gated    | Premium          | **Best** (trained on licensed content, IP indemnification) | Good                     | Future — when API opens to SMBs                    |
+| Midjourney         | **Highest** | **No official API** | $0.01–0.04 (web) | Moderate                                                   | Poor                     | **Not viable** for programmatic pipelines          |
+
+### Recommended Image Stack
+
+> 🔧 **Primary:** OpenAI GPT Image 1 — best balance of quality, API maturity, cost. Production-ready REST API with reliable output.
+>
+> **Text-heavy assets:** Ideogram API — when ad banners, social media graphics, or any image needs readable text, Ideogram's ~90% text rendering accuracy is critical. GPT Image 1's text rendering is improving but not yet reliable for production use.
+>
+> **Volume/budget:** Stability AI — at $0.002–0.006 per image, use for high-volume generation or when budgets are tight. Self-hostable option available.
+
+### Why Midjourney is Excluded
+
+Midjourney produces the highest aesthetic quality of any image generation tool. However, it has **no official API** — all interaction is through Discord or their web interface. This makes it unsuitable for SC's programmatic pipeline. If Midjourney launches an API, it should be re-evaluated.
+
+### Why Video is Deferred to Phase 2
+
+Video generation is 10–100× more expensive than image/text:
+
+| Content                    | Cost per Unit  | Per-Campaign Cost |
+| -------------------------- | -------------- | ----------------- |
+| Text (50 ad copy variants) | $0.01–0.05     | $0.50–2.50        |
+| Images (30 images)         | $0.005–0.07    | $0.70–2.00        |
+| Video (one 30-sec ad)      | $0.10–0.50/sec | **$3.00–15.00**   |
+
+A single video variant costs more than the entire text + image budget combined. At $300–500 test budgets, video generation is not economically viable.
+
+**Phase 2 video stack (when budgets allow):**
+
+- Runway Gen-4 API for ad clips ($0.01–0.50/second, best quality + API)
+- Synthesia/HeyGen for avatar-based explainer content (API available)
+
+### Platform-Specific Image Requirements
+
+| Platform                  | Aspect Ratios                                       | Min Resolution | Format      |
+| ------------------------- | --------------------------------------------------- | -------------- | ----------- |
+| Meta (Facebook/Instagram) | 1:1 (feed), 9:16 (stories/reels), 1.91:1 (link ads) | 1080×1080      | JPG/PNG     |
+| Google Display            | 1.91:1 (landscape), 1:1 (square), 4:5 (portrait)    | 1200×628       | JPG/PNG     |
+| LinkedIn                  | 1.91:1 (sponsored), 1:1 (carousel)                  | 1200×627       | JPG/PNG     |
+| TikTok                    | 9:16 (vertical)                                     | 1080×1920      | JPG/PNG/MP4 |
+
+### Image Generation Prompt Templates
+
+For consistency across campaigns, image generation uses structured prompt templates:
+
+```
+[STYLE: {brand_profile.image_style}]
+[SUBJECT: {creative_brief.image_requirements[n]}]
+[COLOR PALETTE: {brand_profile.color_palette}]
+[ASPECT RATIO: {platform_spec.aspect_ratio}]
+[TEXT OVERLAY: {headline or null}]
+[MOOD: {tone.register} — {tone.voice_notes}]
+[PROHIBITED: {brand_profile.prohibited_terms}]
+```
+
+This answers **Questions 1 and 3** — what AI tools produce campaign-quality creative today, and what the quality bar is.
+
+---
+
+## 9. Brand Consistency Model
+
+### BrandProfile Specification
+
+Each venture gets a BrandProfile that constrains all content generation. The profile is injected as system prompt constraints during Claude API calls for text, and as structured parameters for image generation.
+
+**BrandProfile fields:**
+
+| Field                  | Type                 | Description                                               |
+| ---------------------- | -------------------- | --------------------------------------------------------- |
+| `voice_tone`           | enum                 | professional / casual / technical / friendly / urgent     |
+| `color_palette`        | array of hex strings | Primary, secondary, accent colors                         |
+| `typography_style`     | string               | Sans-serif modern / Serif traditional / etc.              |
+| `image_style`          | string               | Photography / Illustration / Abstract / Minimal           |
+| `prohibited_terms`     | array of strings     | Words/phrases that must never appear in generated content |
+| `required_disclosures` | array of strings     | Legal/compliance text that must appear on all content     |
+| `competitor_names`     | array of strings     | Competitors to avoid mentioning by name                   |
+| `brand_voice_examples` | array of strings     | 2–3 example sentences showing the desired voice           |
+
+### Multi-Venture VaaS Brand Separation
+
+For VaaS, SC maintains a "brand-neutral" default BrandProfile; each client venture overrides it. The `ventures` table ensures complete brand separation:
+
+**`ventures` table schema:**
+
+| Column                  | Type              | Description                |
+| ----------------------- | ----------------- | -------------------------- |
+| `id`                    | TEXT PRIMARY KEY  | Venture identifier         |
+| `name`                  | TEXT NOT NULL     | Venture display name       |
+| `brand_profile`         | TEXT (JSON)       | Full BrandProfile object   |
+| `brand_profile_version` | INTEGER DEFAULT 1 | Auto-incremented on update |
+| `created_at`            | TEXT NOT NULL     | ISO 8601 timestamp         |
+| `updated_at`            | TEXT NOT NULL     | ISO 8601 timestamp         |
+
+The experiments table gets `venture_id TEXT REFERENCES ventures(id)` to link each experiment to its venture's brand.
+
+The CampaignPackage `provenance` field records `brand_profile_version` so content can be traced to the exact profile version that generated it.
+
+### System Prompt Engineering for Voice Consistency
+
+BrandProfile constraints are injected into Claude API calls as system prompt:
+
+```
+You are generating marketing copy for {venture.name}.
+
+Voice tone: {brand_profile.voice_tone}
+Brand voice examples:
+- "{brand_profile.brand_voice_examples[0]}"
+- "{brand_profile.brand_voice_examples[1]}"
+
+NEVER use these terms: {brand_profile.prohibited_terms}
+ALWAYS include: {brand_profile.required_disclosures}
+NEVER mention competitor names: {brand_profile.competitor_names}
+```
+
+### Consistency Mitigation — 3-Variant Generation
+
+Style consistency via prompting has known limits. The pipeline generates **3 variant sets**, scores each against a BrandProfile compliance checklist (specific yes/no checks, not a vague 0–1 score), and selects the best-matching one.
+
+**BrandProfile compliance checklist:**
+
+- [ ] Voice tone matches specified register?
+- [ ] No prohibited terms present?
+- [ ] All required disclosures included?
+- [ ] No competitor names mentioned?
+- [ ] Color palette referenced correctly in creative brief?
+- [ ] Image style matches specification?
+
+Cost impact: 3× text generation = ~$1.50 per campaign, still negligible.
+
+### Quality Gates — Structured Consistency Check
+
+Three-tier quality system:
+
+**Tier 1 — Automated Validation (no human needed):**
+
+- JSON schema validation (all required fields present, correct types)
+- Character count checks per platform (headline within limits, description within limits)
+- Profanity/sensitivity filter
+- BrandProfile compliance check against prohibited terms and required disclosures
+
+**Tier 2 — Structured Consistency Check (automated + logged):**
+Claude answers specific yes/no questions against the Hypothesis Card — not a vague numeric score:
+
+- "Does headline reference the problem statement?" (Y/N)
+- "Are all value props traceable to Solution Hypothesis?" (Y/N)
+- "Does CTA match archetype pattern?" (Y/N)
+- "Are any claims made that aren't in source data?" (Y/N)
+- "Does tone match pain severity register?" (Y/N)
+
+Each check passes or fails. If any fail, **regenerate that specific component** (not the entire package) with the failure as a constraint. If it fails twice on the same check, flag for human review with the specific failure reason attached.
+
+**Tier 3 — Human Approval Gate (required):**
+Final CampaignPackage review before launch. The quality bar: "good enough that the creative itself is not the reason people don't convert." Not agency quality. Not award-winning. Credible.
+
+### Feedback Loops
+
+Track approved vs. rejected content to improve prompt engineering over time:
+
+- Record which components were regenerated and why
+- Track which BrandProfile compliance checks fail most often
+- Adjust system prompts based on failure patterns
+- Key stat: 95% of companies have brand guidelines, only 25–30% enforce them. Automation reduces violations by 78%.
+
+This answers **Question 2** — how to maintain brand consistency across AI-generated content.
+
+---
+
+## 10. Technology Landscape & Build vs. Buy
+
+### AI Content Generation Platform Landscape
+
+The market for AI marketing content platforms is mature and well-funded:
+
+| Platform      | Funding                 | Key Feature                                   | API Available? | Pricing            |
+| ------------- | ----------------------- | --------------------------------------------- | -------------- | ------------------ |
+| Jasper        | $131M                   | Full-stack marketing AI                       | Yes (limited)  | $125/mo+           |
+| Writer        | $369M ($1.9B valuation) | Enterprise content AI                         | Yes            | Enterprise pricing |
+| Copy.ai       | Undisclosed             | Workflow-based copy generation                | Yes            | $49/mo+            |
+| Anyword       | $21M                    | Predictive performance scoring (82% accuracy) | Yes            | $49/mo+            |
+| Typeface      | $206M                   | Brand-consistent content                      | Limited        | Enterprise         |
+| AdCreative.ai | Undisclosed             | Ad creative generation + scoring              | Yes            | $29/mo+            |
+
+### API Ecosystem Maturity Assessment
+
+**Tier 1 — Production-Ready:**
+
+- Claude API (text generation) — SC's primary, already in infrastructure
+- OpenAI GPT-4o (text), GPT Image 1 (images) — mature REST APIs
+- Stability AI (images) — self-hostable, REST API
+
+**Tier 2 — Available but Limited:**
+
+- Ideogram API (images with text) — newer but functional
+- Runway Gen-4 API (video) — available, expensive
+- Anyword API (performance prediction) — genuine differentiator worth integrating in Phase 2
+
+**Tier 3 — Not Viable for Programmatic Pipelines:**
+
+- Midjourney (no API)
+- Adobe Firefly (enterprise-gated)
+- Canva Magic (platform-locked)
+
+### Why Build the Orchestration Layer, Buy API Calls
+
+The recommendation: **build SC's own orchestration pipeline, consume raw APIs for generation.**
+
+| Approach                | Monthly Cost    | Per-Campaign Cost  | Integration     | Flexibility           |
+| ----------------------- | --------------- | ------------------ | --------------- | --------------------- |
+| Jasper subscription     | $125/mo minimum | ~$2.50 (amortized) | Platform-locked | Low — their workflows |
+| Writer enterprise       | $500/mo+        | ~$10+ (amortized)  | API available   | Medium                |
+| Claude API + image APIs | Usage-based     | ~$1–4 (actual)     | Full control    | Full — SC's pipeline  |
+
+The economics are clear: raw API calls cost $1–4 per campaign. Platform subscriptions cost $125–500/month regardless of volume. At SC's validation pace (a few campaigns per month), platforms are dramatically overpriced. At VaaS scale (many campaigns per month), raw APIs scale linearly while platforms hit tier limits.
+
+**Build scope:**
+
+- Prompt templates for each archetype × narrative element combination
+- Pipeline orchestration (7-step workflow in Cloudflare Queue Consumer)
+- BrandProfile injection into system prompts
+- Structured consistency checking
+- R2 asset storage and reference management
+
+**Buy (API consumption):**
+
+- Claude API for all text generation
+- OpenAI GPT Image 1 for image generation
+- Ideogram for text-heavy images
+- Stability AI for volume scenarios
+
+This answers **Question 4** — yes, we can build a content pipeline that generates complete campaign packages from a hypothesis. The APIs are mature; what's needed is the orchestration layer.
+
+---
+
+## 11. Content Generation Pipeline — Detailed Workflow
+
+### Async Architecture
+
+> ⚠️ **Critical constraint:** Cloudflare Workers have a 30-second CPU time limit. Image generation calls alone can take 10–30 seconds each. The pipeline CANNOT run synchronously in a single Worker invocation.
+>
+> **Architecture:** The `POST /experiments/:id/generate-campaign-package` endpoint enqueues a job to a Cloudflare Queue, returns `202 Accepted` with a job ID. The pipeline executes in a Queue Consumer worker (15-minute execution limit). A `GET /experiments/:id/campaign-package/status` endpoint allows polling for completion.
+
+### 7-Step Pipeline
+
+#### Step 1: Context Assembly
+
+**Input:** experiment_id
+**Process:**
+
+1. Fetch Hypothesis Card from `hypothesis_card` column
+2. Fetch Discovery Summary from `discovery_summary` column (if present)
+3. Fetch Test Blueprint from `test_blueprint` column
+4. Fetch BrandProfile from `ventures` table via `venture_id`
+5. Determine generation tier (1 if no Discovery Summary, 2 if present)
+
+**Output:** Assembled context object
+**API calls:** 0 (database reads only)
+**Event logged:** `campaign_gen_started`
+
+#### Step 2: Copy Generation
+
+**Input:** Assembled context
+**Process:**
+
+1. Select prompt template based on archetype
+2. Inject BrandProfile constraints as system prompt
+3. Inject Hypothesis Card fields as context (Messaging Matrix mapping)
+4. If Tier 2: inject Discovery Summary fields (pain severity, top quotes, signal patterns)
+5. Generate 3 variant sets (for brand consistency scoring)
+6. Run BrandProfile compliance checklist on each variant
+7. Select best-matching variant
+
+**Output:** CopyPack object (headline, subheadline, body_copy, cta_text, etc.)
+**API calls:** 3 Claude API calls (one per variant set)
+**Estimated cost:** $0.30–1.50
+**Estimated time:** 10–30 seconds
+
+#### Step 3: Creative Brief Generation
+
+**Input:** CopyPack + BrandProfile + archetype
+**Process:**
+
+1. Generate creative brief from CopyPack content and BrandProfile visual specs
+2. Determine image requirements based on archetype (see Section 7 table)
+3. Specify aspect ratios per target platform (from channel_variants)
+4. Generate image prompt templates from brief
+
+**Output:** CreativeBrief object + image generation prompts
+**API calls:** 1 Claude API call
+**Estimated cost:** $0.05–0.20
+**Estimated time:** 5–10 seconds
+
+#### Step 4: Asset Generation
+
+**Input:** Image prompts + CreativeBrief specs
+**Process:**
+
+1. For each required image (typically 3–10 per campaign):
+   - Select image API based on content type (GPT Image 1 default, Ideogram for text-heavy)
+   - Generate image at required aspect ratio
+   - Store in R2 using existing `generateAssetKey()` pattern
+   - Record R2 key in asset_references array
+2. Parallel generation where possible (multiple images simultaneously)
+
+**Output:** R2 keys for all generated images
+**API calls:** 3–10 image API calls
+**Estimated cost:** $0.15–2.50
+**Estimated time:** 30–120 seconds (API latency bound)
+**Event logged:** `campaign_gen_step_completed` (after each image)
+
+#### Step 5: Campaign Assembly
+
+**Input:** CopyPack + CreativeBrief + asset references + context
+**Process:**
+
+1. Generate channel_variants by formatting copy for each target platform (character limits, etc.)
+2. Generate ab_variants (typically 2 — one pain-led, one solution-led)
+3. Assemble budget allocation from archetype defaults + test blueprint
+4. Assemble targeting spec from Hypothesis Card Customer Segment + ICP refinements
+5. Build provenance metadata (generation tier, model versions, brand profile version)
+6. Compose the full CampaignPackage object
+
+**Output:** Complete CampaignPackage (draft stage)
+**API calls:** 1 Claude API call (for channel variant formatting)
+**Estimated cost:** $0.05–0.20
+**Estimated time:** 5–15 seconds
+
+#### Step 6: Structured Consistency Check
+
+**Input:** CampaignPackage + Hypothesis Card
+**Process:**
+
+1. Run automated validation (JSON schema, character counts, profanity filter)
+2. Run BrandProfile compliance check (prohibited terms, required disclosures)
+3. Run structured consistency checklist via Claude:
+   - Does headline reference the problem statement?
+   - Are all value props traceable to Solution Hypothesis?
+   - Does CTA match archetype pattern?
+   - Are any claims made that aren't in source data?
+   - Does tone match pain severity register?
+4. If any check fails: regenerate the specific failing component (not full package)
+5. If same check fails twice: flag for human review with specific failure reason
+
+**Output:** CampaignPackage with consistency_check results attached
+**API calls:** 1 Claude API call (for checklist evaluation)
+**Estimated cost:** $0.05–0.15
+**Estimated time:** 5–10 seconds
+
+#### Step 7: Human Review Gate
+
+**Input:** CampaignPackage (draft)
+**Process:**
+
+1. Save CampaignPackage to `campaign_package` column (stage: "draft")
+2. Extract and save backward-compatible `copy_pack` and `creative_brief` projections
+3. Notify operator that package is ready for review
+4. Operator reviews, may request specific component regeneration
+5. Operator marks as approved → stage changes to "approved"
+
+**Output:** Approved CampaignPackage
+**API calls:** 0 (human process)
+**Event logged:** `campaign_gen_completed` (on save), `campaign_package_approved` (on approval)
+
+### Pipeline Timing Summary
+
+| Step                  | Duration         | Bottleneck           |
+| --------------------- | ---------------- | -------------------- |
+| 1. Context Assembly   | <1 sec           | Database reads       |
+| 2. Copy Generation    | 10–30 sec        | Claude API latency   |
+| 3. Creative Brief     | 5–10 sec         | Claude API latency   |
+| 4. Asset Generation   | 30–120 sec       | Image API latency    |
+| 5. Campaign Assembly  | 5–15 sec         | Claude API latency   |
+| 6. Consistency Check  | 5–10 sec         | Claude API latency   |
+| 7. Human Review       | Minutes to hours | Human availability   |
+| **Total (automated)** | **~1–3 minutes** | **Image generation** |
+
+### Error Handling
+
+If the pipeline fails at any step:
+
+- `campaign_gen_failed` event logged with step number and error details
+- Partial results are preserved (e.g., if copy was generated but images failed, keep the copy)
+- Operator can retry from the failed step, not from scratch
+- Maximum 3 automatic retries per API call before failing the step
+
+### Integration with event_log
+
+| Event Type                    | Trigger            | event_data (JSON)                                       |
+| ----------------------------- | ------------------ | ------------------------------------------------------- |
+| `campaign_gen_started`        | Pipeline begins    | experiment_id, generation_tier, archetype               |
+| `campaign_gen_step_completed` | Each step finishes | step_number, step_name, duration_ms                     |
+| `campaign_gen_completed`      | Pipeline succeeds  | experiment_id, total_duration_ms, generation_cost_cents |
+| `campaign_gen_failed`         | Pipeline fails     | step_number, error_message, partial_results             |
+| `campaign_package_approved`   | Human approves     | experiment_id, approved_by, modifications_made          |
+
+---
+
+## 12. Ethical Framework — Four Pillars
+
+### Pillar 1: Disclosure
+
+AI generation is recorded in CampaignPackage provenance metadata. External disclosure follows platform-specific requirements:
+
+- **Meta:** Auto-labels AI-generated ads (no additional action needed)
+- **TikTok:** Bans deepfake endorsements; requires synthetic content labels
+- **YouTube:** Requires synthetic content labels for AI-generated material
+- **Google:** Requires disclosure for materially AI-generated ad creative
+- **LinkedIn:** Emerging requirements — monitor and comply
+
+**SC policy:** All CampaignPackages include `provenance` metadata recording the AI models used for generation. VaaS deliverables explicitly note AI involvement in content creation.
+
+### Pillar 2: Commercial Safety
+
+- **Prefer commercially safe image sources.** GPT Image 1 and Stability AI have clear commercial use terms. Ideogram allows commercial use. Adobe Firefly offers full IP indemnification but is enterprise-gated.
+- **All generated assets stored in R2 with provenance tracking.** Each asset records the model that generated it, the prompt used, and the generation timestamp.
+- **No unlicensed stock imagery.** All images are either AI-generated with commercial licenses or explicitly licensed stock.
+
+### Pillar 3: Truthfulness
+
+- All ad copy claims must be verifiable against Hypothesis Card and Discovery Summary data
+- No fabricated statistics — if a stat appears in copy, it must trace to a source field
+- Customer quotes ONLY from actual `top_quotes` in Discovery Summary, with anonymized attribution
+- No synthetic testimonials — social proof is either real (from discovery) or omitted (Tier 1)
+- The structured consistency check (Section 9) specifically validates: "Are any claims made that aren't in source data?"
+
+### Pillar 4: Copyright — Honest Assessment
+
+> ⚠️ **Purely AI-generated marketing content likely has no copyright protection under current law.** The Supreme Court declined to hear _Thaler v. Perlmutter_ (March 2, 2026), leaving in place the Copyright Office's position that works created by AI without human authorship are not copyrightable.
+
+**For validation content, this is acceptable:**
+
+- Validation campaigns are **disposable by design** — the content's purpose is to test demand, not build brand equity
+- Competitors copying ad creative from a validation test is a negligible risk — the ads run for 7–21 days to small audiences
+- The cost of regeneration is $1–4 — even if content were copied, replacing it is trivial
+
+**For Phase 2 / VaaS client-facing content:**
+
+- Add a mandatory human editing step where the reviewer makes substantive modifications to at least the primary headline, hero image, and CTA
+- Track `modification_percentage` in provenance metadata
+- This adds a human authorship element that strengthens copyright claims — though the legal landscape is still evolving
+
+**Don't overstate copyright protection.** Acknowledge the gap and explain why it's acceptable at validation stage.
+
+### Legal Compliance Summary
+
+| Jurisdiction/Law                        | Requirement                                               | SC Compliance                                      |
+| --------------------------------------- | --------------------------------------------------------- | -------------------------------------------------- |
+| FTC Section 5                           | Clear, conspicuous AI disclosure                          | Provenance metadata + platform-specific labels     |
+| California AI Transparency Act (SB 942) | AI content labeling, effective Jan 1, 2026, $5K/violation | Platform auto-labels + provenance metadata         |
+| New York Synthetic Performer Law        | Consent for AI-generated likenesses                       | No synthetic performers used in validation content |
+| EU AI Act                               | Transparency for AI-generated content                     | Provenance tracking meets requirements             |
+| Platform policies                       | Varies — see disclosure section above                     | Per-platform compliance                            |
+
+This answers **Question 5** — ethical considerations around AI-generated marketing content.
+
+---
+
+## 13. Budget Allocation Model
+
+### Budget Breakdown by Test Level
+
+**$300 test:**
+
+| Category                        | %   | Amount |
+| ------------------------------- | --- | ------ |
+| Ad spend (Meta/Google/LinkedIn) | 75% | $225   |
+| Creative iteration buffer       | 15% | $45    |
+| Content generation (API costs)  | 5%  | $15    |
+| Reserve                         | 5%  | $15    |
+
+**$400 test:**
+
+| Category                        | %   | Amount |
+| ------------------------------- | --- | ------ |
+| Ad spend (Meta/Google/LinkedIn) | 75% | $300   |
+| Creative iteration buffer       | 15% | $60    |
+| Content generation (API costs)  | 5%  | $20    |
+| Reserve                         | 5%  | $20    |
+
+**$500 test:**
+
+| Category                        | %   | Amount |
+| ------------------------------- | --- | ------ |
+| Ad spend (Meta/Google/LinkedIn) | 75% | $375   |
+| Creative iteration buffer       | 15% | $75    |
+| Content generation (API costs)  | 5%  | $25    |
+| Reserve                         | 5%  | $25    |
+
+### Content Generation Costs Are Negligible
+
+At ~$1–4 per full campaign package, the $15–25 content generation allocation covers 4–25 complete regeneration cycles. Content generation is not a meaningful cost center — **ad spend drives the budget.**
+
+### Channel-Specific Minimum Viable Spend
+
+| Channel                   | Minimum Viable Daily Spend | Rationale                                  |
+| ------------------------- | -------------------------- | ------------------------------------------ |
+| Meta (Facebook/Instagram) | $10–20/day                 | Sufficient for algorithm optimization      |
+| Google Search             | $15–30/day                 | Higher CPCs, need enough clicks for signal |
+| Google Display            | $10–20/day                 | Lower CPCs, broader reach                  |
+| LinkedIn                  | $25–50/day                 | Highest CPCs ($5–15), B2B premium          |
+| TikTok                    | $10–20/day                 | Low CPCs but requires video (Phase 2)      |
+| Reddit                    | $5–10/day                  | Low CPCs, niche targeting                  |
+
+### Why 75% Goes to Ad Spend
+
+The test budget exists to buy signal — impressions, clicks, conversions. At $300–500 total, every dollar diverted from ad spend reduces sample size. The 75/15/5/5 split ensures:
+
+- Enough ad spend for statistically meaningful results (150–600 clicks)
+- A creative iteration buffer for one messaging pivot (soft kill scenario)
+- Content generation costs covered with generous headroom
+- A reserve for unexpected costs
+
+---
+
+## 14. Channel Selection Logic
+
+### Decision Tree: Customer Segment + Archetype → Channel
+
+| Customer Signal            | Primary Channel             | Secondary              |
+| -------------------------- | --------------------------- | ---------------------- |
+| B2B SaaS, professional     | LinkedIn Ads, Google Search | Meta (retargeting)     |
+| B2C consumer, broad        | Meta (Facebook/Instagram)   | TikTok, Google Display |
+| B2B services, niche        | LinkedIn Ads                | Google Search          |
+| Technical/developer        | Google Search, Reddit       | Twitter/X              |
+| Local/geographic           | Meta (geo-targeted)         | Google Local           |
+| Content/thought leadership | LinkedIn organic + ads      | Meta                   |
+
+### Platform-Specific Creative Specifications
+
+| Platform         | Headline Chars     | Description Chars    | Image Aspect Ratios | Max File Size |
+| ---------------- | ------------------ | -------------------- | ------------------- | ------------- |
+| Meta (Facebook)  | 40                 | 125                  | 1:1, 1.91:1, 9:16   | 30MB          |
+| Meta (Instagram) | 40                 | 125                  | 1:1, 4:5, 9:16      | 30MB          |
+| Google Search    | 30 (×15 headlines) | 90 (×4 descriptions) | N/A                 | N/A           |
+| Google Display   | 30                 | 90                   | 1.91:1, 1:1, 4:5    | 5.12MB        |
+| LinkedIn         | 70                 | 150                  | 1.91:1, 1:1         | 5MB           |
+| TikTok           | 100                | N/A                  | 9:16                | 500MB (video) |
+| Reddit           | 300                | N/A                  | 1:1, 4:3            | 5MB           |
+| Twitter/X        | 70                 | N/A                  | 1.91:1, 1:1         | 5MB           |
+
+### Integration with metrics_daily.source
+
+The existing `metrics_daily` table tracks traffic sources. The current codebase documents `facebook|google|tiktok|manual` as expected source values. The Channel Selection Logic recommends additional channels. The standardized source enum should be:
+
+`facebook`, `google`, `tiktok`, `linkedin`, `reddit`, `twitter`, `email`, `manual`
+
+Per-channel ad format recommendations are encoded in `channel_variants[]` within the CampaignPackage.
+
+### Platform-Native Optimization
+
+Modern ad platforms do significant optimization internally:
+
+- **Meta Advantage+:** Auto-tests creative combinations, reported +22% ROAS with AI features. SC's job is to generate high-quality variants to feed it.
+- **Google Performance Max:** Asset-based, auto-optimizes across all Google properties. Provide multiple headlines, descriptions, and images — the platform does the testing.
+
+SC generates the variants; platforms optimize the delivery. This is complementary, not competitive.
+
+---
+
+## 15. Answering the Six Strategy Session Questions
+
+**1. What AI tools can produce campaign-quality creative assets today?**
+
+**Text:** Claude API (primary) and GPT-4o (secondary) handle all copy generation — ad headlines, descriptions, value props, CTAs, social proof integration, email sequences. The market has mature platforms (Jasper $131M, Writer $369M), but raw LLM APIs replicate most features at a fraction of the cost. Per-campaign text generation: ~$0.50–2.50 for 50 variants.
+
+**Images:** OpenAI GPT Image 1 ($0.005–0.25/image) as primary — best balance of quality, API maturity, cost. Ideogram for text-heavy assets (~90% text rendering accuracy). Stability AI for volume ($0.002–0.006/image). Midjourney has highest aesthetic quality but NO API — not viable. Per-campaign images: ~$0.70–2.00 for 30 images.
+
+**Video:** Runway Gen-4 (top quality + API, $0.01–0.50/second), Sora 2 (API available, $0.10–0.50/second). Video is deferred to Phase 2 — at $3–15 per 30-second variant, it doesn't fit $300–500 test budgets.
+
+**2. How do we maintain brand consistency across AI-generated content?**
+
+BrandProfile per venture — voice tone, color palette, typography, image style, prohibited terms, required disclosures. System prompt constraints inject brand rules into every Claude API call. The pipeline generates 3 variant sets, scores each against a BrandProfile compliance checklist (specific yes/no checks), and selects the best match. Automated post-generation validation catches violations. Human review gate catches the rest. Key stat: automation reduces brand violations by 78%.
+
+**3. What's the quality bar for social media campaign creative?**
+
+"Credible enough that creative isn't the conversion bottleneck." Professional, correct, clear — not agency-grade. Below the bar: obvious AI artifacts, mismatched messaging, unprofessional appearance. At the bar: the kind of content a competent marketing team would produce. Above the bar (unnecessary for validation): award-winning creative, custom photography. The creative iteration buffer (15% of budget) allows one messaging swap if the first version underperforms.
+
+**4. Can we build a content pipeline that generates complete campaign packages from a hypothesis?**
+
+**Yes.** The Campaign Factory is a 7-step async pipeline: Context Assembly → Copy Generation → Creative Brief → Asset Generation → Campaign Assembly → Consistency Check → Human Review. Unlike DD#3's interview space (no developer APIs), content generation APIs are production-ready. Total generation time: 1–3 minutes. Total cost: ~$1–4. The pipeline runs in a Cloudflare Queue Consumer (15-minute execution limit), avoiding the 30-second Worker CPU limit.
+
+**5. What are the ethical considerations around AI-generated marketing content?**
+
+Four pillars: (1) **Disclosure** — AI generation recorded in provenance, platform-specific labels honored. (2) **Commercial safety** — prefer commercially safe image sources, all assets in R2 with provenance. (3) **Truthfulness** — all claims traceable to Hypothesis Card/Discovery Summary, no fabricated stats or quotes. (4) **Copyright** — honestly: purely AI-generated content likely has no copyright protection under current law. For disposable validation campaigns, this is acceptable. Phase 2 adds mandatory human editing. FTC Section 5, California AI Transparency Act (SB 942), and platform policies are all addressed.
+
+**6. How does the story framework output inform messaging and creative direction?**
+
+The Messaging Matrix maps all 5 Venture Narrative elements to specific CampaignPackage outputs: Hero → targeting, Struggle → pain headlines, Stakes → urgency hooks, Breakthrough → value props, Moment → CTA framing. Each archetype emphasizes different elements (e.g., `priced_waitlist` uses all 5 as Primary; `fake_door` uses only Struggle as Primary). The mapping is deterministic and produces archetype-appropriate copy automatically.
+
+---
+
+## 15.5. Answering DD#3's Open Questions
+
+DD#3 Section 15 identified 5 open questions for this deep dive:
+
+**7. How does the Venture Narrative (DD#1) inform campaign messaging and creative direction?**
+
+Through the **Messaging Matrix** (Section 4). Hero → targeting spec and audience description. Struggle (functional/emotional/opportunity pain) → pain-point headlines and problem-aware ad copy. Stakes (failure + success) → urgency hooks and transformation messaging. Breakthrough → value propositions, headline, subheadline. Moment → CTA framing and timeliness hooks. The matrix also varies emphasis by archetype — `fake_door` only uses Struggle as primary, while `priced_waitlist` uses all five.
+
+**8. Which interview insights feed directly into ad copy generation?**
+
+`top_quotes` → social proof quotes and testimonial ad variants. `pain_dimensions` → calibrated copy by dimension (functional → rational, emotional → empathetic, opportunity → urgency). `signal_patterns` → messaging theme selection and keyword targeting. `wtp_signal` → price anchoring language and CTA specificity. `icp_refinements` → targeting spec adjustments. All mapped in the Tier 2 generation model (Section 5).
+
+**9. How are customer quotes from discovery interviews used as social proof on landing pages?**
+
+**Verbatim only** from `discovery_summary.top_quotes`. Anonymized attribution ("Marketing Manager, B2B SaaS" not "Jane Smith, Acme Corp"). Each quote is tagged with its pain dimension (functional/emotional/opportunity cost) so the pipeline places it in the right context. Consent is tracked. In Tier 1 (no Discovery Summary), social proof is **omitted** rather than fabricated.
+
+**10. What content formats work best for each test category?**
+
+**Demand Signal** (fake_door, waitlist, content_magnet): Short-form ads, simple landing pages, email capture focus. Meta/Google optimized for impressions and clicks. **Willingness to Pay** (priced_waitlist, presale): Long-form LP with pricing, trust signals, payment flow. Google Search for intent. **Solution Validation** (service_pilot, concierge): Relationship-building content, detailed service descriptions, scheduling CTAs. LinkedIn/email for professional audiences. Full per-archetype specifications in Section 7.
+
+**11. How does the Discovery Summary's pain severity scoring inform emotional tone in campaign creative?**
+
+Direct mapping via the **emotional register** (Section 5): Score 1–2 → rational tone (feature benefits, time savings). Score 3–4 → empathetic tone ("we know this is frustrating" + solution positioning). Score 5 → urgent/fear tone ("you can't afford to keep doing this" + immediate CTA). The CampaignPackage `tone` object records the pain severity and register, and the pipeline uses this to calibrate all copy generation. Default for Tier 1 (no Discovery Summary): pain_severity = 3, empathetic register.
+
+---
+
+## 16. Recommendations for Functional Spec v2.0
+
+1. **Add `campaign_package` TEXT column** to experiments table — stores the full CampaignPackage artifact (see Schema Sketch in Section 6.5)
+
+2. **Add `ventures` table:** `id`, `name`, `brand_profile` (JSON), `brand_profile_version` (integer, auto-incremented on update), `created_at`, `updated_at`. Add `venture_id TEXT REFERENCES ventures(id)` to experiments table.
+
+3. **Add `campaign_package` to PATCH /experiments/:id updatable fields.** Enforce write invariant: reject direct `copy_pack`/`creative_brief` updates when `campaign_package` is non-null.
+
+4. **Add async campaign generation:** `POST /experiments/:id/generate-campaign-package` enqueues to Cloudflare Queue, returns `202 Accepted`. Queue Consumer executes the 7-step pipeline. `GET /experiments/:id/campaign-package/status` for polling.
+
+5. **Extend landing page template** to consume `social_proof` and `tone` fields from CampaignPackage.
+
+6. **Store generated creative assets in R2** using existing `generateAssetKey()` pattern — CampaignPackage stores R2 keys, not image data.
+
+7. **Add content generation event types to event_log:** `campaign_gen_started`, `campaign_gen_step_completed`, `campaign_gen_completed`, `campaign_gen_failed`, `campaign_package_approved`.
+
+8. **Add platform-specific creative spec validation** (character counts, aspect ratios) to the consistency check step.
+
+9. **Expand `metrics_daily.source` documentation and any reporting code** to recognize: `facebook`, `google`, `tiktok`, `linkedin`, `reddit`, `twitter`, `email`, `manual`.
+
+10. **Add `provenance.generation_tier` (1 or 2) and `provenance.brand_profile_version`** to CampaignPackage schema for reproducibility and audit trail.
+
+---
+
+## 17. Open Questions for Deep Dive #5
+
+Deep Dive #5 covers **Landing Page Automation** — the Step 5 deployment. Questions the Campaign Factory raises for DD#5:
+
+- How does the CampaignPackage inform landing page template selection and generation?
+- What A/B test structure does the landing page implement from `campaign_package.ab_variants`?
+- How do landing page signal capture mechanisms differ by archetype?
+- What is the automation boundary between CampaignPackage and actual landing page deployment?
+- How does the landing page consume `channel_variants` for consistent messaging?
+- When a campaign PIVOTs, does the landing page auto-update from the regenerated CampaignPackage?

--- a/docs/methodology/05-deep-dive-landing-page-automation.md
+++ b/docs/methodology/05-deep-dive-landing-page-automation.md
@@ -1,0 +1,1373 @@
+# Deep Dive #5: Landing Page Automation & Generation — The Launchpad
+
+> **Source:** New document (DD#5)
+> **Document Type:** Deep Dive Working Document
+> **Series:** SC Validation Methodology
+> **Date:** March 2, 2026
+> **Status:** Complete — pending functional spec integration
+> **Parent:** SC Validation Methodology — Strategy Session (March 2026)
+> **Prior:** Deep Dive #4: AI-Generated Marketing Content at Scale — The Campaign Factory
+
+---
+
+# 1. Purpose & Scope
+
+This deep dive defines **The Launchpad** — the Step 5 system in the SC validation workflow that transforms a Campaign Package into a deployed, signal-capturing landing page. It specifies how landing pages are automatically generated from structured data, how per-archetype template architecture replaces the current single-template approach, and how A/B testing, channel-aware personalization, and signal capture integrate into the existing Astro + Cloudflare stack.
+
+**What this document covers:**
+
+- Why a single landing page template does not serve 7 archetypes with different signal capture needs
+- A component-based template architecture for Astro 5 that maps each archetype to a template with shared layout + archetype-specific sections
+- Per-archetype template specifications: required sections, form fields, CTA patterns, content blocks, and signal capture events
+- How the CampaignPackage's `copy_pack`, `social_proof`, `tone`, `channel_variants`, and `ab_variants` fields flow into the landing page
+- Client-side A/B testing via hash-based variant assignment — no third-party tools
+- Channel-aware landing pages that customize the experience per traffic source using UTM parameters
+- Signal capture architecture: event tracking per archetype, integration with `event_log`, and how signals feed `metrics_daily`
+- Technology landscape assessment: why custom Astro templates are correct and landing page builders are wrong for SC
+- The automation boundary: what is automated vs. what requires human input
+- PIVOT handling: how landing pages respond to campaign pivots and CampaignPackage regeneration
+- Schema changes and API endpoints needed for the functional spec v2.0
+- Open questions for Deep Dive #6 (Measurement & Decision System)
+
+**Relationship to DD#1 (The Venture Narrative):**
+
+The Hypothesis Card's narrative elements reach the landing page through the CampaignPackage's CopyPack — headlines from The Struggle, urgency from The Stakes, value props from The Breakthrough, CTA framing from The Moment. The Launchpad consumes these through structured data, not by accessing the Hypothesis Card directly. The landing page is the last link in the chain: Hypothesis Card --> CampaignPackage --> Landing Page.
+
+**Relationship to DD#2 (The Validation Ladder):**
+
+DD#2 defines per-archetype landing page specs for all 7 archetypes — required sections, CTA patterns, form fields, and signal capture mechanisms. The current single template at `[slug].astro` handles only two modes: email capture (free) and Stripe redirect (priced). The Launchpad evolves this into a per-archetype template system that implements DD#2's specifications.
+
+**Relationship to DD#3 (The Discovery Engine):**
+
+The Discovery Summary's `top_quotes` appear on the landing page as social proof (via the CampaignPackage's `social_proof` field). The `pain_severity` score calibrates the page's emotional register through the CampaignPackage's `tone` field. Discovery data reaches the landing page indirectly, mediated by the Campaign Factory.
+
+**Relationship to DD#4 (The Campaign Factory):**
+
+The CampaignPackage is the Launchpad's primary input. DD#4 Section 17 raised six open questions about the CampaignPackage-to-landing-page boundary — this document answers all six. The CampaignPackage's `copy_pack` populates page content, `social_proof` populates testimonial sections, `tone` calibrates styling, `channel_variants` enable per-source customization, and `ab_variants` drive client-side A/B testing.
+
+**The 10 questions this document answers:**
+
+From the Strategy Session (4):
+
+1. How do we automate landing page generation aligned to test types?
+2. How do landing pages leverage the marketing assets produced for campaigns?
+3. What is the minimum viable landing page system for validation?
+4. How does this integrate with the existing pattern library concept in the functional spec?
+
+From DD#4's Open Questions (6):
+
+5. How does the CampaignPackage inform landing page template selection and generation?
+6. What A/B test structure does the landing page implement from `campaign_package.ab_variants`?
+7. How do landing page signal capture mechanisms differ by archetype?
+8. What is the automation boundary between CampaignPackage and actual landing page deployment?
+9. How does the landing page consume `channel_variants` for consistent messaging?
+10. When a campaign PIVOTs, does the landing page auto-update from the regenerated CampaignPackage?
+
+---
+
+# 2. The Landing Page Problem
+
+## Why a Single Template Does Not Work
+
+The current landing page template (`apps/sc-web/src/pages/e/[slug].astro`) handles all experiments with one structure:
+
+```
+Headline --> Subheadline --> [Price badge if priced] --> Value Props --> [Payment CTA | Email Form]
+```
+
+This template serves two modes: email capture (for `waitlist`, `fake_door`, `content_magnet`) and Stripe redirect (for `priced_waitlist`, `presale`). It does not differentiate between archetypes. The problems:
+
+1. **Missing sections.** DD#2 specifies archetype-specific sections: `content_magnet` needs a resource preview, `concierge` needs a service delivery process overview, `service_pilot` needs a pilot program description with scarcity signal. The current template has none of these.
+
+2. **Missing form fields.** `concierge` and `service_pilot` need qualification/screening questions. `content_magnet` needs different post-submission behavior (immediate download vs. thank-you page). The current form is email + name + company for all archetypes.
+
+3. **Missing signal capture.** The current template logs no events to `event_log`. There is no `page_view` tracking, no `form_start` tracking, no distinction between signal types per archetype. DD#2's metrics depend on these signals.
+
+4. **No social proof section.** DD#4's CampaignPackage includes `social_proof` with verbatim quotes from discovery interviews. The current template has no mechanism to display these.
+
+5. **No A/B testing.** DD#4's `ab_variants` specify variant-specific headlines, CTAs, and hero content. The current template renders one version for all visitors.
+
+6. **No channel awareness.** DD#4's `channel_variants` provide per-channel copy optimized for each traffic source. The current template ignores UTM parameters for content customization.
+
+## Why Custom Design Does Not Scale
+
+At \$300-500 per test, custom landing page design is impossible:
+
+| Approach                                  | Cost                            | Time                      | Per-Test Feasibility                             |
+| ----------------------------------------- | ------------------------------- | ------------------------- | ------------------------------------------------ |
+| Agency landing page design                | \$2,000-10,000                  | 1-3 weeks                 | No — exceeds entire test budget                  |
+| Freelance landing page                    | \$500-1,500                     | 3-7 days                  | No — equals or exceeds test budget               |
+| Landing page builder (Unbounce/Instapage) | \$99-199/month + setup time     | 2-4 hours per page        | Marginal — recurring cost, no data ownership     |
+| Custom Astro templates (SC approach)      | \$0 incremental (already built) | Minutes (data population) | Yes — templates built once, reused per archetype |
+
+The Launchpad's approach: **build 7 archetype templates once, populate them from CampaignPackage data automatically.** The incremental cost of each new landing page is zero — the template exists, the data comes from the Campaign Factory, and deployment is a database write + cache invalidation.
+
+---
+
+# 3. Template Architecture
+
+## Design Principles
+
+1. **Component-based.** Shared layout components (header, footer, form, social proof) + archetype-specific section components. DRY across archetypes.
+
+2. **Data-driven.** Templates consume structured data from the CampaignPackage. No hardcoded copy. No per-experiment template editing.
+
+3. **Progressive enhancement.** Base template works with just `copy_pack` (backward compatible with existing experiments). Enhanced features (social proof, A/B testing, channel awareness) activate when the corresponding CampaignPackage fields are present.
+
+4. **Mobile-first.** DD#2 specifies mobile-first for all archetypes — the majority of ad traffic arrives on mobile. Templates use responsive Tailwind classes.
+
+5. **Performance-oriented.** Astro's zero-JS-by-default architecture means landing pages ship minimal client-side JavaScript. Only the signal capture script, A/B variant logic, and form handling need JS — everything else is server-rendered HTML.
+
+## File Structure
+
+```
+apps/sc-web/src/
+  layouts/
+    Base.astro                    -- Existing base layout (unchanged)
+    LandingBase.astro             -- New: shared landing page layout (meta tags, tracking script, footer)
+  components/
+    landing/
+      HeroSection.astro           -- Headline + subheadline + hero image
+      ValueProps.astro            -- Value proposition list (3-5 bullets)
+      SocialProof.astro           -- Discovery quotes section
+      PricingSection.astro        -- Price display with tier options
+      LeadCaptureForm.astro       -- Email + optional fields (name, company)
+      QualificationForm.astro     -- Extended form with screening questions
+      ContentPreview.astro        -- Resource preview for content_magnet
+      ProcessSteps.astro          -- "How it works" 3-step process
+      FaqSection.astro            -- Frequently asked questions
+      RefundPolicy.astro          -- Refund policy display (presale)
+      PilotDetails.astro          -- Pilot program specifics (service_pilot)
+      PaymentCta.astro            -- Stripe checkout CTA
+      SignalCapture.astro         -- Client-side event tracking script (island)
+      AbVariantWrapper.astro      -- A/B variant assignment + rendering
+  pages/
+    e/
+      [slug].astro                -- Existing: evolves to archetype-aware router
+      [slug]/
+        thank-you.astro           -- Existing: post-submission confirmation
+        payment.astro             -- Existing: Stripe checkout redirect
+```
+
+## Archetype Router
+
+The existing `[slug].astro` page evolves from a monolithic template into an archetype-aware router. It reads the experiment's archetype and delegates to the appropriate section composition:
+
+```astro
+---
+// [slug].astro — Archetype Router
+import LandingBase from '../../layouts/LandingBase.astro';
+import { getExperimentBySlug } from '../../lib/api';
+import { resolvePageConfig } from '../../lib/landing';
+
+const { slug } = Astro.params;
+if (!slug) return Astro.redirect('/404');
+
+const experiment = await getExperimentBySlug(slug);
+if (!experiment || !['launch', 'run'].includes(experiment.status)) {
+  return Astro.redirect('/404');
+}
+
+// Parse structured data from experiment
+const copyPack = experiment.copy_pack ? JSON.parse(experiment.copy_pack) : null;
+const campaignPackage = experiment.campaign_package
+  ? JSON.parse(experiment.campaign_package)
+  : null;
+const pageConfig = experiment.page_config
+  ? JSON.parse(experiment.page_config)
+  : null;
+
+// Resolve page configuration: pageConfig overrides > archetype defaults
+const config = resolvePageConfig(experiment.archetype, pageConfig, campaignPackage);
+---
+
+<LandingBase
+  title={copyPack?.meta_title || experiment.name}
+  description={copyPack?.meta_description || ''}
+  ogTitle={copyPack?.og_title}
+  ogDescription={copyPack?.og_description}
+  experiment={experiment}
+  config={config}
+>
+  <!-- Sections rendered based on config.sections array -->
+  <!-- Each archetype has a default section order -->
+  <!-- See Section 4 for per-archetype specifications -->
+</LandingBase>
+```
+
+## The `resolvePageConfig` Function
+
+This function merges archetype defaults with experiment-level overrides and CampaignPackage data. It is the central point where all landing page configuration converges.
+
+```typescript
+// lib/landing.ts
+
+interface PageConfig {
+  archetype: string
+  sections: string[] // Ordered list of section component names
+  formFields: string[] // Which form fields to display
+  ctaStyle: 'email' | 'payment' | 'schedule' | 'download'
+  showPricing: boolean
+  showSocialProof: boolean
+  showFaq: boolean
+  showRefundPolicy: boolean
+  showProcessSteps: boolean
+  showContentPreview: boolean
+  showPilotDetails: boolean
+  signalEvents: string[] // Which events to track
+  abEnabled: boolean
+  channelAware: boolean
+}
+
+const ARCHETYPE_DEFAULTS: Record<string, PageConfig> = {
+  fake_door: {
+    archetype: 'fake_door',
+    sections: ['hero', 'value_props', 'lead_capture'],
+    formFields: ['email'],
+    ctaStyle: 'email',
+    showPricing: false,
+    showSocialProof: false,
+    showFaq: false,
+    showRefundPolicy: false,
+    showProcessSteps: false,
+    showContentPreview: false,
+    showPilotDetails: false,
+    signalEvents: ['page_view', 'form_start', 'form_submit'],
+    abEnabled: true,
+    channelAware: true,
+  },
+  // ... defaults for all 7 archetypes (see Section 4)
+}
+
+function resolvePageConfig(
+  archetype: string,
+  overrides: Partial<PageConfig> | null,
+  campaignPackage: CampaignPackage | null
+): PageConfig {
+  const defaults = ARCHETYPE_DEFAULTS[archetype]
+
+  // Enable social proof only if CampaignPackage has quotes
+  const hasSocialProof = campaignPackage?.social_proof?.quotes?.length > 0
+
+  // Enable A/B testing only if CampaignPackage has variants
+  const hasAbVariants = campaignPackage?.ab_variants?.length > 0
+
+  return {
+    ...defaults,
+    showSocialProof: hasSocialProof,
+    abEnabled: hasAbVariants,
+    ...(overrides || {}),
+  }
+}
+```
+
+## Backward Compatibility
+
+The architecture preserves backward compatibility with existing experiments:
+
+- Experiments without a `campaign_package` continue to work — the template falls back to `copy_pack` data, matching current behavior.
+- Experiments without a `page_config` use archetype defaults.
+- The existing `copy_pack` column remains the primary content source for the landing page. When a CampaignPackage is present, `copy_pack` is a projection from it (per DD#4's write invariant).
+- No migration is required for existing experiments. They render using the default section composition for their archetype, which for `waitlist` and `priced_waitlist` produces output functionally equivalent to the current template.
+
+---
+
+# 4. Per-Archetype Template Specifications
+
+Each archetype maps to a section composition, form configuration, CTA pattern, and signal capture event list. These specifications implement DD#2's per-archetype landing page specs.
+
+---
+
+## 4.1 `fake_door` — Demand Signal
+
+**Template goal:** Minimal page. Present the value proposition above the fold. Single CTA. Fastest possible load. Test whether anyone cares enough to leave their email.
+
+**Sections (ordered):**
+
+1. `HeroSection` — Headline + subheadline. No hero image required. Clean, focused.
+2. `ValueProps` — 3 bullet points (functional benefit, emotional benefit, differentiation). Icon + text.
+3. `LeadCaptureForm` — Email only. Single field. CTA button.
+
+**Form fields:** `email` only.
+
+**CTA pattern:** "Get Notified" / "Join the Waitlist" / "Notify Me When It Launches"
+
+**Post-submission:** Redirect to thank-you page. Message: "Thanks! We'll notify you when we launch." No timeline promise. No product access.
+
+**Signal capture events:**
+
+| Event         | Trigger                            | Event Data                            |
+| ------------- | ---------------------------------- | ------------------------------------- |
+| `page_view`   | Page load                          | `{ archetype, variant_id, channel }`  |
+| `form_start`  | First interaction with email field | `{ field: "email" }`                  |
+| `form_submit` | Form submitted successfully        | `{ email_hash, variant_id, channel }` |
+
+**Content from CampaignPackage:**
+
+| CampaignPackage Field   | Landing Page Element    |
+| ----------------------- | ----------------------- |
+| `copy_pack.headline`    | HeroSection headline    |
+| `copy_pack.subheadline` | HeroSection subheadline |
+| `copy_pack.value_props` | ValueProps bullets      |
+| `copy_pack.cta_text`    | Form submit button text |
+
+**What is NOT shown:** Pricing, social proof, FAQ, process steps, content preview. This is the lightest-weight page.
+
+---
+
+## 4.2 `waitlist` — Demand Signal
+
+**Template goal:** Expanded product description with email capture. More context than fake_door. Visitor understands the product concept and actively joins a waitlist.
+
+**Sections (ordered):**
+
+1. `HeroSection` — Headline + subheadline + optional hero image (from `asset_references`).
+2. `ValueProps` — 3-5 features/benefits with descriptions.
+3. `SocialProof` — Discovery quotes (if Tier 2 CampaignPackage). Omitted if Tier 1.
+4. `LeadCaptureForm` — Email + name. Optional company (if `copy_pack.show_company !== false`).
+5. `FaqSection` — Optional. 3-5 common questions.
+
+**Form fields:** `email` (required), `name` (optional), `company` (optional, B2B only).
+
+**CTA pattern:** "Join the Waitlist" / "Reserve Your Spot" / "Get Early Access"
+
+**Post-submission:** Thank-you page with estimated timeline and option to share.
+
+**Signal capture events:**
+
+| Event          | Trigger                      | Event Data                            |
+| -------------- | ---------------------------- | ------------------------------------- |
+| `page_view`    | Page load                    | `{ archetype, variant_id, channel }`  |
+| `scroll_depth` | 25%, 50%, 75%, 100% of page  | `{ depth_pct }`                       |
+| `form_start`   | First form field interaction | `{ field }`                           |
+| `form_submit`  | Form submitted               | `{ email_hash, variant_id, channel }` |
+
+**Content from CampaignPackage:**
+
+| CampaignPackage Field   | Landing Page Element                         |
+| ----------------------- | -------------------------------------------- |
+| `copy_pack.headline`    | HeroSection headline                         |
+| `copy_pack.subheadline` | HeroSection subheadline                      |
+| `copy_pack.body_copy`   | Problem/solution narrative below hero        |
+| `copy_pack.value_props` | ValueProps bullets                           |
+| `copy_pack.cta_text`    | Form submit button text                      |
+| `social_proof.quotes`   | SocialProof section (anonymized attribution) |
+| `tone.register`         | CSS class modifier for emotional styling     |
+
+---
+
+## 4.3 `content_magnet` — Demand Signal
+
+**Template goal:** Content-focused page with resource preview. Visitor downloads a free resource in exchange for email.
+
+**Sections (ordered):**
+
+1. `HeroSection` — Headline focused on the resource value ("The Freelancer's Tax Deduction Checklist").
+2. `ContentPreview` — Resource preview: table of contents, sample page image, or 3 key takeaways.
+3. `ValueProps` — 3 learning outcomes or takeaways from the resource.
+4. `LeadCaptureForm` — Email only. CTA: "Download Free Guide."
+5. `FaqSection` — Optional.
+
+**Form fields:** `email` (required).
+
+**CTA pattern:** "Download Free Guide" / "Get the Checklist" / "Access the Template"
+
+**Post-submission:** Immediate delivery — either inline download link on thank-you page or email with attachment/link.
+
+**Signal capture events:**
+
+| Event                  | Trigger                                   | Event Data                            |
+| ---------------------- | ----------------------------------------- | ------------------------------------- |
+| `page_view`            | Page load                                 | `{ archetype, variant_id, channel }`  |
+| `content_preview_view` | ContentPreview section enters viewport    | `{}`                                  |
+| `form_start`           | First form field interaction              | `{ field }`                           |
+| `form_submit`          | Form submitted                            | `{ email_hash, variant_id, channel }` |
+| `resource_downloaded`  | Download link clicked (on thank-you page) | `{ resource_id }`                     |
+
+**Additional configuration:** The `page_config` must include a `resource_url` field pointing to the downloadable resource (R2 key or external URL). The thank-you page renders a download button linked to this URL.
+
+---
+
+## 4.4 `priced_waitlist` — Willingness to Pay
+
+**Template goal:** Product page with prominent pricing. Visitor sees the price BEFORE the CTA. Signup implies price acceptance.
+
+**Sections (ordered):**
+
+1. `HeroSection` — Headline + subheadline. Transformation-focused.
+2. `ValueProps` — 3-5 features that justify the price point.
+3. `PricingSection` — Clear, unambiguous pricing. If testing tiers, show all tiers.
+4. `SocialProof` — Prior test numbers or discovery quotes.
+5. `LeadCaptureForm` — Email + name. CTA includes price reference.
+6. `FaqSection` — Pricing-related questions (refund policy, what is included, billing frequency).
+
+**Form fields:** `email` (required), `name` (optional), `pricing_tier` (optional — radio buttons if testing tiers).
+
+**CTA pattern:** "Join the Waitlist - \$X/mo" / "Reserve Your Spot at \$X" / "Get Early Access at Launch Price"
+
+**Post-submission:** Thank-you page confirming the price they will pay and estimated launch timeline.
+
+**Signal capture events:**
+
+| Event                 | Trigger                        | Event Data                                               |
+| --------------------- | ------------------------------ | -------------------------------------------------------- |
+| `page_view`           | Page load                      | `{ archetype, variant_id, channel }`                     |
+| `pricing_view`        | PricingSection enters viewport | `{ price_cents, tier }`                                  |
+| `pricing_tier_select` | User selects a pricing tier    | `{ tier, price_cents }`                                  |
+| `scroll_depth`        | 25%, 50%, 75%, 100%            | `{ depth_pct }`                                          |
+| `form_start`          | First form field interaction   | `{ field }`                                              |
+| `form_submit`         | Form submitted                 | `{ email_hash, variant_id, channel, tier, price_cents }` |
+
+**Content from CampaignPackage:**
+
+| CampaignPackage Field    | Landing Page Element                     |
+| ------------------------ | ---------------------------------------- |
+| `copy_pack.pricing_copy` | PricingSection description               |
+| `copy_pack.urgency_hook` | Urgency banner or badge                  |
+| `copy_pack.value_props`  | ValueProps bullets (price-justifying)    |
+| `copy_pack.cta_text`     | Form submit button text (includes price) |
+| `social_proof.quotes`    | SocialProof section                      |
+
+---
+
+## 4.5 `presale` — Willingness to Pay
+
+**Template goal:** Full sales page with Stripe Checkout integration. Longest-form page. Visitor reads, decides, pays.
+
+**Sections (ordered):**
+
+1. `HeroSection` — Headline + subheadline. Transformation-focused, high urgency.
+2. `ValueProps` — 5 features with benefit descriptions.
+3. `ProcessSteps` — "How it works" — 3-step visual process.
+4. `PricingSection` — Price with Stripe Buy button.
+5. `SocialProof` — Waitlist count from prior tests + discovery quotes.
+6. `RefundPolicy` — "Full refund within 30 days, no questions asked."
+7. `FaqSection` — Product, pricing, refund, delivery timeline questions.
+8. `PaymentCta` — Stripe Checkout redirect. Requires `stripe_price_id` and `stripe_product_id`.
+
+**Form fields:** None (payment form is Stripe-hosted).
+
+**CTA pattern:** "Buy Now - \$X" / "Pre-Order for \$X" / "Get Lifetime Access for \$X"
+
+**Post-submission:** Stripe success redirect to confirmation page with receipt, expected delivery timeline, and "what happens next."
+
+**Signal capture events:**
+
+| Event              | Trigger                            | Event Data                            |
+| ------------------ | ---------------------------------- | ------------------------------------- |
+| `page_view`        | Page load                          | `{ archetype, variant_id, channel }`  |
+| `scroll_depth`     | 25%, 50%, 75%, 100%                | `{ depth_pct }`                       |
+| `pricing_view`     | PricingSection enters viewport     | `{ price_cents }`                     |
+| `payment_start`    | User clicks Stripe Checkout button | `{ price_cents, variant_id }`         |
+| `payment_complete` | Stripe webhook confirms payment    | `{ stripe_payment_id, amount_cents }` |
+| `payment_failed`   | Stripe reports failure             | `{ error_code }`                      |
+
+---
+
+## 4.6 `concierge` — Solution Validation
+
+**Template goal:** Service-focused page with application/signup flow. Emphasizes the outcome and the founder's direct involvement.
+
+**Sections (ordered):**
+
+1. `HeroSection` — Outcome-focused headline ("Get X Without Doing Y").
+2. `ProcessSteps` — "How it works" — 3 steps showing the service delivery process.
+3. `ValueProps` — 3-5 deliverables the customer receives.
+4. `SocialProof` — Credibility: prior validation numbers, founder bio, or discovery quotes.
+5. `PricingSection` — Optional (can be free for first customers).
+6. `QualificationForm` — Extended form with screening questions for ICP fit.
+7. `FaqSection` — Service delivery, time commitment, what happens after signup.
+
+**Form fields:** `email` (required), `name` (required), `company` (required for B2B), plus 2-3 screening questions from `page_config.screening_questions`.
+
+**CTA pattern:** "Apply Now" / "Get Started" / "Book Your Spot"
+
+**Post-submission:** Personal welcome — thank-you page promises personal founder outreach within 24 hours.
+
+**Signal capture events:**
+
+| Event                         | Trigger                           | Event Data                                               |
+| ----------------------------- | --------------------------------- | -------------------------------------------------------- |
+| `page_view`                   | Page load                         | `{ archetype, variant_id, channel }`                     |
+| `scroll_depth`                | 25%, 50%, 75%, 100%               | `{ depth_pct }`                                          |
+| `form_start`                  | First form field interaction      | `{ field }`                                              |
+| `screening_question_answered` | Each screening question completed | `{ question_id, answer_hash }`                           |
+| `form_submit`                 | Application submitted             | `{ email_hash, variant_id, channel, screening_answers }` |
+
+**Additional configuration:** `page_config.screening_questions` is an array of `{ id, label, type, options? }` objects defining the qualification questions. These are rendered by the `QualificationForm` component.
+
+---
+
+## 4.7 `service_pilot` — Solution Validation
+
+**Template goal:** Beta/pilot program page. Emphasizes early access, limited capacity, and the exchange of feedback for value.
+
+**Sections (ordered):**
+
+1. `HeroSection` — Beta program framing with value emphasis.
+2. `PilotDetails` — Pilot timeline, what is included, what is expected (feedback commitment), capacity limit.
+3. `ValueProps` — 3-5 pilot deliverables.
+4. `ProcessSteps` — Pilot journey: apply --> onboard --> use --> feedback.
+5. `PricingSection` — Pilot pricing (discounted from launch price).
+6. `SocialProof` — Prior concierge customer testimonials if available, or prior validation numbers.
+7. `QualificationForm` — Application form with screening questions. Communicate scarcity honestly.
+8. `FaqSection` — Pilot program specifics.
+
+**Form fields:** `email` (required), `name` (required), `company` (required for B2B), plus screening questions from `page_config.screening_questions`.
+
+**CTA pattern:** "Apply for the Beta" / "Join the Pilot Program" / "Become a Founding Member"
+
+**Post-submission:** Personal outreach — thank-you page mentions limited spots and promises personal contact.
+
+**Signal capture events:**
+
+| Event                         | Trigger                              | Event Data                                               |
+| ----------------------------- | ------------------------------------ | -------------------------------------------------------- |
+| `page_view`                   | Page load                            | `{ archetype, variant_id, channel }`                     |
+| `scroll_depth`                | 25%, 50%, 75%, 100%                  | `{ depth_pct }`                                          |
+| `pilot_details_view`          | PilotDetails section enters viewport | `{}`                                                     |
+| `form_start`                  | First form field interaction         | `{ field }`                                              |
+| `screening_question_answered` | Each screening question completed    | `{ question_id, answer_hash }`                           |
+| `form_submit`                 | Application submitted                | `{ email_hash, variant_id, channel, screening_answers }` |
+
+---
+
+## 4.8 Summary Table — All Archetypes
+
+| Archetype         | Sections                                                                                  | Form Fields                     | CTA Style          | Signal Events | Social Proof |
+| ----------------- | ----------------------------------------------------------------------------------------- | ------------------------------- | ------------------ | ------------- | ------------ |
+| `fake_door`       | hero, value_props, form                                                                   | email                           | email              | 3             | No           |
+| `waitlist`        | hero, value_props, social_proof, form, faq                                                | email, name, company            | email              | 4             | If Tier 2    |
+| `content_magnet`  | hero, content_preview, value_props, form                                                  | email                           | download           | 5             | No           |
+| `priced_waitlist` | hero, value_props, pricing, social_proof, form, faq                                       | email, name, tier               | email (with price) | 6             | If Tier 2    |
+| `presale`         | hero, value_props, process, pricing, social_proof, refund, faq, payment                   | (Stripe-hosted)                 | payment            | 6             | Yes          |
+| `concierge`       | hero, process, value_props, social_proof, pricing, qualification_form, faq                | email, name, company, screening | application        | 5             | If available |
+| `service_pilot`   | hero, pilot_details, value_props, process, pricing, social_proof, qualification_form, faq | email, name, company, screening | application        | 6             | If available |
+
+---
+
+# 5. CampaignPackage to Landing Page Data Flow
+
+## Data Flow Diagram
+
+```
+CampaignPackage (experiment.campaign_package)
+  |
+  |-- copy_pack -----------------> Page content (headline, subheadline, value_props, CTA text)
+  |-- creative_brief ------------> Hero image selection, visual style
+  |-- social_proof.quotes[] -----> SocialProof component (verbatim, anonymized)
+  |-- tone ----------------------> CSS class modifier (rational | empathetic | urgent)
+  |-- channel_variants[] --------> Per-source content overrides (via UTM matching)
+  |-- ab_variants[] -------------> Client-side variant assignment (headline/CTA swaps)
+  |-- asset_references[] --------> Hero image, section images (R2 URLs)
+  |-- targeting ------------------> (Not used by landing page — campaign-side only)
+  |-- budget --------------------> (Not used by landing page — campaign-side only)
+  |-- provenance ----------------> (Not used by landing page — audit trail only)
+```
+
+## Field-Level Mapping
+
+### copy_pack --> Page Content
+
+| CopyPack Field   | Component                                                | Element                       |
+| ---------------- | -------------------------------------------------------- | ----------------------------- |
+| `headline`       | `HeroSection`                                            | `<h1>`                        |
+| `subheadline`    | `HeroSection`                                            | `<p>` subtitle                |
+| `body_copy`      | Below hero (waitlist, presale, concierge, service_pilot) | Narrative paragraph(s)        |
+| `cta_text`       | `LeadCaptureForm` / `PaymentCta`                         | Submit button text            |
+| `urgency_hook`   | `HeroSection` or `PricingSection`                        | Urgency badge/banner          |
+| `value_props[]`  | `ValueProps`                                             | Bullet list with check icons  |
+| `social_proof`   | `SocialProof` (fallback — simple string)                 | Quote or count display        |
+| `pricing_copy`   | `PricingSection`                                         | Price description and context |
+| `feature_list[]` | `ValueProps` (extended mode)                             | Feature grid or list          |
+| `refund_policy`  | `RefundPolicy`                                           | Policy text block             |
+
+### social_proof --> SocialProof Component
+
+When `campaign_package.social_proof` is present (Tier 2 only), the `SocialProof` component renders each quote with:
+
+- Verbatim quote text (no modification)
+- Anonymized attribution (e.g., "Marketing Manager, B2B SaaS (50-200 employees)")
+- Pain dimension indicator (not shown to visitor, used for placement logic)
+
+**Placement logic:** Quotes tagged with `functional` pain dimension appear near feature descriptions. Quotes tagged with `emotional` appear near the CTA. Quotes tagged with `opportunity_cost` appear near urgency hooks. If only one quote exists, it appears above the form.
+
+### tone --> Visual Styling
+
+The `tone.register` field controls CSS class modifiers applied to the page:
+
+| Register     | CSS Class         | Visual Effect                                                              |
+| ------------ | ----------------- | -------------------------------------------------------------------------- |
+| `rational`   | `tone-rational`   | Clean blue/gray palette, professional typography, subdued CTAs             |
+| `empathetic` | `tone-empathetic` | Warm palette, slightly larger type, supportive language framing            |
+| `urgent`     | `tone-urgent`     | High-contrast palette, bold CTAs, urgency badges, countdown-style elements |
+
+These classes modify Tailwind utility compositions at the layout level:
+
+```css
+/* Example: CTA button styling per register */
+.tone-rational .cta-primary {
+  @apply bg-blue-600 hover:bg-blue-700;
+}
+.tone-empathetic .cta-primary {
+  @apply bg-teal-600 hover:bg-teal-700;
+}
+.tone-urgent .cta-primary {
+  @apply bg-red-600 hover:bg-red-700 font-bold;
+}
+```
+
+### asset_references --> Images
+
+R2 keys in `asset_references` are resolved to public URLs at render time. The first image with a matching aspect ratio becomes the hero image. Additional images populate section illustrations.
+
+```typescript
+// lib/landing.ts
+function resolveAssetUrl(r2Key: string): string {
+  return `https://assets.siliconcrane.com/${r2Key}`
+}
+```
+
+---
+
+# 6. A/B Testing Implementation
+
+## Design Constraints
+
+- **No third-party tools.** No Optimizely, VWO, Google Optimize. These add cost, complexity, and external dependencies to a \$300-500 validation test.
+- **Simple.** Two variants maximum per test. Hash-based assignment. No multi-armed bandits, no Bayesian optimization. Those are DD#6 territory when SC has 50+ tests of calibration data.
+- **Deterministic.** Same visitor always sees same variant. No variant flipping between visits.
+- **Stateless on server.** Variant assignment happens client-side. No server-side session state.
+
+## Hash-Based Variant Assignment
+
+When a visitor arrives, the landing page assigns them to a variant using a deterministic hash of their visitor ID and the experiment slug:
+
+```javascript
+// SignalCapture.astro (client-side script)
+
+function assignVariant(visitorId, experimentSlug, variantCount) {
+  // Create a deterministic hash from visitor ID + experiment slug
+  const input = `${visitorId}:${experimentSlug}`
+  let hash = 0
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i)
+    hash = (hash << 5) - hash + char
+    hash = hash & hash // Convert to 32-bit integer
+  }
+  // Map hash to variant index (0 to variantCount-1)
+  return Math.abs(hash) % variantCount
+}
+
+// Usage
+const visitorId = getOrCreateId('sc_visitor_id')
+const variantIndex = assignVariant(visitorId, experimentSlug, abVariants.length)
+const activeVariant = abVariants[variantIndex]
+```
+
+**Why this works for validation testing:**
+
+- At \$300-500 budgets generating 150-600 clicks, the sample sizes are small. A simple 50/50 split with a deterministic hash provides even distribution at these volumes.
+- The hash function does not need cryptographic security — it needs consistent distribution. The djb2-style hash above provides adequate uniformity for two-variant splits.
+- The visitor ID is stored in `localStorage`, ensuring the same visitor sees the same variant across page visits.
+
+## What Variants Can Change
+
+DD#4's `ab_variants` specify a `changes` object that overrides specific CopyPack fields. The landing page applies these overrides at render time:
+
+```typescript
+interface AbVariant {
+  variant_id: string // "A" or "B"
+  hypothesis: string // "Pain-led headline converts better than solution-led"
+  changes: {
+    headline?: string // Override copy_pack.headline
+    subheadline?: string // Override copy_pack.subheadline
+    cta_text?: string // Override copy_pack.cta_text
+    urgency_hook?: string // Override copy_pack.urgency_hook
+    hero_image?: string // Override primary asset_reference
+  }
+}
+```
+
+**Scope limits:** A/B variants can change headlines, subheadlines, CTAs, urgency hooks, and hero images. They cannot change page structure (sections), form fields, pricing, or archetype. Structural changes require a new experiment, not an A/B variant.
+
+## Variant Tracking
+
+Every signal event includes the `variant_id` in its `event_data`:
+
+```javascript
+logEvent('form_submit', {
+  email_hash: hashEmail(email),
+  variant_id: activeVariant.variant_id, // "A" or "B"
+  channel: utmParams.utm_source || 'direct',
+})
+```
+
+This allows the metrics pipeline to compute per-variant conversion rates, enabling the measurement system (DD#6) to determine which variant won.
+
+## No Flicker Protocol
+
+A/B variant assignment must happen before the page renders visible content to prevent "flicker" (showing variant A briefly before swapping to variant B):
+
+1. The `AbVariantWrapper` component runs variant assignment in the Astro frontmatter (server-side) when possible.
+2. For SSR pages, the variant is determined server-side using the visitor cookie value (if present in the request).
+3. For first-time visitors (no cookie), the page renders with variant A by default, and client-side JS immediately assigns and applies the correct variant before the first paint completes.
+4. A `<style>` block hides the hero section with `opacity: 0` until variant assignment completes, then reveals it with a CSS transition. Maximum hide duration: 100ms.
+
+```html
+<style>
+  .ab-pending {
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+  .ab-resolved {
+    opacity: 1;
+  }
+</style>
+```
+
+---
+
+# 7. Channel-Aware Landing Pages
+
+## The Problem
+
+A visitor arriving from a Facebook ad has different context than a visitor arriving from Google Search. The Facebook visitor saw a specific ad with specific messaging. The Google visitor searched for specific keywords. The LinkedIn visitor is in a professional context. Showing all visitors the same landing page wastes the context established by the ad.
+
+## How Channel Variants Work
+
+DD#4's CampaignPackage includes `channel_variants[]` — per-channel formatted content with channel-specific headlines, descriptions, and CTAs. The landing page reads the visitor's UTM parameters and applies the matching channel variant's copy.
+
+**Matching logic:**
+
+```javascript
+function resolveChannelVariant(utmSource, channelVariants) {
+  if (!utmSource || !channelVariants || channelVariants.length === 0) {
+    return null // Use default copy_pack
+  }
+
+  // Normalize source to channel name
+  const sourceToChannel = {
+    facebook: 'facebook',
+    fb: 'facebook',
+    instagram: 'facebook', // Same Meta platform
+    ig: 'facebook',
+    google: 'google',
+    gclid: 'google', // Google auto-tagging
+    linkedin: 'linkedin',
+    li: 'linkedin',
+    tiktok: 'tiktok',
+    reddit: 'reddit',
+    twitter: 'twitter',
+    x: 'twitter',
+  }
+
+  const channel = sourceToChannel[utmSource.toLowerCase()]
+  if (!channel) return null
+
+  return channelVariants.find((v) => v.channel === channel) || null
+}
+```
+
+**Override behavior:** When a channel variant is found, its fields override the default `copy_pack` values:
+
+| Channel Variant Field | Overrides CopyPack Field |
+| --------------------- | ------------------------ |
+| `headline`            | `copy_pack.headline`     |
+| `description`         | `copy_pack.subheadline`  |
+| `cta`                 | `copy_pack.cta_text`     |
+
+Fields not present in the channel variant fall through to the default `copy_pack`. This means channel variants only need to specify what differs — the rest comes from the base copy.
+
+## UTM Parameter Handling
+
+The existing `[slug].astro` template already extracts UTM parameters from the URL query string. The Launchpad extends this:
+
+1. **Capture on arrival.** All 5 UTM parameters (`utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`) are extracted from the URL and stored in `sessionStorage`.
+
+2. **Persist across pages.** If the visitor navigates from the landing page to the thank-you page or payment page, UTM parameters are appended to internal links automatically.
+
+3. **Include in form submissions.** All UTM parameters are sent with the lead capture API call (existing behavior — no change needed).
+
+4. **Include in events.** The `utm_source` is included in every `event_log` entry (existing behavior — the `SignalCapture` component extends this to include all 5 parameters in `event_data`).
+
+5. **Naming convention.** All UTM values are stored and transmitted in lowercase. This prevents data fragmentation from inconsistent casing (`Facebook` vs. `facebook` vs. `FACEBOOK`).
+
+## Message Match
+
+"Message match" is the principle that the landing page headline should closely match the ad copy the visitor clicked on. Channel variants implement this automatically: the same CampaignPackage that generates the Facebook ad headline also generates the Facebook channel variant's landing page headline. Because both originate from the same source data and generation pipeline, message match is structural, not accidental.
+
+---
+
+# 8. Signal Capture Architecture
+
+## Event Tracking Overview
+
+Every landing page emits events to the `event_log` table via `POST /events`. The Launchpad standardizes which events are tracked per archetype, what data is included, and how events flow into `metrics_daily` for threshold evaluation.
+
+## Standard Event Types
+
+| Event Type                    | Fired When                       | All Archetypes?          | Event Data                                     |
+| ----------------------------- | -------------------------------- | ------------------------ | ---------------------------------------------- |
+| `page_view`                   | Page loads                       | Yes                      | `{ archetype, variant_id, channel, referrer }` |
+| `scroll_depth`                | Visitor scrolls to 25/50/75/100% | All except fake_door     | `{ depth_pct }`                                |
+| `form_start`                  | First form field interaction     | All with forms           | `{ field }`                                    |
+| `form_submit`                 | Form submitted successfully      | All with forms           | `{ email_hash, variant_id, channel }`          |
+| `payment_start`               | Stripe Checkout button clicked   | presale only             | `{ price_cents, variant_id }`                  |
+| `payment_complete`            | Stripe webhook confirms payment  | presale only             | `{ stripe_payment_id, amount_cents }`          |
+| `payment_failed`              | Stripe reports failure           | presale only             | `{ error_code }`                               |
+| `pricing_view`                | Pricing section enters viewport  | priced_waitlist, presale | `{ price_cents, tier }`                        |
+| `pricing_tier_select`         | User selects a pricing tier      | priced_waitlist          | `{ tier, price_cents }`                        |
+| `content_preview_view`        | Content preview section visible  | content_magnet only      | `{}`                                           |
+| `resource_downloaded`         | Download link clicked            | content_magnet only      | `{ resource_id }`                              |
+| `screening_question_answered` | Screening question completed     | concierge, service_pilot | `{ question_id }`                              |
+| `pilot_details_view`          | Pilot details section visible    | service_pilot only       | `{}`                                           |
+
+## The SignalCapture Component
+
+The `SignalCapture` component is a client-side Astro island that handles all event tracking. It is included in every landing page via `LandingBase.astro`.
+
+```astro
+---
+// components/landing/SignalCapture.astro
+interface Props {
+  experimentId: string;
+  slug: string;
+  archetype: string;
+  variantId: string;
+  apiUrl: string;
+  signalEvents: string[];
+}
+
+const { experimentId, slug, archetype, variantId, apiUrl, signalEvents } = Astro.props;
+---
+
+<script is:inline define:vars={{ experimentId, slug, archetype, variantId, apiUrl, signalEvents }}>
+  // Visitor and session management
+  function getOrCreateId(key) {
+    let id = localStorage.getItem(key);
+    if (!id) {
+      id = `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+      localStorage.setItem(key, id);
+    }
+    return id;
+  }
+
+  const visitorId = getOrCreateId('sc_visitor_id');
+  const sessionId = getOrCreateId('sc_session_id');
+
+  // UTM parameter extraction
+  const urlParams = new URLSearchParams(window.location.search);
+  const utmSource = (urlParams.get('utm_source') || '').toLowerCase() || null;
+
+  // Event logging function
+  function logEvent(eventType, eventData = {}) {
+    if (!signalEvents.includes(eventType)) return;
+
+    const payload = {
+      experiment_id: experimentId,
+      event_type: eventType,
+      event_data: JSON.stringify({
+        ...eventData,
+        archetype,
+        variant_id: variantId,
+        channel: utmSource || 'direct',
+      }),
+      session_id: sessionId,
+      visitor_id: visitorId,
+      utm_source: utmSource,
+      url: window.location.href,
+      referrer: document.referrer || null,
+    };
+
+    // Use sendBeacon for reliability (survives page navigation)
+    const blob = new Blob([JSON.stringify(payload)], { type: 'application/json' });
+    navigator.sendBeacon(`${apiUrl}/events`, blob);
+  }
+
+  // Automatic page_view on load
+  if (signalEvents.includes('page_view')) {
+    logEvent('page_view', { referrer: document.referrer });
+  }
+
+  // Scroll depth tracking
+  if (signalEvents.includes('scroll_depth')) {
+    const thresholds = [25, 50, 75, 100];
+    const fired = new Set();
+
+    function checkScrollDepth() {
+      const scrollPct = Math.round(
+        (window.scrollY / (document.body.scrollHeight - window.innerHeight)) * 100
+      );
+      for (const threshold of thresholds) {
+        if (scrollPct >= threshold && !fired.has(threshold)) {
+          fired.add(threshold);
+          logEvent('scroll_depth', { depth_pct: threshold });
+        }
+      }
+    }
+
+    window.addEventListener('scroll', checkScrollDepth, { passive: true });
+  }
+
+  // Section viewport tracking (IntersectionObserver)
+  if (signalEvents.includes('pricing_view')
+      || signalEvents.includes('content_preview_view')
+      || signalEvents.includes('pilot_details_view')) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const eventType = entry.target.dataset.trackView;
+          if (eventType) {
+            logEvent(eventType, {});
+            observer.unobserve(entry.target);
+          }
+        }
+      });
+    }, { threshold: 0.5 });
+
+    document.querySelectorAll('[data-track-view]').forEach((el) => {
+      observer.observe(el);
+    });
+  }
+
+  // Form interaction tracking
+  if (signalEvents.includes('form_start')) {
+    let formStarted = false;
+    document.querySelectorAll('form input, form select, form textarea').forEach((field) => {
+      field.addEventListener('focus', () => {
+        if (!formStarted) {
+          formStarted = true;
+          logEvent('form_start', { field: field.name || field.id });
+        }
+      }, { once: true });
+    });
+  }
+
+  // Expose logEvent for form submit handlers
+  window.__sc = { logEvent };
+</script>
+```
+
+## How Signals Feed metrics_daily
+
+The `event_log` table captures granular events. The `metrics_daily` table captures daily aggregates. The bridge between them:
+
+| event_log Events                               | metrics_daily Column |
+| ---------------------------------------------- | -------------------- |
+| `page_view` count (deduplicated by session_id) | `sessions`           |
+| `form_submit` + `payment_complete` count       | `conversions`        |
+| `payment_complete` sum of `amount_cents`       | `revenue_cents`      |
+
+The `impressions`, `clicks`, and `spend_cents` columns in `metrics_daily` come from ad platform data imports (external to the landing page). The landing page contributes `sessions`, `conversions`, and `revenue_cents`.
+
+**Aggregation logic:** A scheduled job (or the metrics import endpoint) aggregates `event_log` entries into `metrics_daily` rows. The aggregation groups by `experiment_id`, `date` (from `created_at`), and `source` (from `utm_source`). Derived metrics (`cvr_bp`, `cpl_cents`, etc.) are recomputed using the formulas in tech spec Section 3.6.
+
+## Per-Archetype Signal Summary
+
+| Archetype         | Conversion Event   | Secondary Signals                                                                |
+| ----------------- | ------------------ | -------------------------------------------------------------------------------- |
+| `fake_door`       | `form_submit`      | `page_view`, `form_start`                                                        |
+| `waitlist`        | `form_submit`      | `page_view`, `scroll_depth`, `form_start`                                        |
+| `content_magnet`  | `form_submit`      | `page_view`, `content_preview_view`, `resource_downloaded`                       |
+| `priced_waitlist` | `form_submit`      | `page_view`, `pricing_view`, `pricing_tier_select`, `scroll_depth`               |
+| `presale`         | `payment_complete` | `page_view`, `pricing_view`, `payment_start`, `scroll_depth`                     |
+| `concierge`       | `form_submit`      | `page_view`, `scroll_depth`, `screening_question_answered`                       |
+| `service_pilot`   | `form_submit`      | `page_view`, `pilot_details_view`, `scroll_depth`, `screening_question_answered` |
+
+---
+
+# 9. Technology Landscape
+
+## Landing Page Builder Assessment
+
+The market for landing page builders is mature and well-funded. Key players in 2026:
+
+| Platform  | Pricing     | AI Features                                             | API           | Data Ownership  | Custom Templates       |
+| --------- | ----------- | ------------------------------------------------------- | ------------- | --------------- | ---------------------- |
+| Unbounce  | \$99-625/mo | Smart Traffic AI (auto-routes visitors to best variant) | Limited       | Platform-hosted | Yes (drag-and-drop)    |
+| Instapage | \$99-499/mo | AI content generation, heatmaps                         | Limited       | Platform-hosted | Yes (drag-and-drop)    |
+| Leadpages | \$37-79/mo  | AI-assisted copy                                        | No public API | Platform-hosted | Yes (template library) |
+| Carrd     | \$9-49/yr   | None                                                    | No API        | Platform-hosted | Minimal                |
+| Framer    | \$5-30/mo   | AI site generation                                      | No API        | Platform-hosted | Full design control    |
+
+## Why Custom Astro Templates are Correct for SC
+
+### Arguments Against Third-Party Builders
+
+1. **Data ownership.** Landing page builders host the pages on their infrastructure. Lead capture data, event tracking, and visitor behavior data live in their systems. SC needs this data in D1 and `event_log` for threshold evaluation, kill criteria checking, and the Decision Framework. Extracting data from a builder adds integration complexity and creates vendor dependency.
+
+2. **Cost at scale.** Even at \$37/month (Leadpages), that is \$444/year — more than the budget for a single validation test. For VaaS operating multiple ventures simultaneously, builder costs compound. Custom templates cost \$0 per page after the initial build.
+
+3. **Archetype specificity.** No builder knows about SC's 7 archetypes, the CampaignPackage schema, or the signal capture requirements. Every page would need manual customization, defeating the purpose of automation.
+
+4. **A/B testing integration.** Builders offer their own A/B testing, but it does not integrate with SC's `ab_variants` structure, `event_log`, or `metrics_daily`. Using a builder's A/B testing means maintaining two measurement systems.
+
+5. **UTM/channel awareness.** Builders do not support the dynamic content replacement based on `channel_variants` that SC requires. Some support basic UTM parameter capture, but none support swapping headlines and CTAs based on traffic source.
+
+6. **Deployment control.** SC deploys via Cloudflare Pages with SSR. Landing pages must be served from the same domain (`siliconcrane.com/e/[slug]`) for analytics continuity and trust signals. Builder-hosted pages live on separate domains or subdomains, breaking the analytics chain.
+
+### What Builders Do Well (That SC Does Not Need)
+
+- **Visual drag-and-drop editing.** SC does not need this — templates are pre-built, content comes from structured data.
+- **Conversion optimization for mature products.** Unbounce's Smart Traffic AI is impressive for optimizing existing high-traffic pages. SC's validation tests generate 150-600 clicks — not enough traffic for sophisticated optimization.
+- **Template marketplaces.** SC has 7 specific archetypes with specific requirements. A generic template marketplace adds noise, not value.
+
+### The Decision
+
+**Build custom Astro templates. Consume data from the CampaignPackage. Track signals through event_log. Deploy via Cloudflare Pages.**
+
+This is the same build-vs-buy conclusion DD#3 reached for interview platforms and DD#4 reached for content generation: build the orchestration layer (templates, data flow, tracking), consume APIs for generation (Claude for copy, image APIs for visuals). The templates are SC's proprietary IP — they encode the Validation Ladder's archetype requirements into reusable components.
+
+---
+
+# 10. Automation Boundary
+
+## What is Automated
+
+| Step                       | Automation Level | How It Works                                                                              |
+| -------------------------- | ---------------- | ----------------------------------------------------------------------------------------- |
+| Template selection         | Fully automated  | Archetype on the experiment record determines which sections render                       |
+| Content population         | Fully automated  | CopyPack fields from CampaignPackage populate template components                         |
+| Social proof insertion     | Fully automated  | Discovery quotes from CampaignPackage `social_proof` render in SocialProof component      |
+| Tone styling               | Fully automated  | `tone.register` applies CSS class modifier to page                                        |
+| A/B variant assignment     | Fully automated  | Hash-based client-side assignment from `ab_variants`                                      |
+| Channel variant resolution | Fully automated  | UTM parameter matching to `channel_variants`                                              |
+| Signal capture             | Fully automated  | SignalCapture component tracks all configured events                                      |
+| Image resolution           | Fully automated  | R2 keys from `asset_references` resolved to public URLs                                   |
+| Deployment                 | Fully automated  | Page is live as soon as experiment status changes to `launch` — SSR serves it dynamically |
+
+## What Requires Human Input
+
+| Step                  | Human Role                                                                          | Why It Cannot Be Automated                                                                        |
+| --------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Final page review     | Operator checks the rendered page before campaign launch                            | Content may have AI generation artifacts, image placement issues, or archetype-inappropriate copy |
+| Screening questions   | Operator defines qualification questions for concierge and service_pilot archetypes | Questions are venture-specific and require domain knowledge                                       |
+| Resource upload       | Operator creates and uploads the downloadable resource for content_magnet           | The resource itself is not generated by the pipeline (though AI can draft it)                     |
+| Stripe configuration  | Operator sets up Stripe product and price for presale archetypes                    | Payment configuration requires Stripe dashboard access and pricing decisions                      |
+| Custom sections       | Operator can add custom content blocks via `page_config.custom_sections`            | Venture-specific content that does not fit standard components                                    |
+| Page config overrides | Operator can override archetype defaults via `page_config`                          | Edge cases where the default section composition does not fit                                     |
+
+## The Deployment Pipeline
+
+```
+Step 1: CampaignPackage approved (DD#4 Step 7)
+     |
+Step 2: Archetype template auto-selected from experiment.archetype
+     |
+Step 3: CopyPack + social_proof + tone + channel_variants + ab_variants
+         extracted from CampaignPackage
+     |
+Step 4: page_config checked for overrides (screening questions,
+         resource_url, custom sections)
+     |
+Step 5: Preview URL generated: /e/[slug]?preview=true
+         (renders page with status check bypassed for operator review)
+     |
+Step 6: Operator reviews preview
+         - Checks content accuracy
+         - Verifies form fields
+         - Tests mobile rendering
+         - Confirms signal capture (test event fired)
+     |
+Step 7: Operator transitions experiment status to "launch"
+     |
+Step 8: Landing page is live at /e/[slug]
+         SSR serves it dynamically from experiment data
+     |
+Step 9: Campaign goes live, driving traffic to the page
+```
+
+**Time from CampaignPackage approval to live page:** Minutes, not hours or days. The bottleneck is human review (Step 6), not technical deployment.
+
+## Preview Mode
+
+A preview mode allows operators to review the landing page before launch:
+
+```typescript
+// [slug].astro — Preview mode check
+const isPreview = Astro.url.searchParams.get('preview') === 'true'
+
+if (!experiment || (!['launch', 'run'].includes(experiment.status) && !isPreview)) {
+  return Astro.redirect('/404')
+}
+```
+
+Preview mode bypasses the `launch`/`run` status check but otherwise renders the exact same page visitors will see. Preview URLs are not indexed (meta robots noindex) and not linked from anywhere public.
+
+---
+
+# 11. PIVOT Handling
+
+## What Happens When a Campaign PIVOTs
+
+The strategy session's Pivot Routing Table (Section: Decision Framework) defines pivot scenarios. When the verdict is PIVOT and the pivot routes to Step 4 (new Campaign Package) or Step 5 (revised landing page):
+
+### Scenario: CampaignPackage Regenerated (Pivot to Step 4)
+
+When the CampaignPackage is regenerated after a pivot:
+
+1. **Landing page auto-updates.** Because the landing page reads from `experiment.campaign_package` and `experiment.copy_pack` at render time (SSR), the updated CampaignPackage content appears on the next page load. No redeployment is needed.
+
+2. **URL preserved.** The experiment slug does not change. The same URL continues to work. This means existing bookmarks, cached links, and social shares still reach the updated page.
+
+3. **A/B variant tracking resets.** The pivot event is logged to `event_log` with type `experiment_pivoted`. The measurement system (DD#6) uses this timestamp to segment pre-pivot and post-pivot conversion data. Pre-pivot variant performance is archived, not discarded — it is useful for understanding what did not work.
+
+4. **Channel variants update.** If the regenerated CampaignPackage includes new `channel_variants`, the landing page immediately serves the updated per-channel copy.
+
+5. **Social proof preserved or replaced.** If the Discovery Summary has not changed, the same `social_proof` quotes persist. If the pivot includes new discovery data, the regenerated CampaignPackage will include updated quotes.
+
+### Scenario: Landing Page Revised (Pivot to Step 5)
+
+When the pivot routes specifically to Step 5 (e.g., "Good CTR, poor landing page CVR"):
+
+1. The operator modifies `page_config` to adjust sections, form fields, or CTA patterns.
+2. Alternatively, the CampaignPackage is regenerated with revised copy (new headline, different value framing).
+3. The experiment ID gains a pivot suffix (e.g., `SC-2026-042a` becomes `SC-2026-042b` per strategy session Pivot Rules).
+4. A new experiment record may be created (preserving the original for comparison) OR the existing record is updated with the new CampaignPackage.
+
+### PIVOT Event Logging
+
+```json
+{
+  "event_type": "experiment_pivoted",
+  "event_data": {
+    "pivot_from": "SC-2026-042a",
+    "pivot_to": "SC-2026-042b",
+    "pivot_reason": "poor_landing_page_cvr",
+    "pivot_routing": "step_5",
+    "changes": ["headline", "cta_text", "value_props"],
+    "pre_pivot_metrics": {
+      "sessions": 1200,
+      "conversions": 8,
+      "cvr_bp": 67
+    }
+  }
+}
+```
+
+### What Does NOT Auto-Update
+
+- **Stripe configuration.** If the pivot changes the price (for `priced_waitlist` or `presale`), the Stripe product and price must be updated manually.
+- **Screening questions.** If the pivot changes the ICP for `concierge` or `service_pilot`, the operator must update `page_config.screening_questions`.
+- **Downloadable resource.** If the pivot changes the content magnet, the operator must upload a new resource and update `page_config.resource_url`.
+
+---
+
+# 12. Answering the Strategy Session Questions
+
+The strategy session (Deep Dive #5 section) identified four questions. Here are the answers:
+
+**1. How do we automate landing page generation aligned to test types?**
+
+Through **per-archetype template composition** in the Astro component architecture (Section 3). Each of the 7 archetypes maps to a specific set of sections, form fields, CTA patterns, and signal capture events (Section 4). The archetype on the experiment record determines which template composition renders. Content comes from the CampaignPackage's `copy_pack` field, which is populated by the Campaign Factory (DD#4). The Launchpad adds no manual content creation — it consumes structured data and renders it through archetype-appropriate components.
+
+**2. How do landing pages leverage the marketing assets produced for campaigns?**
+
+Through the **CampaignPackage-to-landing-page data flow** (Section 5). The CampaignPackage's `copy_pack` provides all text content (headlines, subheadlines, value props, CTAs). The `social_proof` field provides discovery interview quotes. The `asset_references` array provides R2 keys for generated images (hero images, section illustrations). The `tone` field controls visual styling (rational, empathetic, or urgent register). The `channel_variants` provide per-traffic-source copy overrides. Every element of the landing page traces back to the Campaign Factory's output.
+
+**3. What is the minimum viable landing page system for validation?**
+
+The current single template (`[slug].astro`) plus the existing `copy_pack` data — which is already working. The minimum viable evolution is adding **signal capture** (the `SignalCapture` component) to track `page_view`, `form_start`, and `form_submit` events. Without event tracking, the landing page cannot feed `metrics_daily`, and the Decision Framework cannot evaluate thresholds. The archetype-specific templates, A/B testing, and channel awareness are Phase 2 enhancements that improve signal quality but are not strictly required for the first validation test.
+
+**4. How does this integrate with the existing pattern library concept in the functional spec?**
+
+The functional spec (FR-501) references a "pattern library" — a collection of reusable landing page patterns. The Launchpad **replaces** the pattern library concept with a **component library** — Astro components (`HeroSection`, `ValueProps`, `SocialProof`, `LeadCaptureForm`, etc.) that compose into per-archetype templates. The distinction: a pattern library implies visual design patterns chosen by a designer. A component library implies functional components selected by archetype. The archetype determines the composition; the CampaignPackage provides the content. No design decisions at deployment time.
+
+---
+
+# 12.5. Answering DD#4's Open Questions
+
+DD#4 Section 17 identified 6 open questions for this deep dive:
+
+**5. How does the CampaignPackage inform landing page template selection and generation?**
+
+The CampaignPackage does not select the template — the **archetype** on the experiment record selects the template. The CampaignPackage populates the selected template with content. This is a deliberate separation: archetype determines structure (which sections, which form, which signals), CampaignPackage determines content (what the headline says, what the value props are, what the CTA text is). The `resolvePageConfig` function (Section 3) merges archetype defaults with CampaignPackage-driven overrides (e.g., enabling social proof only when quotes exist). See Section 5 for the full data flow mapping.
+
+**6. What A/B test structure does the landing page implement from `campaign_package.ab_variants`?**
+
+Hash-based client-side variant assignment (Section 6). The visitor's `localStorage` visitor ID is hashed with the experiment slug to produce a deterministic variant index. Each variant can override `headline`, `subheadline`, `cta_text`, `urgency_hook`, and `hero_image` from the default `copy_pack`. Every signal event includes the `variant_id`, enabling per-variant conversion rate calculation. Variant assignment is deterministic (same visitor always sees same variant), stateless on the server, and flicker-free (variant resolved before first paint).
+
+**7. How do landing page signal capture mechanisms differ by archetype?**
+
+Each archetype tracks a different set of events, reflecting its unique signal capture requirements (Section 8). All archetypes track `page_view` and `form_start`. Demand Signal archetypes add `scroll_depth`. WTP archetypes add `pricing_view` and `pricing_tier_select`. `presale` adds `payment_start`, `payment_complete`, and `payment_failed`. Solution Validation archetypes add `screening_question_answered`. `content_magnet` adds `content_preview_view` and `resource_downloaded`. The conversion event itself differs: `form_submit` for all non-payment archetypes, `payment_complete` for `presale`. See Section 4.8 for the per-archetype summary.
+
+**8. What is the automation boundary between CampaignPackage and actual landing page deployment?**
+
+Section 10 defines the boundary. Fully automated: template selection, content population, social proof insertion, tone styling, A/B variant assignment, channel variant resolution, signal capture, image resolution, and deployment. Requires human input: final page review, screening question definition, resource upload, Stripe configuration, custom sections, and page config overrides. The deployment pipeline (Section 10) takes the page from CampaignPackage approval to live URL in minutes — the bottleneck is human review, not technical work.
+
+**9. How does the landing page consume `channel_variants` for consistent messaging?**
+
+Through UTM parameter matching (Section 7). The landing page reads `utm_source` from the URL query string, normalizes it to a channel name (e.g., `fb` --> `facebook`), and looks up the matching entry in `campaign_package.channel_variants[]`. If found, the channel variant's `headline`, `description`, and `cta` override the default `copy_pack` values. This produces "message match" — the landing page headline mirrors the ad copy the visitor clicked. Channel variants are optional; pages without them render the default `copy_pack` for all traffic sources.
+
+**10. When a campaign PIVOTs, does the landing page auto-update from the regenerated CampaignPackage?**
+
+Yes — because the landing page is SSR (server-side rendered) and reads from `experiment.campaign_package` at request time (Section 11). When the CampaignPackage is regenerated after a pivot, the updated content appears on the next page load. No redeployment, no cache invalidation (Cloudflare's edge cache respects short TTLs for SSR pages), no URL change. A/B variant tracking is segmented by the pivot timestamp — pre-pivot and post-pivot conversion data are analyzed separately. The pivot event is logged for audit and analysis. Items that do NOT auto-update: Stripe configuration, screening questions, and downloadable resources — these require manual updates.
+
+---
+
+# 13. Landing Page Schema Sketch
+
+## New `page_config` Column
+
+Add a `page_config` TEXT (JSON) column to the experiments table. This stores per-experiment landing page configuration overrides.
+
+```json
+{
+  "page_config": {
+    "type": "object",
+    "required": false,
+    "description": "Per-experiment landing page configuration. Overrides archetype defaults.",
+    "properties": {
+      "sections": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Ordered list of section component names. Overrides archetype default."
+      },
+      "form_fields": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Form fields to display. Overrides archetype default."
+      },
+      "cta_style": {
+        "type": "string",
+        "enum": ["email", "payment", "schedule", "download"],
+        "description": "CTA interaction pattern. Overrides archetype default."
+      },
+      "screening_questions": {
+        "type": "array",
+        "items": {
+          "id": { "type": "string" },
+          "label": { "type": "string" },
+          "type": { "type": "string", "enum": ["text", "select", "radio", "textarea"] },
+          "options": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Options for select/radio types"
+          },
+          "required": { "type": "boolean", "default": false }
+        },
+        "maxItems": 5,
+        "description": "Qualification questions for concierge and service_pilot archetypes."
+      },
+      "resource_url": {
+        "type": "string",
+        "description": "R2 key or external URL for downloadable resource (content_magnet)."
+      },
+      "pricing_tiers": {
+        "type": "array",
+        "items": {
+          "name": { "type": "string" },
+          "price_cents": { "type": "integer" },
+          "description": { "type": "string" },
+          "stripe_price_id": { "type": "string" }
+        },
+        "maxItems": 3,
+        "description": "Pricing tier options for priced_waitlist with tier testing."
+      },
+      "faq_items": {
+        "type": "array",
+        "items": {
+          "question": { "type": "string" },
+          "answer": { "type": "string" }
+        },
+        "maxItems": 10,
+        "description": "FAQ entries. If empty, FAQ section is hidden."
+      },
+      "custom_sections": {
+        "type": "array",
+        "items": {
+          "position": { "type": "string", "enum": ["before_form", "after_hero", "before_faq"] },
+          "content": { "type": "string", "maxLength": 5000 },
+          "title": { "type": "string" }
+        },
+        "maxItems": 3,
+        "description": "Custom content blocks inserted at specified positions."
+      },
+      "show_company_field": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether to show the company field in forms. Default true for B2B."
+      },
+      "signal_events": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Additional signal events to track beyond archetype defaults."
+      }
+    }
+  }
+}
+```
+
+## Existing Columns — No Migration Required
+
+The Launchpad consumes data from columns that already exist or are recommended by DD#1-DD#4:
+
+| Column              | Status                  | Used By Launchpad                                  |
+| ------------------- | ----------------------- | -------------------------------------------------- |
+| `archetype`         | Exists                  | Template selection                                 |
+| `copy_pack`         | Exists                  | Page content (backward compatible)                 |
+| `creative_brief`    | Exists                  | Image selection (via `assets` array)               |
+| `campaign_package`  | DD#4 recommendation     | Full data source (replaces copy_pack when present) |
+| `stripe_price_id`   | Exists                  | Payment CTA (presale)                              |
+| `stripe_product_id` | Exists                  | Payment CTA (presale)                              |
+| `price_cents`       | Exists                  | Price display                                      |
+| `page_config`       | **New (this document)** | Landing page overrides                             |
+
+## Migration Plan
+
+A single migration adds the `page_config` column:
+
+```sql
+-- Migration: 000N_add_page_config.sql
+ALTER TABLE experiments ADD COLUMN page_config TEXT;
+-- JSON: PageConfigSchema — per-experiment landing page configuration
+```
+
+No data migration is needed. Existing experiments have `page_config = NULL`, which causes `resolvePageConfig` to use archetype defaults — producing output functionally equivalent to the current template.
+
+---
+
+# 14. Recommendations for Functional Spec v2.0
+
+1. **Add `page_config` TEXT (JSON) column** to the experiments table (see Schema Sketch in Section 13). This stores per-experiment landing page configuration overrides, including screening questions, resource URLs, pricing tiers, FAQ items, and custom sections.
+
+2. **Evolve `[slug].astro`** from a monolithic template to an archetype-aware router that delegates to component compositions. The component library includes: `HeroSection`, `ValueProps`, `SocialProof`, `PricingSection`, `LeadCaptureForm`, `QualificationForm`, `ContentPreview`, `ProcessSteps`, `FaqSection`, `RefundPolicy`, `PilotDetails`, `PaymentCta`, `SignalCapture`, and `AbVariantWrapper`.
+
+3. **Add the `SignalCapture` component** to all landing pages. This is the highest-priority item — without event tracking, the landing page cannot feed `metrics_daily`, and the Decision Framework cannot evaluate thresholds. Even without the full archetype template system, adding `SignalCapture` to the existing template provides immediate value.
+
+4. **Add `LandingBase.astro` layout** as a shared landing page layout that handles meta tags (from CopyPack `meta_title`, `meta_description`, `og_title`, `og_description`), the `SignalCapture` component injection, and the shared footer.
+
+5. **Add preview mode** to `[slug].astro` — allow `?preview=true` to bypass the status check for operator review before launch. Preview pages should include `<meta name="robots" content="noindex">`.
+
+6. **Standardize event types** in `event_log` for landing page signals: `page_view`, `scroll_depth`, `form_start`, `form_submit`, `payment_start`, `payment_complete`, `payment_failed`, `pricing_view`, `pricing_tier_select`, `content_preview_view`, `resource_downloaded`, `screening_question_answered`, `pilot_details_view`, `experiment_pivoted`.
+
+7. **Add aggregation logic** to bridge `event_log` signals into `metrics_daily` rows. The `sessions` column is populated from deduplicated `page_view` events (by `session_id`). The `conversions` column is populated from `form_submit` events (for non-payment archetypes) and `payment_complete` events (for `presale`).
+
+8. **Add the `resolvePageConfig` function** to `apps/sc-web/src/lib/landing.ts` with archetype defaults for all 7 archetypes. This is the central configuration point for the template system.
+
+9. **Add API endpoint for page_config updates:** `PATCH /experiments/:id` should accept `page_config` as an updatable field. Validation should enforce the `PageConfigSchema` structure.
+
+10. **Extend leads API** to accept `custom_fields` for screening question responses. The `POST /leads` endpoint already accepts a `custom_fields` JSON field — ensure it stores the structured responses from `QualificationForm`.
+
+11. **Add `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`** to the `event_log` `event_data` JSON (not as top-level columns — they are already captured on leads but not on events). This enables channel-level analysis in the measurement system.
+
+---
+
+# 15. Open Questions for Deep Dive #6
+
+Deep Dive #6 covers the **Measurement & Decision System** — Step 6 in the validation workflow. Questions the Launchpad raises for DD#6:
+
+1. **How are per-variant conversion rates calculated and compared?** The landing page assigns variants and tracks `variant_id` in every event. DD#6 must define how to compute per-variant CVR, determine statistical significance at small sample sizes (20-60 conversions), and decide when to call a variant winner.
+
+2. **How does the metrics aggregation pipeline bridge event_log into metrics_daily?** The Launchpad fires granular events; `metrics_daily` stores daily aggregates. DD#6 must specify when and how aggregation runs — scheduled job, on-demand calculation, or real-time counter.
+
+3. **How does the system handle bot traffic and data quality?** The landing page includes a honeypot field on forms and uses `navigator.sendBeacon` for event tracking. DD#6 must define additional data quality checks: duplicate session detection, suspicious click patterns, known bot user agents, and the INVALID flag criteria.
+
+4. **How do pre-pivot and post-pivot metrics get segmented?** The Launchpad logs `experiment_pivoted` events with a timestamp. DD#6 must define how the Validation Report separates pre-pivot performance from post-pivot performance and whether pre-pivot data counts toward the minimum conversion threshold.
+
+5. **How is the per-channel CVR breakdowns calculated from UTM-tagged events?** The Launchpad captures `utm_source` on every event. DD#6 must define how channel-level conversion funnels are constructed and whether channel performance influences the GO/KILL/PIVOT decision or is advisory only.
+
+6. **What is the real-time monitoring approach during the test run?** The Launchpad fires events continuously during the test. DD#6 must define whether there is a real-time dashboard, alert thresholds (e.g., "zero conversions after 48 hours"), and automated Hard Kill detection from the kill criteria JSON.
+
+7. **How does the Validation Report artifact consume landing page signal data?** DD#6 must define the Validation Report schema — which signals from `event_log` are included, how funnel metrics (page_view --> form_start --> form_submit) are calculated, and how the report compares actual metrics against the Test Blueprint's thresholds.

--- a/docs/methodology/06-deep-dive-measurement-decision.md
+++ b/docs/methodology/06-deep-dive-measurement-decision.md
@@ -1,0 +1,1477 @@
+# Deep Dive #6: Measurement & Decision System — The Verdict
+
+> **Source:** New document (DD#6)
+> **Document Type:** Deep Dive Working Document
+> **Series:** SC Validation Methodology
+> **Date:** March 2, 2026
+> **Status:** Complete — pending functional spec integration
+> **Parent:** SC Validation Methodology — Strategy Session (March 2026)
+> **Prior:** Deep Dive #5: Landing Page Automation
+
+---
+
+# 1. Purpose & Scope
+
+This deep dive defines the **Measurement & Decision System** — the final two stages in the SC validation workflow (Steps 6 and 7). It specifies the measurement infrastructure, the Validation Report artifact, the enhanced Decision Memo, the threshold calibration system, automated decision support logic, the GO handoff to product development, the KILL archival protocol, and the INVALID handling process. The framework is branded **The Verdict**.
+
+The naming progression now spans the complete methodology arc: **Narrative** (story) -> **Ladder** (testing) -> **Engine** (discovery) -> **Factory** (production) -> **[DD#5]** (deployment) -> **Verdict** (measurement and decision). This is the capstone document — it closes the loop on the entire validation methodology and defines how data becomes decisions.
+
+**What this document covers:**
+
+- Why measurement for validation is fundamentally different from product analytics
+- Measurement infrastructure built on existing `metrics_daily`, `event_log`, and D1 tables
+- The Validation Report artifact (Step 6 output) — specification, schema, auto-generation logic
+- The enhanced Decision Memo artifact (Step 7 output) — structured evidence, confidence calculation, recommendation engine
+- The 3-phase threshold calibration system (fleshing out DD#2 Section 7)
+- Automated decision support — not automated decisions, but automated evidence presentation
+- INVALID handling — detection, root causes, resolution paths
+- Learning Memos and continuous improvement
+- GO handoff from Silicon Crane validation into Ventracrane product development
+- KILL archival protocol with the "kill library" for cross-venture learning
+- Explicit answers to the 5 strategy session questions for DD#6
+- Recommendations for Functional Spec v2.0
+- Complete methodology summary across all 6 deep dives
+
+**Relationship to DD#1 (The Venture Narrative):**
+
+The Hypothesis Card is the starting artifact. When a venture receives a GO verdict, the validated Hypothesis Card — enriched through discovery and confirmed by market data — becomes the foundation for the product specification. When a venture is killed, the Hypothesis Card is archived with the kill rationale for pattern recognition.
+
+**Relationship to DD#2 (The Validation Ladder):**
+
+DD#2 Section 7 defined a 3-phase calibration plan: Phase 1 (industry defaults), Phase 2 (internal benchmarking after 10+ tests), Phase 3 (dynamic calibration after 50+ tests). DD#2 explicitly stated "This is Deep Dive #6 territory — covered there in detail." This document fulfills that promise. The per-archetype thresholds from DD#2 Section 3 are the Phase 1 defaults that this document's calibration system evolves.
+
+**Relationship to DD#3 (The Discovery Engine):**
+
+The Discovery Summary's pain severity score is one of the four GO criteria (pain severity >= 3/5). The Validation Report references the Discovery Summary as qualitative evidence alongside quantitative campaign metrics.
+
+**Relationship to DD#4 (The Campaign Factory):**
+
+The Campaign Package's provenance metadata, A/B variant structure, and channel allocation data flow into the Validation Report's campaign performance analysis. The budget allocation model (75% ad spend, 15% creative buffer, 5% generation, 5% reserve) constrains the measurement infrastructure's cost expectations.
+
+**Relationship to existing infrastructure:**
+
+The system builds on top of the existing D1 schema: `metrics_daily` (daily campaign snapshots with derived metrics in basis points), `event_log` (raw events), `decision_memos` (verdict records), and `learning_memos` (weekly observations). No existing tables are replaced — they are extended and augmented.
+
+---
+
+# 2. The Measurement Challenge
+
+## Why Validation Measurement is Different
+
+Validation testing is not product analytics. The goals, constraints, sample sizes, and decision outcomes are fundamentally different.
+
+| Dimension                | Product Analytics                                       | Validation Measurement                                                          |
+| ------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **Goal**                 | Optimize a metric (conversion rate, retention, revenue) | Make a binary decision (GO / KILL / PIVOT / INVALID)                            |
+| **Sample size**          | Thousands to millions of data points                    | 15-60 conversions from \$300-500 spend                                          |
+| **Time horizon**         | Ongoing, indefinite                                     | Time-boxed: 7-30 days                                                           |
+| **Statistical standard** | p < 0.05 frequentist significance                       | Practical significance — is the signal strong enough to bet on?                 |
+| **Cost of wrong answer** | Suboptimal feature deployment                           | \$1,500 cap wasted (false positive) or killed a viable venture (false negative) |
+| **Data quality**         | Mature instrumentation, clean pipelines                 | New tracking, potential bot traffic, platform anomalies                         |
+| **Iteration**            | Continuous improvement                                  | Discrete test → decision → next test or exit                                    |
+
+## The Small Sample Reality
+
+The strategy session established the budget rationale: \$300-500 per test buys 150-600 clicks at typical \$0.50-\$2.00 CPCs. At a 10% CVR baseline, that yields 15-60 conversions. This is the data the entire decision hangs on.
+
+**What this means for statistics:**
+
+- **Frequentist significance testing (p < 0.05) is not appropriate.** To detect a meaningful difference in conversion rates with 95% confidence typically requires hundreds to thousands of conversions. We have 15-60.
+- **Bayesian approaches are appropriate.** The Beta-Binomial conjugate model works naturally with small samples: the posterior distribution is Beta(alpha + conversions, beta + sessions - conversions). With a weakly informative prior, even 20 conversions produce a useful posterior distribution.
+- **Practical significance matters more than statistical significance.** The question is not "is this CVR different from zero?" — it is "is this CVR high enough to justify building a product?"
+- **Directional confidence replaces binary significance.** Instead of "significant / not significant," the system reports "85% probability that true CVR exceeds the GO threshold" — which is actionable information.
+
+## The Asymmetric Error Cost
+
+The strategy session noted that Phase 1 thresholds should be deliberately conservative — "it is better to kill ventures that might have worked than to invest further in ventures that probably will not."
+
+This establishes a clear asymmetry:
+
+- **False positive (saying GO when the venture will fail):** Cost = remaining validation budget (\$500-1,000) plus opportunity cost of product development time. High cost.
+- **False negative (saying KILL when the venture could have worked):** Cost = the missed venture. Lower immediate cost, but accumulated false negatives reduce portfolio hit rate.
+
+Phase 1 calibration leans toward false negatives. Phase 2-3 calibration tightens as data allows more precise thresholds.
+
+---
+
+# 3. Measurement Infrastructure
+
+## Data Pipeline Architecture
+
+The measurement infrastructure consists of four stages, built on existing SC infrastructure:
+
+```
+Ad Platforms          Landing Pages           SC-API               Decision Support
+(Meta, Google,        (event_log via          (metrics_daily        (Validation Report
+ LinkedIn, etc.)       POST /events)           via POST /metrics)    + Decision Memo)
+     │                      │                       │                      │
+     ▼                      ▼                       ▼                      ▼
+┌──────────┐         ┌──────────┐            ┌──────────────┐      ┌──────────────┐
+│ Platform │         │ Real-time │            │ Daily Batch  │      │  Threshold   │
+│ APIs     │────────>│ Events   │            │ Aggregation  │─────>│  Evaluation  │
+│ (manual/ │         │ (event_  │────────────│ (metrics_    │      │  + Report    │
+│  import) │         │  log)    │ nightly    │  daily)      │      │  Generation  │
+└──────────┘         └──────────┘ rollup     └──────────────┘      └──────────────┘
+```
+
+### Stage 1: Raw Event Capture (Real-Time)
+
+**Already built.** The `event_log` table captures every landing page interaction in real-time via `POST /events`. Events include `page_view`, `form_start`, `generate_lead`, `purchase`, and custom archetype-specific events.
+
+**What already works:**
+
+- Session tracking via `session_id` and `visitor_id`
+- UTM attribution (`utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`)
+- De-duplication via `event_hash` (SHA-256)
+- Country-level geo data from Cloudflare CF-IPCountry
+
+**What needs extension for DD#6:**
+
+- New event types for measurement: `threshold_evaluation`, `validation_report_generated`, `decision_memo_created`
+- Structured `event_data` payloads for measurement events (metric snapshots, threshold comparison results)
+
+### Stage 2: Ad Platform Metrics Import (Manual / Semi-Automated)
+
+**Already built.** The `POST /metrics` endpoint accepts daily metric snapshots. The `metrics_daily` table stores raw metrics (impressions, clicks, sessions, conversions, spend_cents, revenue_cents) and derived metrics (ctr_bp, cvr_bp, cpl_cents, roas_bp) with the `source` field tracking the ad platform.
+
+**Phase 1 (now):** Manual import via the admin interface (Coda Pack or direct API calls). The operator exports daily metrics from each ad platform and imports them via `POST /metrics`.
+
+**Phase 2 (future):** Semi-automated import via ad platform APIs (Meta Marketing API, Google Ads API). A scheduled Cloudflare Worker fetches yesterday's metrics and writes to `metrics_daily`. This eliminates the manual import bottleneck but requires platform API credentials and rate limit management.
+
+### Stage 3: Daily Batch Aggregation
+
+**Already built (partially).** Derived metrics are computed on import using the `computeDerivedMetrics()` function from the tech spec (Section 3.6). All rates use basis points (100 bp = 1%).
+
+**What needs extension for DD#6:**
+
+- **Cumulative aggregation:** Sum raw metrics across all days for an experiment to produce running totals (total impressions, total clicks, total sessions, total conversions, total spend, total revenue).
+- **Cumulative derived metrics:** Recalculate derived metrics from cumulative raw totals (not averages of daily derived metrics — that produces incorrect results due to Simpson's paradox).
+- **Per-source aggregation:** Split cumulative metrics by `source` for channel-level analysis.
+- **Trend calculation:** Track whether cumulative CVR is improving, stable, or declining over the test period (useful for PIVOT decisions).
+
+### Stage 4: Threshold Evaluation & Report Generation
+
+**New (DD#6).** This is the core of The Verdict. After each daily metrics import:
+
+1. Compute cumulative metrics for the experiment
+2. Evaluate cumulative metrics against kill criteria from the Test Blueprint
+3. Check for Hard Kill triggers (strategy session criteria)
+4. Check for Soft Kill triggers
+5. Evaluate GO criteria (all four conditions from strategy session)
+6. Generate or update the draft Validation Report
+7. If a terminal condition is reached (all criteria met for GO, or a Hard Kill triggered), flag the experiment for human review
+
+This evaluation runs as part of the metrics import pipeline — not as a separate scheduled job. Every time new data arrives, the system re-evaluates.
+
+## Real-Time vs. Batch: Design Decision
+
+| Data Type            | Processing Model                  | Rationale                                                                            |
+| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------ |
+| Landing page events  | Real-time (event_log)             | Needed for live tracking, session analysis, form funnel debugging                    |
+| Ad platform metrics  | Daily batch (metrics_daily)       | Ad platforms report daily; sub-daily data is unreliable due to attribution windows   |
+| Threshold evaluation | Triggered on batch import         | Decision thresholds operate on cumulative metrics, which change daily, not per-event |
+| Validation Report    | Generated on demand / after batch | Needs cumulative data; auto-generated after each metrics import                      |
+
+The system does not attempt real-time decision-making. Campaign metrics have attribution delays (Meta reports up to 7 days after click for conversions). Evaluating thresholds on incomplete daily data produces false alarms. The daily batch model aligns with how ad platforms actually report data.
+
+---
+
+# 4. The Validation Report — Artifact Specification
+
+The **Validation Report** is the Step 6 output artifact. It is the structured summary of all campaign data, evaluated against the Test Blueprint's thresholds, with data quality verification and trend analysis. For internal Ventracrane use, it informs the Decision Memo. For VaaS clients, it is the client-facing deliverable.
+
+## What the Validation Report Contains
+
+| Section                      | Description                                                                | Source                                                       |
+| ---------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Experiment summary**       | ID, name, archetype, duration, budget, channels                            | experiments table + test_blueprint                           |
+| **Metrics summary**          | Cumulative raw + derived metrics                                           | metrics_daily (aggregated)                                   |
+| **Evidence table**           | Each archetype metric vs. its threshold, with GO/AMBER/KILL classification | metrics_daily + test_blueprint thresholds                    |
+| **Sample size verification** | Whether minimum conversion count was met                                   | metrics_daily.conversions vs. test_blueprint.min_conversions |
+| **Data quality flags**       | Bot traffic detection, tracking failures, platform anomalies               | event_log analysis + metrics_daily consistency checks        |
+| **Trend analysis**           | Are metrics improving, stable, or declining over the test period?          | metrics_daily (time series)                                  |
+| **Channel breakdown**        | Per-source metrics for multi-channel campaigns                             | metrics_daily grouped by source                              |
+| **Cost analysis**            | Total spend, CPL, ROAS, budget utilization                                 | metrics_daily.spend_cents + revenue_cents                    |
+| **Discovery context**        | Pain severity, problem confirmation, WTP signal                            | discovery_summary (if available)                             |
+| **Recommended verdict**      | System-generated recommendation based on threshold evaluation              | Automated decision support logic (Section 9)                 |
+| **Confidence assessment**    | Bayesian probability that true metrics exceed GO thresholds                | Calculated from cumulative data (Section 8)                  |
+
+## Two Completion Stages
+
+### Draft (Auto-Generated)
+
+After each metrics import, the system updates the draft Validation Report. All quantitative sections are populated automatically. The recommended verdict and confidence assessment are computed from the data. The draft is a living document during the test run.
+
+### Final (Human-Reviewed)
+
+When the test reaches a terminal condition (budget exhausted, duration expired, or Hard Kill triggered), or when the operator decides the test has sufficient data, the report is finalized. The operator reviews the auto-generated content, adds contextual notes, and locks the report. The final report becomes the input to Decision Memo creation (Step 7).
+
+**For VaaS:** The final Validation Report is the primary client deliverable. It must be professional, clear, and self-contained — a client with no SC context should be able to read it and understand what happened, what was measured, and what the data suggests.
+
+## Evidence Table Format
+
+The evidence table is the heart of the Validation Report. It compares each metric against the archetype's thresholds from DD#2.
+
+| Metric      | Value | Unit           | GO Threshold | Kill Threshold | Status | Notes                 |
+| ----------- | ----- | -------------- | ------------ | -------------- | ------ | --------------------- |
+| CVR         | 280   | bp (2.80%)     | >= 200 bp    | < 50 bp        | GO     | Exceeds target by 40% |
+| CPL         | 714   | cents (\$7.14) | <= 800       | > 2000         | GO     | Well within target    |
+| CTR         | 180   | bp (1.80%)     | >= 100 bp    | < 40 bp        | GO     | Strong ad engagement  |
+| Conversions | 42    | count          | >= 20        | < 10           | GO     | 2.1x minimum sample   |
+
+All metrics use the existing basis point and cents conventions from the `metrics_daily` schema.
+
+## Trend Analysis Method
+
+The trend analysis evaluates whether cumulative CVR is improving, stable, or declining over the test period. The method:
+
+1. Split the test duration into 3 equal periods (e.g., days 1-3, 4-6, 7-9 for a 9-day test)
+2. Calculate cumulative CVR at the end of each period
+3. Classify the trend:
+   - **Improving:** Period 3 CVR > Period 1 CVR by more than 10% relative
+   - **Declining:** Period 3 CVR < Period 1 CVR by more than 10% relative
+   - **Stable:** Within 10% relative of Period 1
+
+**Why this matters:** A declining trend suggests the initial audience was more receptive than the broader market. A test that passes GO thresholds but shows a declining trend should be noted in the report — the GO verdict holds, but the product team should expect lower conversion rates at scale.
+
+## Data Quality Flags
+
+| Flag                            | Detection Method                                       | Severity | Action                                                |
+| ------------------------------- | ------------------------------------------------------ | -------- | ----------------------------------------------------- |
+| **Bot traffic suspected**       | CTR > 5% with CVR < 0.1% (many clicks, no conversions) | High     | Investigate — may invalidate test                     |
+| **Tracking gap**                | Days with zero sessions but non-zero ad spend          | Medium   | Check tracking code deployment                        |
+| **Platform anomaly**            | Single day with metrics > 3x the daily average         | Medium   | Check for platform reporting errors                   |
+| **Attribution mismatch**        | Clicks >> sessions (> 2x)                              | Low      | Expected with attribution windows; flag if persistent |
+| **Insufficient data**           | Total sessions < 50% of archetype minimum              | High     | Test may need extension or relaunch                   |
+| **Revenue without conversions** | revenue_cents > 0 but conversions = 0                  | High     | Data integrity issue — investigate immediately        |
+
+---
+
+# 4.5. Validation Report Schema Sketch
+
+Field specification for a `validation_report` TEXT (JSON) column on the experiments table:
+
+```json
+{
+  "experiment_id": { "type": "string", "required": true },
+  "report_version": { "type": "integer", "required": true, "default": 1 },
+  "stage": { "type": "string", "enum": ["draft", "final"], "required": true },
+
+  "experiment_summary": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "name": { "type": "string" },
+      "archetype": { "type": "string" },
+      "category": { "type": "string" },
+      "start_date": { "type": "string", "format": "date" },
+      "end_date": { "type": "string", "format": "date" },
+      "duration_days": { "type": "integer" },
+      "budget_cents": { "type": "integer" },
+      "channels": { "type": "array", "items": { "type": "string" } }
+    }
+  },
+
+  "metrics_summary": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "total_impressions": { "type": "integer" },
+      "total_clicks": { "type": "integer" },
+      "total_sessions": { "type": "integer" },
+      "total_conversions": { "type": "integer" },
+      "total_spend_cents": { "type": "integer" },
+      "total_revenue_cents": { "type": "integer" },
+      "cumulative_ctr_bp": { "type": "integer" },
+      "cumulative_cvr_bp": { "type": "integer" },
+      "cumulative_cpl_cents": { "type": "integer" },
+      "cumulative_roas_bp": { "type": "integer" }
+    }
+  },
+
+  "evidence_table": {
+    "type": "array",
+    "required": true,
+    "items": {
+      "metric": { "type": "string" },
+      "value": { "type": "integer" },
+      "unit": { "type": "string" },
+      "go_threshold": { "type": "integer" },
+      "kill_threshold": { "type": "integer" },
+      "status": { "type": "string", "enum": ["go", "amber", "kill"] },
+      "notes": { "type": "string" }
+    }
+  },
+
+  "sample_size_check": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "conversions_actual": { "type": "integer" },
+      "conversions_required": { "type": "integer" },
+      "sessions_actual": { "type": "integer" },
+      "sessions_minimum": { "type": "integer" },
+      "sufficient": { "type": "boolean" }
+    }
+  },
+
+  "data_quality": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "flags": {
+        "type": "array",
+        "items": {
+          "flag": { "type": "string" },
+          "severity": { "type": "string", "enum": ["high", "medium", "low"] },
+          "detail": { "type": "string" },
+          "detected_at": { "type": "string", "format": "date" }
+        }
+      },
+      "overall_quality": {
+        "type": "string",
+        "enum": ["clean", "minor_issues", "major_issues", "unreliable"]
+      }
+    }
+  },
+
+  "trend_analysis": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "direction": { "type": "string", "enum": ["improving", "stable", "declining"] },
+      "period_1_cvr_bp": { "type": "integer" },
+      "period_2_cvr_bp": { "type": "integer" },
+      "period_3_cvr_bp": { "type": "integer" },
+      "notes": { "type": "string" }
+    }
+  },
+
+  "channel_breakdown": {
+    "type": "array",
+    "required": false,
+    "items": {
+      "source": { "type": "string" },
+      "impressions": { "type": "integer" },
+      "clicks": { "type": "integer" },
+      "sessions": { "type": "integer" },
+      "conversions": { "type": "integer" },
+      "spend_cents": { "type": "integer" },
+      "cvr_bp": { "type": "integer" },
+      "cpl_cents": { "type": "integer" }
+    }
+  },
+
+  "cost_analysis": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "total_spend_cents": { "type": "integer" },
+      "budget_utilization_pct": { "type": "integer" },
+      "cpl_cents": { "type": "integer" },
+      "roas_bp": { "type": "integer" },
+      "cost_per_session_cents": { "type": "integer" }
+    }
+  },
+
+  "discovery_context": {
+    "type": "object",
+    "required": false,
+    "properties": {
+      "pain_severity_composite": { "type": "number" },
+      "problem_confirmed": { "type": "boolean" },
+      "wtp_signal": { "type": "string" },
+      "interview_count_weighted": { "type": "number" }
+    }
+  },
+
+  "confidence_assessment": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "method": { "type": "string", "default": "bayesian_beta_binomial" },
+      "prior_alpha": { "type": "number" },
+      "prior_beta": { "type": "number" },
+      "posterior_alpha": { "type": "number" },
+      "posterior_beta": { "type": "number" },
+      "prob_exceeds_go_threshold": {
+        "type": "number",
+        "description": "P(true CVR >= GO threshold)"
+      },
+      "prob_below_kill_threshold": {
+        "type": "number",
+        "description": "P(true CVR < KILL threshold)"
+      },
+      "credible_interval_90": {
+        "type": "object",
+        "properties": {
+          "lower_bp": { "type": "integer" },
+          "upper_bp": { "type": "integer" }
+        }
+      }
+    }
+  },
+
+  "recommended_verdict": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "verdict": { "type": "string", "enum": ["GO", "KILL", "PIVOT", "INVALID"] },
+      "reasoning": { "type": "string", "maxLength": 1000 },
+      "conditions_met": {
+        "type": "array",
+        "items": {
+          "condition": { "type": "string" },
+          "met": { "type": "boolean" },
+          "detail": { "type": "string" }
+        }
+      }
+    }
+  },
+
+  "analyst_notes": { "type": "string", "required": false, "maxLength": 2000 },
+
+  "generated_at": { "type": "string", "format": "date-time" },
+  "finalized_at": { "type": "string", "format": "date-time" },
+  "finalized_by": { "type": "string" }
+}
+```
+
+---
+
+# 5. Cumulative Metrics Computation
+
+The Validation Report requires cumulative metrics across the entire test period, not just daily snapshots. This section specifies the aggregation logic.
+
+## Aggregation Query
+
+```sql
+SELECT
+  experiment_id,
+  SUM(impressions) AS total_impressions,
+  SUM(clicks) AS total_clicks,
+  SUM(sessions) AS total_sessions,
+  SUM(conversions) AS total_conversions,
+  SUM(spend_cents) AS total_spend_cents,
+  SUM(revenue_cents) AS total_revenue_cents
+FROM metrics_daily
+WHERE experiment_id = ?
+GROUP BY experiment_id
+```
+
+## Cumulative Derived Metrics
+
+Derived metrics are recalculated from cumulative raw totals — **not** averaged from daily derived metrics. This is critical because averaging ratios produces incorrect results.
+
+```typescript
+function computeCumulativeMetrics(totals: CumulativeRaw): CumulativeDerived {
+  return {
+    cumulative_ctr_bp:
+      totals.total_impressions > 0
+        ? Math.round((totals.total_clicks / totals.total_impressions) * 10000)
+        : null,
+    cumulative_cvr_bp:
+      totals.total_sessions > 0
+        ? Math.round((totals.total_conversions / totals.total_sessions) * 10000)
+        : null,
+    cumulative_cpl_cents:
+      totals.total_conversions > 0
+        ? Math.round(totals.total_spend_cents / totals.total_conversions)
+        : null,
+    cumulative_roas_bp:
+      totals.total_spend_cents > 0
+        ? Math.round((totals.total_revenue_cents / totals.total_spend_cents) * 10000)
+        : null,
+  }
+}
+```
+
+This uses the same `Math.round()` convention as the existing `computeDerivedMetrics()` function in the tech spec (Section 3.6), maintaining consistency across all metric calculations.
+
+---
+
+# 6. The Decision Memo — Enhanced Specification
+
+The existing `decision_memos` table stores GO/KILL/PIVOT/INVALID decisions with a free-text `rationale`, `key_metrics` JSON snapshot, `confidence_pct`, and `next_steps`. This is functional but minimal. DD#6 enhances the Decision Memo with structured evidence, calculated confidence, and a link to the Validation Report.
+
+## What Changes
+
+| Current (v1.0)                            | Enhanced (v2.0)                                                                | Rationale                                                |
+| ----------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| `rationale` — free text                   | `rationale` — free text + structured `evidence` JSON                           | Structured evidence enables cross-venture analysis       |
+| `confidence_pct` — human estimate (0-100) | `confidence_pct` — calculated from Bayesian posterior + human override option  | Reproducible confidence methodology                      |
+| `key_metrics` — ad-hoc JSON snapshot      | `key_metrics` — standardized snapshot matching evidence table format           | Consistent format for querying and comparison            |
+| No link to Validation Report              | `validation_report_ref` — references the specific report                       | Decision traceable to evidence                           |
+| No recommendation tracking                | `system_recommendation` — what the system suggested vs. what the human decided | Calibration data for improving the recommendation engine |
+
+## Enhanced Decision Memo Fields
+
+The existing table columns remain unchanged (backward compatibility). The enhancement is a new `decision_detail` TEXT (JSON) column that stores structured data alongside the existing free-text fields.
+
+| Field                     | Type           | Description                                                                     |
+| ------------------------- | -------------- | ------------------------------------------------------------------------------- |
+| `validation_report_ref`   | string         | References the Validation Report this decision is based on                      |
+| `evidence`                | array          | Structured evidence items (metric, value, threshold, status, weight)            |
+| `confidence_calculation`  | object         | Method, inputs, and result of the confidence calculation                        |
+| `system_recommendation`   | object         | The automated recommendation and its reasoning                                  |
+| `human_override`          | object or null | If the human chose a different verdict, the override rationale                  |
+| `go_conditions`           | array          | The 4 GO criteria from the strategy session, each with pass/fail status         |
+| `kill_criteria_triggered` | array          | Which kill criteria (hard or soft) were triggered, if any                       |
+| `pivot_routing`           | object or null | If PIVOT: which signal pattern, which re-entry point (from Pivot Routing Table) |
+| `handoff_initiated`       | boolean        | Whether a GO handoff was initiated (GO verdicts only)                           |
+
+## Confidence Calculation Methodology
+
+Confidence is not a gut feeling — it is a calculated probability that the true underlying conversion rate supports the verdict.
+
+### For GO Verdicts
+
+Confidence = P(true CVR >= GO threshold | observed data)
+
+Using the Beta-Binomial model:
+
+1. **Prior:** Beta(1, 1) — uniform prior (no strong assumptions). As SC accumulates data (Phase 2+), informative priors derived from portfolio data can be used.
+2. **Posterior:** Beta(1 + conversions, 1 + sessions - conversions)
+3. **Confidence:** 1 - CDF(GO_threshold | posterior)
+
+> **Worked example:** A `fake_door` test with 42 conversions from 1,400 sessions.
+>
+> - Observed CVR = 42/1400 = 3.0% (300 bp)
+> - GO threshold = 2.0% (200 bp)
+> - Prior: Beta(1, 1)
+> - Posterior: Beta(43, 1359)
+> - P(true CVR >= 200 bp) = 1 - BetaCDF(0.02 | 43, 1359) = 0.997
+> - **Confidence: 99.7%** — very high confidence that true CVR exceeds the GO threshold
+>
+> Compare with a marginal result: 22 conversions from 1,400 sessions (CVR = 1.57%, 157 bp).
+>
+> - Posterior: Beta(23, 1379)
+> - P(true CVR >= 200 bp) = 1 - BetaCDF(0.02 | 23, 1379) = 0.138
+> - **Confidence: 13.8%** — low confidence; this CVR likely does not exceed the GO threshold
+
+### For KILL Verdicts
+
+Confidence = P(true CVR < KILL threshold | observed data)
+
+Same model, evaluated at the kill threshold.
+
+### For PIVOT Verdicts
+
+Confidence is reported as "N/A — PIVOT is a routing decision, not a threshold evaluation." The Decision Memo instead records which metrics fell in the amber range and the signal pattern that triggered the pivot.
+
+### Human Override
+
+The operator can override the calculated confidence with their own assessment. When this happens:
+
+- `confidence_calculation.system_value` records the calculated confidence
+- `confidence_calculation.override_value` records the human's assessment
+- `confidence_calculation.override_rationale` explains why
+- Over time, the delta between system and human confidence becomes calibration data
+
+---
+
+# 6.5. Decision Memo Enhanced Schema Sketch
+
+Field specification for a `decision_detail` TEXT (JSON) column on the `decision_memos` table:
+
+```json
+{
+  "validation_report_ref": {
+    "type": "string",
+    "required": true,
+    "description": "Reference to the experiment's validation_report that this decision is based on"
+  },
+
+  "evidence": {
+    "type": "array",
+    "required": true,
+    "items": {
+      "metric": { "type": "string" },
+      "value": { "type": "integer" },
+      "unit": { "type": "string" },
+      "go_threshold": { "type": "integer" },
+      "kill_threshold": { "type": "integer" },
+      "status": { "type": "string", "enum": ["go", "amber", "kill"] },
+      "weight": {
+        "type": "number",
+        "description": "Relative importance: 1.0 = primary metric, 0.5 = secondary"
+      }
+    }
+  },
+
+  "confidence_calculation": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "method": { "type": "string", "default": "bayesian_beta_binomial" },
+      "prior": { "type": "object", "properties": { "alpha": "number", "beta": "number" } },
+      "posterior": { "type": "object", "properties": { "alpha": "number", "beta": "number" } },
+      "system_value": { "type": "integer", "description": "Calculated confidence 0-100" },
+      "override_value": {
+        "type": "integer",
+        "description": "Human override 0-100, null if not overridden"
+      },
+      "override_rationale": { "type": "string" },
+      "credible_interval_90_bp": {
+        "type": "object",
+        "properties": { "lower": "integer", "upper": "integer" }
+      }
+    }
+  },
+
+  "system_recommendation": {
+    "type": "object",
+    "required": true,
+    "properties": {
+      "verdict": { "type": "string", "enum": ["GO", "KILL", "PIVOT", "INVALID"] },
+      "reasoning": { "type": "string" },
+      "confidence_pct": { "type": "integer" }
+    }
+  },
+
+  "human_override": {
+    "type": "object",
+    "required": false,
+    "properties": {
+      "original_recommendation": { "type": "string" },
+      "final_decision": { "type": "string" },
+      "rationale": { "type": "string" }
+    }
+  },
+
+  "go_conditions": {
+    "type": "array",
+    "required": true,
+    "description": "The 4 GO criteria from the strategy session",
+    "items": {
+      "condition": { "type": "string" },
+      "met": { "type": "boolean" },
+      "detail": { "type": "string" }
+    }
+  },
+
+  "kill_criteria_triggered": {
+    "type": "array",
+    "required": false,
+    "items": {
+      "criterion": { "type": "string" },
+      "severity": { "type": "string", "enum": ["hard", "soft"] },
+      "metric": { "type": "string" },
+      "value": { "type": "integer" },
+      "threshold": { "type": "integer" }
+    }
+  },
+
+  "pivot_routing": {
+    "type": "object",
+    "required": false,
+    "properties": {
+      "signal_pattern": { "type": "string" },
+      "reentry_step": { "type": "integer", "minimum": 1, "maximum": 5 },
+      "what_changes": { "type": "string" },
+      "pivot_number": {
+        "type": "integer",
+        "description": "1 or 2 (max 2 pivots per strategy session)"
+      },
+      "cumulative_spend_cents": { "type": "integer" },
+      "remaining_budget_cents": { "type": "integer" }
+    }
+  },
+
+  "handoff_initiated": {
+    "type": "boolean",
+    "required": false,
+    "default": false,
+    "description": "Whether a GO handoff document was generated"
+  }
+}
+```
+
+---
+
+# 7. GO Conditions Evaluation
+
+The strategy session defined four conditions that must ALL be met for a GO verdict. This section operationalizes each one.
+
+## Condition 1: Primary Metric Meets or Exceeds Threshold
+
+**Check:** `cumulative_{primary_metric} >= test_blueprint.metrics.target_threshold`
+
+The primary metric varies by archetype (CVR for most, ROAS for presale). The threshold comes from the Test Blueprint, which inherits archetype defaults from DD#2 but may include overrides.
+
+**Example:** `fake_door` with CVR target >= 200 bp. If cumulative CVR = 280 bp, condition 1 is met.
+
+## Condition 2: Sample Size Rule Satisfied
+
+**Check:** `total_conversions >= test_blueprint.min_conversions`
+
+Minimum conversions are archetype-specific (from DD#2): fake_door = 20, waitlist = 25, content_magnet = 25, priced_waitlist = 20, presale = 15, concierge = 10, service_pilot = 10.
+
+**Important:** Time-box expiration alone does NOT satisfy this condition. A test that ran for 14 days but collected only 8 conversions cannot receive a GO verdict — it is INVALID regardless of other metrics.
+
+## Condition 3: Data Quality Verified
+
+**Check:** No data quality flags with severity = "high" in the Validation Report.
+
+Specifically:
+
+- No INVALID flags (bot traffic, tracking failures, platform anomalies)
+- Attribution mismatch ratio (clicks/sessions) <= 2.0
+- No days with revenue but zero conversions
+- At least 70% of test days have non-zero sessions (tracking was operational)
+
+## Condition 4: Discovery Summary Pain Severity >= 3/5
+
+**Check:** `discovery_summary.pain_severity.composite >= 3.0` OR `discovery_summary.pain_severity.{any_dimension} >= 4.0`
+
+This references DD#3's pain severity scoring and the Peak Dimension Rule. A venture can have moderate overall pain but extreme pain in one dimension and still qualify.
+
+**Exception:** If no Discovery Summary exists (edge case: fake_door test run before discovery, with documented Discovery Gate exception from DD#2), this condition is evaluated as "N/A — gate exception documented" and does not block the GO verdict. This should be rare.
+
+---
+
+# 8. Threshold Calibration System
+
+DD#2 Section 7 defined a 3-phase calibration plan. This section fleshes out each phase in detail, specifying data structures, calculation methods, and transition criteria.
+
+## Phase 1: Industry Defaults (Now — Fewer Than 10 Completed Tests)
+
+### How the Defaults Were Derived
+
+The Phase 1 thresholds in DD#2 are based on industry benchmarks from multiple sources:
+
+| Data Source                                   | What It Informed                                                                 |
+| --------------------------------------------- | -------------------------------------------------------------------------------- |
+| Meta Ads benchmarks (2024-2025)               | Average CTR by industry: 0.9%-1.5%. SC's CTR thresholds use these as baselines.  |
+| Google Ads benchmarks (2024-2025)             | Average CVR by industry: 2.35%-4.4% for search, 0.5%-1.5% for display.           |
+| Unbounce landing page benchmarks              | Median LP CVR: 3.2% across industries. Informed waitlist/content_magnet targets. |
+| Lean Startup literature                       | Minimum viable sample sizes, innovation accounting metrics                       |
+| Y Combinator / Techstars published thresholds | Typical validation metrics for accelerator portfolio companies                   |
+
+### Why They Are Conservative
+
+"Conservative" in this context means: **the GO thresholds are set above industry average, and the KILL thresholds are set below industry worst-case.** This creates a wide amber zone where the venture gets a PIVOT recommendation rather than a premature GO.
+
+The asymmetry is intentional (see Section 2): false positives (premature GO) cost more than false negatives (premature KILL) in Phase 1, when SC has no portfolio data to calibrate against.
+
+### Phase 1 Prior for Bayesian Confidence
+
+In Phase 1, the Bayesian confidence calculation uses a weakly informative prior: **Beta(1, 1)** — the uniform distribution. This says "we have no strong prior belief about the conversion rate." The posterior is entirely determined by the observed data.
+
+**Why not use industry benchmarks as the prior?** Because the prior should reflect SC-specific experience, not general market data. Industry benchmarks informed the _thresholds_, not the _priors_. In Phase 2, SC's own data becomes the prior.
+
+### Data Structure for Phase 1
+
+No additional data structure is needed. Phase 1 uses the archetype defaults hardcoded in DD#2 Section 3 and the uniform Beta(1, 1) prior.
+
+## Phase 2: Internal Benchmarking (After 10+ Completed Tests)
+
+### Transition Criteria
+
+Phase 2 begins when SC has completed 10 or more experiments (across all archetypes) with non-INVALID verdicts. "Completed" means a Decision Memo exists with a GO, KILL, or PIVOT verdict.
+
+### What Changes
+
+1. **Percentile-based thresholds replace fixed defaults** for archetypes with 5+ completed tests
+2. **Portfolio-derived priors replace the uniform prior** for Bayesian confidence
+3. **Cross-venture learning** becomes available
+
+### Percentile-Based Thresholds
+
+For each archetype with 5+ completed tests, calculate the distribution of cumulative CVR (the primary metric for most archetypes):
+
+- **GO threshold:** Set at the 75th percentile of observed CVR across completed tests for that archetype. This means a test must perform in the top quartile of SC's historical performance to receive a GO.
+- **KILL threshold:** Set at the 25th percentile. Tests in the bottom quartile are killed.
+- **Amber zone:** 25th to 75th percentile. Tests in this range receive a PIVOT recommendation.
+
+> **Worked example:** After 8 completed `fake_door` tests with CVRs: [80, 120, 180, 210, 280, 300, 350, 420] bp.
+>
+> - p25 = 150 bp (between 120 and 180)
+> - p75 = 325 bp (between 300 and 350)
+> - Phase 2 thresholds: GO >= 325 bp, KILL < 150 bp, Amber = 150-325 bp
+>
+> Compare with Phase 1 defaults: GO >= 200 bp, KILL < 50 bp. Phase 2 is more stringent for GO (the portfolio's top quartile performs better than the industry default) and more lenient for KILL (SC's bottom quartile is above the industry worst-case).
+
+### Portfolio-Derived Priors
+
+Instead of the uniform Beta(1, 1), the prior for Bayesian confidence becomes:
+
+**Prior = Beta(alpha_portfolio, beta_portfolio)** where alpha and beta are derived from the portfolio's historical conversion data for that archetype.
+
+Calculation method:
+
+1. Collect all completed tests for the archetype
+2. Calculate the mean CVR (mu) and variance (sigma^2) across tests
+3. Derive Beta parameters using method-of-moments:
+   - `alpha = mu * (mu * (1 - mu) / sigma^2 - 1)`
+   - `beta = (1 - mu) * (mu * (1 - mu) / sigma^2 - 1)`
+
+**Safety guardrail:** If the derived prior has alpha + beta > 50, cap it at 50. This prevents the prior from dominating the posterior when sample sizes are small. The prior should inform, not overwhelm.
+
+### Data Structure: `threshold_registry` Table
+
+```sql
+CREATE TABLE IF NOT EXISTS threshold_registry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  phase INTEGER NOT NULL CHECK(phase IN (1, 2, 3)),
+
+  -- Thresholds (in native units: bp for rates, cents for costs)
+  go_threshold INTEGER NOT NULL,
+  kill_threshold INTEGER NOT NULL,
+  metric TEXT NOT NULL,
+
+  -- Calibration data
+  sample_count INTEGER NOT NULL,
+  percentile_25 INTEGER,
+  percentile_75 INTEGER,
+  mean_value INTEGER,
+  std_dev INTEGER,
+
+  -- Bayesian prior
+  prior_alpha REAL,
+  prior_beta REAL,
+
+  -- Metadata
+  effective_from TEXT NOT NULL,
+  superseded_at TEXT,
+  calculation_notes TEXT,
+
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX idx_threshold_archetype ON threshold_registry(archetype);
+CREATE INDEX idx_threshold_phase ON threshold_registry(phase);
+```
+
+When a new threshold set is calculated, the previous entry gets `superseded_at` set to the current timestamp. The system always uses the entry with `superseded_at IS NULL` for each archetype.
+
+### Cross-Venture Learning
+
+With 10+ tests, SC can begin identifying patterns across ventures:
+
+- **Industry correlations:** Do B2B ventures consistently have lower CVR but higher CPL than B2C? If so, industry-adjusted thresholds may be warranted in Phase 3.
+- **Channel performance:** Does LinkedIn consistently outperform or underperform Meta for certain archetypes?
+- **Pain severity correlation:** Do ventures with higher discovery pain severity consistently produce better campaign metrics?
+
+These patterns are captured in learning memos and inform Phase 3 calibration, but they do not change thresholds automatically in Phase 2.
+
+## Phase 3: Dynamic Calibration (After 50+ Completed Tests)
+
+### Transition Criteria
+
+Phase 3 begins when SC has completed 50 or more experiments with non-INVALID verdicts. At this scale, the portfolio has enough data for fine-grained calibration.
+
+### What Changes
+
+1. **Per-category and per-industry threshold adjustments**
+2. **Bayesian updating of thresholds after each new test**
+3. **Confidence intervals on verdicts**
+4. **Predictive scoring** — can the system predict GO/KILL before the test completes?
+
+### Bayesian Threshold Updating
+
+After each completed test, the threshold registry is updated:
+
+1. The new test's CVR is added to the archetype's historical distribution
+2. Percentile thresholds are recalculated
+3. The Beta prior is re-derived from the updated portfolio data
+4. If the new thresholds differ from the current ones by more than 10%, a new `threshold_registry` entry is created
+
+This creates a self-improving system: every test makes the thresholds more accurate.
+
+### Per-Category Adjustments
+
+With 50+ tests, there should be enough data to split thresholds by:
+
+- **Industry:** B2B SaaS, B2C consumer, B2B services, B2C e-commerce, etc.
+- **Price point:** Free/low-commitment, \$10-50/mo, \$50-200/mo, \$200+/mo
+- **Channel:** Meta, Google, LinkedIn (different channels have different baseline CVRs)
+
+Each sub-category follows the same percentile-based threshold calculation, but only when the sub-category has 5+ tests. Below that threshold, the archetype-level data is used.
+
+### Data Structure: `venture_benchmarks` Table
+
+```sql
+CREATE TABLE IF NOT EXISTS venture_benchmarks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+  -- Categorization
+  archetype TEXT NOT NULL,
+  industry TEXT,
+  price_range TEXT,
+  channel TEXT,
+
+  -- Aggregated metrics
+  test_count INTEGER NOT NULL,
+  mean_cvr_bp INTEGER,
+  median_cvr_bp INTEGER,
+  p25_cvr_bp INTEGER,
+  p75_cvr_bp INTEGER,
+  std_dev_cvr_bp INTEGER,
+  mean_cpl_cents INTEGER,
+  median_cpl_cents INTEGER,
+
+  -- Outcome correlation
+  go_rate_pct INTEGER,
+  kill_rate_pct INTEGER,
+  pivot_rate_pct INTEGER,
+
+  -- Bayesian prior
+  prior_alpha REAL,
+  prior_beta REAL,
+
+  -- Metadata
+  last_updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  calculation_notes TEXT
+);
+
+CREATE INDEX idx_benchmarks_archetype ON venture_benchmarks(archetype);
+CREATE INDEX idx_benchmarks_industry ON venture_benchmarks(industry);
+```
+
+This table is recomputed periodically (weekly or after each completed test) from the full experiment history.
+
+### Confidence Intervals on Verdicts
+
+In Phase 3, the Decision Memo includes a confidence interval on the verdict itself:
+
+> "GO with 92% confidence. The 90% credible interval for true CVR is [240 bp, 380 bp], which lies entirely above the GO threshold of 200 bp."
+
+Or for marginal cases:
+
+> "PIVOT recommended. The 90% credible interval for true CVR is [130 bp, 270 bp], which straddles the GO threshold of 200 bp. 64% probability of exceeding GO threshold — insufficient for a confident GO verdict."
+
+---
+
+# 9. Automated Decision Support
+
+The system does not make decisions. It evaluates metrics against thresholds and presents a recommended verdict with evidence. The human makes the final call.
+
+## Decision Support Algorithm
+
+The algorithm runs after each metrics import and produces a `recommended_verdict` for the Validation Report:
+
+```
+FUNCTION evaluate_experiment(experiment_id):
+
+  1. COMPUTE cumulative metrics
+  2. CHECK data quality
+     IF any high-severity flag:
+       RECOMMEND INVALID
+       REASON: "Data quality issue: {flag_detail}"
+       RETURN
+
+  3. CHECK sample size
+     IF total_conversions < min_conversions AND budget_remaining > 0:
+       RECOMMEND "Continue — insufficient data for any verdict"
+       RETURN
+     IF total_conversions < min_conversions AND budget_exhausted:
+       RECOMMEND INVALID
+       REASON: "Budget exhausted with insufficient conversions ({actual} of {required} minimum)"
+       RETURN
+
+  4. CHECK hard kill criteria (strategy session)
+     IF CTR < 40 bp after 1000+ impressions:
+       RECOMMEND KILL (hard)
+       REASON: "Hard kill: CTR below 0.4% after {impressions} impressions"
+       RETURN
+     IF zero conversions after full budget spend:
+       RECOMMEND KILL (hard)
+       REASON: "Hard kill: Zero conversions after full budget spend"
+       RETURN
+
+  5. EVALUATE primary metric against GO threshold
+     IF primary_metric >= go_threshold:
+       EVALUATE all 4 GO conditions:
+         C1: primary metric >= threshold ✓
+         C2: conversions >= minimum
+         C3: no high-severity data quality flags
+         C4: pain severity >= 3/5 (or peak >= 4)
+       IF all 4 met:
+         CALCULATE Bayesian confidence
+         RECOMMEND GO with confidence
+       ELSE:
+         RECOMMEND "Metrics meet threshold but GO conditions not fully satisfied"
+         LIST which conditions are not met
+
+  6. CHECK soft kill criteria (archetype-specific)
+     IF primary_metric < 50% of go_threshold:
+       IF creative swap already attempted:
+         RECOMMEND KILL (soft)
+       ELSE:
+         RECOMMEND "Soft kill territory — creative swap recommended before final verdict"
+     IF CPL > 2x kill_threshold:
+       RECOMMEND KILL (soft, cost)
+
+  7. CHECK amber range
+     IF primary_metric between kill_threshold and go_threshold:
+       ANALYZE per-channel and per-variant performance
+       IF any segment clears GO threshold:
+         RECOMMEND PIVOT with segment data
+         ROUTING: "Narrow ICP to {segment} — Step 3 re-entry"
+       ELSE:
+         RECOMMEND PIVOT
+         USE Pivot Routing Table to determine re-entry point
+
+  8. FALLBACK
+     RECOMMEND "Insufficient information for automated recommendation — manual review required"
+```
+
+## Edge Cases
+
+### Split Metrics (Some GO, Some KILL)
+
+When primary metric is GO but secondary metrics are in KILL range (e.g., CVR meets threshold but CPL is 3x over limit):
+
+- The system flags the conflict in the evidence table
+- Recommended verdict: PIVOT — "Primary metric meets threshold but unit economics are unsustainable at current CPL. Recommend: test lower-cost channels or revise targeting to reduce CPL."
+- The human may override to GO if they believe CPL will improve at scale
+
+### Insufficient Sample Size with Strong Signal
+
+When conversion rate looks excellent but total conversions are below minimum (e.g., 8 conversions at 4.0% CVR from a `fake_door` test requiring 20):
+
+- Recommended verdict: INVALID — "Strong signal (CVR 400 bp, above GO threshold of 200 bp) but insufficient sample (8 of 20 required conversions). Recommend: extend budget or relaunch to reach minimum sample."
+- This is not a GO. The sample size rule exists because small samples produce highly variable rates.
+
+### Data Quality Questionable but Metrics Strong
+
+When metrics exceed all thresholds but a medium-severity data quality flag is present (e.g., single day with 3x average traffic):
+
+- Recommended verdict: GO with caveat — "All metrics exceed thresholds. Data quality flag: {detail}. Recommend: verify the flagged date's data before finalizing."
+- The flag is noted in the Validation Report for the human reviewer to investigate.
+
+---
+
+# 10. INVALID Handling
+
+An INVALID verdict means the test produced inconclusive results. It is neither a GO (validated) nor a KILL (invalidated) — it is a measurement failure. The venture's hypothesis is neither confirmed nor denied.
+
+## Root Causes
+
+| Root Cause                 | Detection                                                                         | Frequency                                                                            |
+| -------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Insufficient traffic**   | Total sessions < 50% of archetype minimum                                         | Common — ad targeting too narrow, budget too small, or campaign not running properly |
+| **Tracking failure**       | Days with ad spend but zero sessions in event_log                                 | Moderate — tracking code not deployed, UTM parameters misconfigured                  |
+| **Bot contamination**      | CTR > 5x industry average with near-zero CVR; non-human session patterns          | Rare but devastating — invalidates all conversion data                               |
+| **Platform anomaly**       | Metrics that are impossible (e.g., conversions > sessions) or obviously erroneous | Rare — ad platform reporting bugs                                                    |
+| **Campaign not delivered** | Very low impressions relative to budget (platform rejected ads, account issues)   | Moderate — ad policy violations, payment failures                                    |
+
+## Resolution Paths
+
+| Root Cause             | Resolution                                                                                  | Cost Impact                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| Insufficient traffic   | Extend budget by \$100-200 or broaden targeting                                             | Within \$1,500 cap                          |
+| Tracking failure       | Fix tracking code, relaunch with same budget                                                | Wasted spend is lost; new budget within cap |
+| Bot contamination      | Exclude bot traffic from metrics, re-evaluate; if insufficient clean data remains, relaunch | Relaunch cost within cap                    |
+| Platform anomaly       | Contact platform support; manually correct metrics if source data is available              | No additional cost                          |
+| Campaign not delivered | Fix the delivery issue (creative policy, payment, targeting), relaunch                      | Same budget                                 |
+
+## INVALID Decision Memo
+
+An INVALID verdict requires a Decision Memo, just like any other verdict. The memo documents:
+
+- What went wrong (root cause from the table above)
+- What data was collected (even if insufficient)
+- The resolution path chosen
+- Whether the experiment is being extended, relaunched, or redesigned
+
+## Budget Accounting for INVALID Tests
+
+INVALID test spend counts toward the \$1,500 cumulative cap from the strategy session. If a \$300 test produces an INVALID result and is relaunched for another \$300, the cumulative spend is \$600. This is by design — INVALID tests are a real cost.
+
+---
+
+# 11. Learning Memos & Continuous Improvement
+
+The existing `learning_memos` table captures weekly observations during the test run. DD#6 specifies how these feed into methodology improvement.
+
+## What Gets Captured During a Test
+
+| Timing                  | Content                                                                   | Source                                           |
+| ----------------------- | ------------------------------------------------------------------------- | ------------------------------------------------ |
+| **Weekly (during run)** | Observations, hypotheses, actions taken, next week plan, metrics snapshot | Operator via learning_memos table                |
+| **Daily (automated)**   | Metric imports, threshold evaluations, data quality checks                | metrics_daily + event_log                        |
+| **Ad hoc**              | Creative swaps, targeting changes, budget adjustments, campaign pauses    | event_log with `experiment_status_change` events |
+
+## What Gets Captured After a Test
+
+| Timing                     | Content                                                                                             | Source                                      |
+| -------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **At decision**            | Validation Report (final), Decision Memo with structured evidence                                   | validation_report + decision_detail columns |
+| **Post-mortem (optional)** | Reflections on what was learned beyond the metrics — methodology observations, process improvements | Free-text addendum to the Decision Memo     |
+
+## Pattern Recognition Across Tests
+
+Learning memos feed into cross-venture pattern recognition when queried in aggregate:
+
+- **Messaging patterns:** Which headline structures (pain-led, solution-led, urgency-led) perform best across ventures? The Campaign Package's `ab_variants` with their performance data answer this.
+- **Channel patterns:** Which channels consistently outperform for which customer segments? The `metrics_daily.source` breakdown answers this.
+- **Timing patterns:** Do tests launched on specific days or during specific weeks perform differently? The date fields answer this.
+- **Calibration patterns:** How often does the system's recommended verdict match the human's final decision? The `system_recommendation` vs. `human_override` fields in the Decision Memo answer this.
+
+This pattern data feeds into Phase 2 and Phase 3 threshold calibration (Section 8) and into methodology refinement across the entire DD#1-DD#6 chain.
+
+---
+
+# 12. GO Handoff — From Validation to Product Development
+
+The GO handoff is the most important transition in the validation workflow. It is where a validated hypothesis becomes a real business. This section specifies what happens when a venture receives a GO verdict.
+
+## What Carries Forward
+
+When a venture receives a GO verdict, the following artifacts carry forward from Silicon Crane validation into Ventracrane product development:
+
+| Artifact                                | Source                                  | What It Provides                                                                                                          |
+| --------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Hypothesis Card (Tier 2, validated)** | DD#1 — experiments.hypothesis_card      | Customer segment, validated problem, solution hypothesis, key assumptions (now evidence-backed), market sizing            |
+| **Discovery Summary (final)**           | DD#3 — experiments.discovery_summary    | Customer pain evidence, feature priorities, WTP signal, price range, ICP refinements, discovery channels, customer quotes |
+| **Test Blueprint**                      | DD#2 — experiments.test_blueprint       | Archetype sequence, budget history, threshold performance                                                                 |
+| **Campaign Package**                    | DD#4 — experiments.campaign_package     | Messaging that worked, creative assets, channel performance, A/B variant results                                          |
+| **Validation Report (final)**           | DD#6 — experiments.validation_report    | Complete metrics evidence, trend analysis, confidence assessment                                                          |
+| **Decision Memo (GO)**                  | DD#6 — decision_memos + decision_detail | Verdict, confidence, structured evidence, GO conditions                                                                   |
+| **Learning Memos**                      | learning_memos                          | Weekly observations from the test run                                                                                     |
+| **Raw data: leads**                     | leads table                             | Actual captured leads — the venture's first potential customers                                                           |
+| **Raw data: metrics**                   | metrics_daily                           | Full daily metrics history for forecasting                                                                                |
+| **Raw data: events**                    | event_log                               | Behavioral data from landing page interactions                                                                            |
+
+## The Handoff Document
+
+The GO Handoff Document is a synthesized deliverable that packages the validation evidence for the product development team. It is generated from the artifacts above, not written from scratch.
+
+### Handoff Document Structure
+
+**1. Executive Summary**
+
+- Venture name, one-liner (from Hypothesis Card)
+- GO verdict with confidence percentage
+- Total validation spend and duration
+- Key metric: primary metric value vs. threshold
+
+**2. Customer Evidence**
+
+- Pain severity scores (from Discovery Summary)
+- Top 5 customer quotes (from Discovery Summary)
+- ICP definition (refined from discovery)
+- Feature priorities (from Discovery Summary)
+
+**3. Market Evidence**
+
+- Campaign metrics (from Validation Report)
+- Channel performance (best-performing channel, CPC, CPL)
+- Conversion rate with confidence interval
+- Audience size estimates (from ad platform reach data)
+
+**4. Messaging That Worked**
+
+- Winning headline and CTA (from Campaign Package A/B results)
+- Pain dimension that resonated most (from Campaign Package tone)
+- Channel-specific messaging insights
+
+**5. Unit Economics (Preliminary)**
+
+- Customer acquisition cost (from CPL)
+- Projected LTV (from price point in test + industry retention benchmarks)
+- LTV:CAC ratio estimate
+- Break-even timeline estimate
+
+**6. Risks & Open Questions**
+
+- Key assumptions that remain untested (from Hypothesis Card)
+- Data quality caveats (from Validation Report)
+- Trend direction (improving/stable/declining from Validation Report)
+- Competitive risks (from Hypothesis Card)
+
+**7. Recommended Next Steps**
+
+- Product scope recommendation (based on feature priorities from discovery)
+- Launch channel recommendation (based on campaign performance)
+- Target customer profile (based on ICP refinements)
+- Suggested pricing (based on WTP data from discovery + validation)
+
+**8. Raw Data Access**
+
+- Links to all leads captured during validation
+- Links to all metrics data
+- Links to all event data
+- Data retention notes (90-day PII window from strategy session)
+
+## The Ventracrane Transition
+
+The GO handoff transitions from Silicon Crane (validation) into the broader Ventracrane product development process.
+
+### What Changes at Handoff
+
+| Aspect             | During Validation (SC)              | After GO Handoff (Ventracrane)                                  |
+| ------------------ | ----------------------------------- | --------------------------------------------------------------- |
+| **Goal**           | Decide: GO or KILL                  | Build: ship the product                                         |
+| **Budget**         | \$300-1,500 (test budget)           | Product development budget (TBD per venture)                    |
+| **Team**           | Solo operator or small SC team      | Product development team                                        |
+| **Metrics**        | Validation metrics (CVR, CPL, ROAS) | Product metrics (retention, engagement, revenue, churn)         |
+| **Timeline**       | 1-10 weeks                          | Months to years                                                 |
+| **Infrastructure** | SC Console (D1, Workers, Astro)     | Venture-grade stack (may use SC infrastructure or build custom) |
+
+### Lead Nurturing Bridge
+
+The leads captured during validation are the venture's first potential customers. During the handoff:
+
+1. **Warm leads:** All leads from GO experiments are exported or API-accessible for the product team
+2. **Communication:** A "we're building it" email sequence is triggered via Kit to keep leads warm
+3. **Beta recruitment:** Leads from the validation test are the first beta invite candidates
+4. **Retention:** The product team inherits the Kit email list and continues the relationship
+
+### For VaaS: Client Deliverable
+
+When SC operates as Validation-as-a-Service, the GO Handoff Document is the primary client deliverable. It is the product the client paid for — the validated evidence package.
+
+**VaaS handoff includes:**
+
+- Everything in the standard Handoff Document
+- All raw data (leads, metrics, events) exported in a standard format (CSV + JSON)
+- The Campaign Package (messaging and creative assets) with commercial usage rights
+- A 30-minute handoff call to walk through the findings
+- 30-day post-handoff support for questions about the data
+
+**VaaS pricing consideration:** The Handoff Document is the high-value deliverable. The validation test is the process; the handoff is the product.
+
+---
+
+# 13. KILL Archival Protocol
+
+When a venture is killed, everything is archived for learning. Killed ventures are not deleted — they are the most valuable source of pattern recognition data.
+
+## Archive Process
+
+1. **Decision Memo filed** with KILL verdict, structured evidence, and rationale
+2. **Experiment status set to `archive`** in the experiments table
+3. **All artifacts preserved:**
+   - Hypothesis Card (what was believed)
+   - Discovery Summary (what customers said)
+   - Test Blueprint (how it was tested)
+   - Campaign Package (what was said to the market)
+   - Validation Report (what the market said back)
+   - Learning Memos (what was observed)
+   - Raw data (leads, metrics, events)
+4. **PII retention clock starts:** 90 days from the archive date, PII in leads and event_log is purged per the strategy session's Kill Protocol
+
+## 90-Day PII Retention
+
+From the strategy session: "90-day PII retention policy on any collected contact data, then purge."
+
+**What gets purged after 90 days:**
+
+- `leads.email` — set to SHA-256 hash (retains uniqueness for count, loses recoverability)
+- `leads.name` — set to NULL
+- `leads.company` — set to NULL
+- `leads.phone` — set to NULL
+- `event_log.user_agent` — set to NULL (already covered by existing maintenance worker)
+
+**What is preserved (anonymized):**
+
+- `leads.custom_fields` — retained (archetype-specific data, typically not PII)
+- `leads.utm_*` — retained (attribution data, not PII)
+- `leads.ip_country` — retained (country-level, not PII)
+- All `metrics_daily` data — retained (aggregate metrics, no PII)
+- All `event_log` data except user_agent — retained (event types and behavioral data)
+- All artifact columns on experiments — retained
+
+**Implementation:** Extend the existing `sc-maintenance` worker's daily cron job to check for archived experiments past the 90-day retention window.
+
+## The Kill Library
+
+The kill library is a queryable archive of killed ventures, designed for pattern recognition across failed hypotheses.
+
+### What the Kill Library Enables
+
+- **Failure pattern detection:** Are ventures in certain industries consistently killed? At which step? For what reasons?
+- **Messaging autopsies:** Which headline types and messaging approaches consistently fail?
+- **ICP pattern recognition:** Are certain customer segments consistently unreachable or unresponsive?
+- **Threshold validation:** Do killed ventures stay dead? (If a killed hypothesis is later validated by a competitor, the kill threshold may have been too aggressive.)
+- **Cost of learning:** What is the average cost to learn that an idea does not work? This informs VaaS pricing.
+
+### Kill Library Query Patterns
+
+```sql
+-- All kills by archetype
+SELECT archetype, COUNT(*) as kill_count
+FROM experiments e
+JOIN decision_memos d ON e.id = d.experiment_id
+WHERE d.decision = 'KILL'
+GROUP BY archetype;
+
+-- Average spend before kill
+SELECT AVG(total_spend) FROM (
+  SELECT e.id, SUM(m.spend_cents) as total_spend
+  FROM experiments e
+  JOIN metrics_daily m ON e.id = m.experiment_id
+  JOIN decision_memos d ON e.id = d.experiment_id
+  WHERE d.decision = 'KILL'
+  GROUP BY e.id
+);
+
+-- Kill reasons (from structured decision_detail)
+SELECT
+  json_extract(d.decision_detail, '$.kill_criteria_triggered[0].criterion') as primary_kill_reason,
+  COUNT(*) as count
+FROM decision_memos d
+WHERE d.decision = 'KILL'
+  AND d.decision_detail IS NOT NULL
+GROUP BY primary_kill_reason
+ORDER BY count DESC;
+```
+
+---
+
+# 14. Answering the Five Strategy Session Questions
+
+The strategy session identified five questions for Deep Dive #6. Here are the definitive answers:
+
+**1. How should initial thresholds be calibrated before we have historical data?**
+
+Phase 1 thresholds (Section 8) use industry benchmarks from Meta/Google ad platform data, Unbounce landing page benchmarks, and Lean Startup literature. They are deliberately conservative — GO thresholds above industry average, KILL thresholds below industry worst-case — because false positives (premature GO) cost more than false negatives (premature KILL) when SC has no portfolio data. The Bayesian confidence calculation uses a uniform Beta(1, 1) prior, letting the observed data speak for itself. Phase 2 (after 10+ tests) replaces defaults with percentile-based thresholds from SC's own portfolio distribution, and Phase 3 (after 50+ tests) adds per-category and per-industry adjustments with Bayesian threshold updating.
+
+**2. What measurement infrastructure is needed (analytics, event tracking, data pipelines)?**
+
+The existing infrastructure covers 80% of what is needed (Section 3). Real-time event tracking exists via `event_log` and `POST /events`. Daily batch metrics exist via `metrics_daily` and `POST /metrics`. What is new: cumulative metric aggregation (Section 5), threshold evaluation logic triggered on each metrics import, Validation Report auto-generation, Bayesian confidence calculation, and data quality flag detection. Phase 1 uses manual ad platform metric import; Phase 2 adds semi-automated import via platform APIs. The infrastructure runs entirely on the existing Cloudflare Workers + D1 stack with no new external dependencies.
+
+**3. How does the Decision Framework evolve as we accumulate validation data across ventures?**
+
+Through the 3-phase calibration system (Section 8). Phase 1: static industry defaults. Phase 2: dynamic percentile-based thresholds (GO at p75, KILL at p25) derived from SC's own portfolio, with portfolio-derived Bayesian priors. Phase 3: Bayesian updating of thresholds after each completed test, per-category and per-industry adjustments, confidence intervals on verdicts. The `threshold_registry` and `venture_benchmarks` tables store calibration data. Every test makes the system smarter — completed experiments feed back into threshold recalculation and prior updates. The system also tracks human overrides of automated recommendations, using the delta between system and human confidence as calibration data for improving the recommendation engine.
+
+**4. What artifacts from validation carry forward when a venture receives a GO verdict?**
+
+Everything (Section 12). The Hypothesis Card (validated), Discovery Summary (customer evidence), Test Blueprint (test design history), Campaign Package (messaging that worked), Validation Report (market evidence), Decision Memo (verdict and evidence), Learning Memos (observations), and all raw data (leads, metrics, events). These are packaged into a GO Handoff Document with 8 sections: Executive Summary, Customer Evidence, Market Evidence, Messaging That Worked, Unit Economics, Risks & Open Questions, Recommended Next Steps, and Raw Data Access. The leads captured during validation are the venture's first potential customers — they bridge directly into beta recruitment.
+
+**5. How does the handoff work from Silicon Crane validation into Ventracrane product development?**
+
+The GO Handoff Document (Section 12) is the transition mechanism. It synthesizes all validation artifacts into a product development brief. The handoff changes the goal (from "decide" to "build"), the budget (from \$300-1,500 test budgets to product development budgets), the team (from solo operator to product team), the metrics (from validation metrics like CVR/CPL to product metrics like retention/engagement/revenue), and the timeline (from weeks to months). Leads are exported and a "we're building it" email sequence keeps them warm. For VaaS clients, the Handoff Document is the primary deliverable — the product the client paid for — supplemented with raw data exports, creative assets with usage rights, a handoff call, and 30-day post-handoff support.
+
+---
+
+# 15. Recommendations for Functional Spec v2.0
+
+## Schema Changes
+
+1. **Add `validation_report` TEXT (JSON) column** to the experiments table — stores the complete Validation Report artifact (see Schema Sketch in Section 4.5)
+
+2. **Add `decision_detail` TEXT (JSON) column** to the decision_memos table — stores structured evidence, confidence calculation, system recommendation, and human override data (see Schema Sketch in Section 6.5)
+
+3. **Create `threshold_registry` table** for calibration data — archetype-specific threshold history with phase tracking, percentile data, and Bayesian priors (Section 8)
+
+4. **Create `venture_benchmarks` table** for cross-venture learning — aggregated performance data by archetype, industry, price range, and channel (Section 8)
+
+## API Endpoints
+
+5. **Add `GET /experiments/:id/validation-report`** — returns the current Validation Report (draft or final)
+
+6. **Add `POST /experiments/:id/validation-report/finalize`** — locks the Validation Report to "final" stage
+
+7. **Add `GET /experiments/:id/cumulative-metrics`** — returns cumulative aggregated metrics across all days and sources
+
+8. **Add `POST /experiments/:id/evaluate-thresholds`** — triggers threshold evaluation and returns the recommended verdict with evidence (can also be auto-triggered on metrics import)
+
+9. **Add `GET /thresholds/:archetype`** — returns the current threshold set for an archetype (from threshold_registry)
+
+10. **Add `GET /benchmarks`** — returns portfolio benchmark data (from venture_benchmarks), filterable by archetype, industry, etc.
+
+## Automated Decision Support Logic
+
+11. **Implement the decision support algorithm** (Section 9) as a function called after each `POST /metrics` import. The function computes cumulative metrics, evaluates thresholds, checks GO conditions, and updates the draft Validation Report.
+
+12. **Implement Bayesian confidence calculation** (Section 6) using the Beta-Binomial model. Phase 1 uses Beta(1,1) prior. Phase 2+ uses portfolio-derived priors from `threshold_registry`.
+
+## Data Pipeline
+
+13. **Add cumulative metric aggregation** (Section 5) to the metrics import pipeline. After each daily metrics import, recompute cumulative metrics and store in the Validation Report.
+
+14. **Add data quality flag detection** (Section 4) to the metrics import pipeline. Check for bot traffic patterns, tracking gaps, platform anomalies, and attribution mismatches.
+
+## Maintenance
+
+15. **Extend the `sc-maintenance` worker** to handle 90-day PII purge for archived experiments (Section 13). Check for experiments in `archive` status with `decided_at` older than 90 days and purge PII from leads and event_log.
+
+16. **Add threshold recalculation** to a scheduled job (weekly or after each completed experiment). When the completed test count crosses the Phase 2 (10 tests) or Phase 3 (50 tests) thresholds, recalculate and update `threshold_registry`.
+
+## Event Types
+
+17. **Add measurement event types to `event_log`:**
+    - `threshold_evaluation` — triggered after each metrics import
+    - `validation_report_generated` — draft report created or updated
+    - `validation_report_finalized` — report locked to final
+    - `decision_support_recommendation` — system recommendation generated
+    - `go_handoff_initiated` — GO handoff document generated
+    - `experiment_archived` — experiment moved to archive status
+
+---
+
+# 16. Methodology Complete — Summary of All Deep Dives
+
+This is the capstone document in the SC Validation Methodology series. The six deep dives, together with the strategy session, define a complete system for validating business hypotheses — from raw idea to GO/KILL decision.
+
+## The Complete Artifact Chain
+
+```
+Raw Idea
+    │
+    ▼
+DD#1: The Venture Narrative ──────────► Structured Hypothesis Card
+    │                                    (5 narrative elements, 10 fields,
+    │                                     confidence score, early kill)
+    ▼
+DD#3: The Discovery Engine ───────────► Discovery Summary
+    │                                    (pain severity, customer quotes,
+    │                                     WTP signal, ICP refinements)
+    ▼
+DD#2: The Validation Ladder ──────────► Test Blueprint
+    │                                    (archetype, metrics, thresholds,
+    │                                     kill criteria, decision rules)
+    ▼
+DD#4: The Campaign Factory ───────────► Campaign Package
+    │                                    (copy, creative, targeting,
+    │                                     budget, channel variants)
+    ▼
+DD#5: [Landing Page Automation] ──────► Live Experiment
+    │                                    (deployed page, tracking verified,
+    │                                     signals capturing)
+    ▼
+DD#6: The Verdict ────────────────────► Validation Report + Decision Memo
+    │                                    (metrics vs. thresholds, evidence,
+    │                                     Bayesian confidence, verdict)
+    │
+    ├──► GO ──────► Handoff Document ──► Product Development
+    │
+    ├──► KILL ────► Kill Archive ──────► Kill Library (learning)
+    │
+    ├──► PIVOT ───► Pivot Routing ─────► Re-entry at Step 1-5
+    │
+    └──► INVALID ─► Resolution ────────► Extend / Relaunch / Redesign
+```
+
+## Deep Dive Summary Table
+
+| #   | Name                           | Branded Name          | Artifact Produced                 | Key Innovation                                                                                       |
+| --- | ------------------------------ | --------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 1   | Story-Based Framework          | The Venture Narrative | Hypothesis Card                   | 5-element narrative with 3-dimensional pain taxonomy; confidence scoring for early kill              |
+| 2   | Test Type Taxonomy             | The Validation Ladder | Test Blueprint                    | 7 archetypes in 3 categories; per-archetype metrics/thresholds/kill criteria; 3-rung sequencing      |
+| 3   | AI-Scaled Customer Discovery   | The Discovery Engine  | Discovery Summary                 | 3 interview modes with mode-weighted counting; 4 protocols mapped to HC fields; pain severity rubric |
+| 4   | AI-Generated Marketing Content | The Campaign Factory  | Campaign Package                  | 7-step async pipeline; Messaging Matrix; two-tier generation model; BrandProfile system              |
+| 5   | Landing Page Automation        | [DD#5 name]           | Live Experiment                   | [Covered in DD#5]                                                                                    |
+| 6   | Measurement & Decision System  | The Verdict           | Validation Report + Decision Memo | Bayesian confidence; 3-phase calibration; automated decision support; GO handoff; kill library       |
+
+## What Comes Next: Functional Spec v2.0
+
+The six deep dives collectively recommend significant changes to the functional spec:
+
+| Source | Key Recommendations                                                                                                                                                                                                               |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DD#1   | Replace Distill Brief with Hypothesis Card; add `hypothesis_card` column                                                                                                                                                          |
+| DD#2   | Restructure archetypes (remove `interview`, add `fake_door`); add `test_blueprint` column; add Discovery Gate                                                                                                                     |
+| DD#3   | Add `discovery_summary` column; create `interviews` table; add `discovery` status to experiment lifecycle                                                                                                                         |
+| DD#4   | Add `campaign_package` column; create `ventures` table; async generation pipeline via Cloudflare Queue                                                                                                                            |
+| DD#5   | [Covered in DD#5]                                                                                                                                                                                                                 |
+| DD#6   | Add `validation_report` column; add `decision_detail` column; create `threshold_registry` and `venture_benchmarks` tables; automated threshold evaluation; Bayesian confidence; GO handoff protocol; kill archival with PII purge |
+
+The Functional Spec v2.0 synthesis will consolidate these recommendations into a coherent database migration plan, API specification update, and implementation roadmap. The six deep dives provide the "what" and "why" — the functional spec provides the "how" and "when."
+
+**The SC Validation Methodology is now fully specified from idea to decision.**

--- a/docs/pm/prd-contributions/context.md
+++ b/docs/pm/prd-contributions/context.md
@@ -1,0 +1,15 @@
+# PRD Review Context
+
+## Source Documents
+
+- /Users/scottdurgan/dev/sc-console/docs/process/sc-project-instructions.md
+- /Users/scottdurgan/dev/sc-console/docs/technical/sc-functional-spec-v2.md
+
+## User Corrections
+
+None
+
+## Review Parameters
+
+- Rounds: 1
+- Date: 2026-03-02

--- a/docs/pm/prd-contributions/round-1/business-analyst.md
+++ b/docs/pm/prd-contributions/round-1/business-analyst.md
@@ -1,0 +1,436 @@
+# Business Analyst Contribution - PRD Review Round 1
+
+**Author:** Business Analyst
+**Date:** 2026-03-02
+**Scope:** MVP / Phase 0 only (Milestone A: Phases 1-3 per Functional Spec v2.0, Section 8)
+
+---
+
+## MVP User Stories
+
+The following user stories cover the Milestone A scope: Schema Foundation (Phase 1), Hypothesis Card (Phase 2), and Discovery Engine (Phase 3). This corresponds to the "v2.0-alpha" milestone defined in the functional spec as "First user-facing value" targeting approximately 2-3 weeks.
+
+**Personas referenced:**
+
+- **SC Operator**: The Silicon Crane team member running validation sprints for ventures (internal Ventracrane ventures or external VaaS clients).
+- **VaaS Client**: An external entrepreneur who has engaged Silicon Crane for a validation sprint.
+
+---
+
+### US-001: Run v2.0 Schema Migration
+
+**As an** SC Operator,
+**I want** the database schema to be extended with all v2.0 columns and tables,
+**so that** the application can store Hypothesis Cards, Discovery Summaries, interview records, and supporting metadata without breaking existing experiments.
+
+**Acceptance Criteria:**
+
+- [ ] Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 6 new artifact columns are added to `experiments`: `hypothesis_card`, `test_blueprint`, `discovery_summary`, `campaign_package`, `page_config`, `validation_report`
+- [ ] Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 4 new supporting columns are added to `experiments`: `venture_id`, `category`, `sequence_position`, `prior_test_ref`
+- [ ] Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 1 new column `decision_detail` is added to `decision_memos`
+- [ ] Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 4 new tables are created: `interviews`, `ventures`, `threshold_registry`, `venture_benchmarks`
+- [ ] Given existing experiments with archetype `interview`, when Migration 0002 runs Step 2, then draft/preflight experiments are migrated to `fake_door` and active experiments are archived
+- [ ] Given the migration completes Step 3 (table recreation), when I query for experiments, then the `archetype` CHECK constraint accepts `fake_door` and rejects `interview`
+- [ ] Given the migration completes Step 3, when I query for experiments, then the `status` CHECK constraint accepts `discovery` as a valid status
+- [ ] Given the migration is complete, when I query `SELECT COUNT(*) FROM experiments WHERE archetype = 'interview'`, then the result is 0
+- [ ] Given the migration is complete, when I compare row counts to pre-migration, then the count is preserved (no data loss)
+- [ ] Given the migration is complete, when I update any experiment's name, then the `updated_at` trigger fires and updates the timestamp
+- [ ] Given all new columns are nullable, when I query existing experiments that lack v2.0 data, then all new columns return NULL and existing behavior is unchanged
+
+**Business Rules:** BR-001, BR-002, BR-003, BR-004
+
+**Out of Scope:** Populating the `threshold_registry` with default values (deferred to Phase 7). Ventures CRUD API (deferred to Phase 5). Enforcing `venture_id` as a foreign key (D1 does not enforce FKs by default; deferred to Phase 5).
+
+---
+
+### US-002: Write a Hypothesis Card for an Experiment
+
+**As an** SC Operator,
+**I want** to write a Structured Hypothesis Card to an experiment,
+**so that** I can capture the venture narrative fields and move the experiment through the validation workflow.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment exists, when I send `PATCH /experiments/:id` with a valid `hypothesis_card` JSON body, then the `hypothesis_card` column is updated
+- [ ] Given a Tier 1 (draft) Hypothesis Card, when I write it to an experiment, then the 6 required Tier 1 fields are present: `customer_segment`, `problem_statement`, `stakes_failure`, `stakes_success`, `solution_hypothesis`, `why_now`
+- [ ] Given a Tier 2 (full) Hypothesis Card, when I write it to an experiment, then the 4 additional fields are accepted: `current_alternatives`, `market_sizing`, `competitive_landscape`, `key_assumptions`
+- [ ] Given a Hypothesis Card with `confidence` set to `proceed`, `uncertain`, or `abandon`, when I write it, then the value is accepted
+- [ ] Given a Hypothesis Card with an invalid `confidence` value (e.g., "maybe"), when I write it, then the API returns a 400 error
+- [ ] Given a Hypothesis Card, when `confidence` is provided, then `confidence_rationale` must also be provided or the API returns a 400 error
+- [ ] Given a Hypothesis Card with `key_assumptions`, when I write it, then each assumption has `claim`, `evidence`, `risk` (high/medium/low), and `basis` fields
+- [ ] Given a Hypothesis Card with `key_assumptions`, when fewer than 3 or more than 5 assumptions are provided, then the API returns a 400 error
+- [ ] Given a Hypothesis Card with a `tier` field, when the value is anything other than `draft` or `full`, then the API returns a 400 error
+- [ ] Given a Hypothesis Card with an `one_liner` field, when the value exceeds 200 characters, then the API returns a 400 error
+- [ ] Given an experiment that already has a `hypothesis_card`, when I send a new `hypothesis_card` via PATCH, then the old card is overwritten with the new one
+
+**Business Rules:** BR-005, BR-006, BR-007, BR-008
+
+**Out of Scope:** AI agent auto-generation of Hypothesis Cards (methodology concern, not MVP platform scope). Variant generation (2-3 alternative framings). Auto-archival triggered by `abandon` confidence (advisory only in Phase 2 per functional spec).
+
+---
+
+### US-003: Enforce Distill Brief Write Invariant
+
+**As an** SC Operator,
+**I want** the legacy Distill Brief fields to be auto-populated from the Hypothesis Card and protected from direct editing,
+**so that** data remains consistent between the card and the legacy columns.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with `hypothesis_card` containing `customer_segment`, then `target_audience` is auto-updated to match `hypothesis_card.customer_segment`
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with `hypothesis_card` containing `problem_statement`, then `problem_statement` column is auto-updated to match `hypothesis_card.problem_statement`
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with `hypothesis_card` containing `solution_hypothesis`, then `value_proposition` is auto-updated to match `hypothesis_card.solution_hypothesis`
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with `hypothesis_card` containing `market_sizing`, then `market_size_estimate` is auto-updated to match `hypothesis_card.market_sizing`
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with a direct update to `target_audience`, then the API returns a 400 error with message indicating the field is read-only when `hypothesis_card` is present
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with a direct update to `problem_statement`, then the API returns a 400 error
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with a direct update to `value_proposition`, then the API returns a 400 error
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with a direct update to `market_size_estimate`, then the API returns a 400 error
+- [ ] Given an experiment with a null `hypothesis_card`, when I send `PATCH /experiments/:id` with a direct update to `target_audience`, then the update succeeds (backward compatibility)
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `PATCH /experiments/:id` with an updated `hypothesis_card` that changes `customer_segment`, then `target_audience` is also updated to reflect the new value
+
+**Business Rules:** BR-009, BR-010
+
+**Out of Scope:** Bulk migration of existing Distill Brief data into Hypothesis Card format. Reverse projection (populating Hypothesis Card from Distill Brief columns).
+
+---
+
+### US-004: Read a Hypothesis Card from an Experiment
+
+**As an** SC Operator,
+**I want** to retrieve the Hypothesis Card for an experiment,
+**so that** I can review the structured hypothesis and use it as input for discovery and test selection.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment with a non-null `hypothesis_card`, when I send `GET /experiments/:id`, then the response includes the full `hypothesis_card` JSON object
+- [ ] Given an experiment with a null `hypothesis_card`, when I send `GET /experiments/:id`, then the `hypothesis_card` field is null in the response
+- [ ] Given an experiment with a non-null `hypothesis_card` and the `tier` field is `draft`, when I read the experiment, then Tier 2 fields (`current_alternatives`, `market_sizing`, `competitive_landscape`, `key_assumptions`) may be null
+- [ ] Given an experiment with a non-null `hypothesis_card` and the `tier` field is `full`, when I read the experiment, then all 10 fields plus `confidence`, `confidence_rationale`, and `tier` are present
+
+**Business Rules:** BR-006
+
+**Out of Scope:** Hypothesis Card comparison between experiments. Card versioning or history tracking.
+
+---
+
+### US-005: Transition an Experiment to Discovery Status
+
+**As an** SC Operator,
+**I want** to transition an experiment from `preflight` to `discovery` status,
+**so that** I can begin recording discovery interviews against the experiment.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment in `preflight` status, when I send `PATCH /experiments/:id` with `status: "discovery"`, then the status is updated to `discovery`
+- [ ] Given an experiment in `draft` status, when I send `PATCH /experiments/:id` with `status: "discovery"`, then the API returns a 400 error (invalid transition)
+- [ ] Given an experiment in `discovery` status, when I send `PATCH /experiments/:id` with `status: "build"`, then the transition is allowed (Discovery Gate enforcement is deferred to Phase 4)
+- [ ] Given an experiment in `discovery` status, when I send `PATCH /experiments/:id` with `status: "archive"`, then the transition is allowed (archive is always allowed)
+- [ ] Given an experiment in `preflight` status, when I send `PATCH /experiments/:id` with `status: "build"`, then the transition is allowed (Discovery Gate exception path; enforcement deferred to Phase 4)
+- [ ] Given the updated status transitions map, when I attempt any transition not listed in the valid transitions table, then the API returns a 400 error
+
+**Business Rules:** BR-011, BR-012, BR-013
+
+**Out of Scope:** Discovery Gate enforcement on `discovery -> build` and `preflight -> build` transitions (Phase 4). Requiring `discovery_gate_exception` flag for `preflight -> build` (Phase 4).
+
+---
+
+### US-006: Start a Discovery Sprint
+
+**As an** SC Operator,
+**I want** to initialize a discovery sprint for an experiment,
+**so that** I can formally begin the discovery process and log the sprint initiation.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment in `preflight` or `discovery` status, when I send `POST /experiments/:id/discovery/start`, then the experiment status transitions to `discovery` (if not already)
+- [ ] Given an experiment in `draft` status, when I send `POST /experiments/:id/discovery/start`, then the API returns a 400 error
+- [ ] Given a successful discovery start, when the sprint is initialized, then a `discovery_sprint_started` event is logged to `event_log` with `event_data` containing `{ mode: string, target_count: number, protocols: string[] }`
+- [ ] Given an experiment already in `discovery` status, when I send `POST /experiments/:id/discovery/start` again, then the API returns a 409 Conflict error (sprint already active)
+
+**Business Rules:** BR-011, BR-014
+
+**Out of Scope:** Auto-generating interview protocols from the Hypothesis Card (AI agent capability, not platform API). Candidate sourcing assistance.
+
+---
+
+### US-007: Record a Completed Interview
+
+**As an** SC Operator,
+**I want** to record a completed interview against an experiment,
+**so that** the interview data is captured in a structured format and contributes to the Discovery Summary.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment in `discovery` status, when I send `POST /experiments/:id/interviews` with valid interview data, then a new row is inserted into the `interviews` table
+- [ ] Given an experiment NOT in `discovery` status, when I send `POST /experiments/:id/interviews`, then the API returns a 400 error
+- [ ] Given valid interview data, when the `mode` field is `ai`, `hybrid`, or `human`, then the interview is accepted
+- [ ] Given valid interview data, when the `mode` field is an invalid value (e.g., "phone"), then the API returns a 400 error
+- [ ] Given valid interview data, when `protocols_covered` contains valid protocol names (`problem_discovery`, `solution_fit`, `willingness_to_pay`, `icp_validation`), then the interview is accepted
+- [ ] Given valid interview data, when `protocols_covered` is an empty array, then the API returns a 400 error (at least one protocol required)
+- [ ] Given valid interview data, when `participant_id` is provided, then it is stored as-is (opaque identifier)
+- [ ] Given valid interview data, when `pain_scores` is provided as a JSON object with `functional`, `emotional`, and `opportunity` numeric fields (1-5), then the scores are stored
+- [ ] Given valid interview data, when `pain_scores` has a value outside the 1-5 range, then the API returns a 400 error
+- [ ] Given valid interview data, when `signal_extraction` is provided as a JSON object, then it is stored as-is (flexible schema for extraction reports)
+- [ ] Given valid interview data, when `transcript_ref` is provided, then it is stored as an R2 key reference
+- [ ] Given valid interview data, when `duration_minutes` is provided, then it is stored as a positive integer
+- [ ] Given a successful interview creation, when the response is returned, then it includes the auto-generated `id` and `created_at` timestamp
+- [ ] Given a successful interview creation, when an `interview_completed` event is logged to `event_log`, then the event data includes `participant_id`, `mode`, `duration_minutes`, and `protocols_covered`
+
+**Business Rules:** BR-015, BR-016, BR-017, BR-018
+
+**Out of Scope:** Transcript upload to R2 (infrastructure concern, not API). Real-time AI co-pilot during interviews (Phase 2+ capability). AI-conducted interviews (Phase 3+ capability). Transcript-to-signal extraction automation (AI agent workflow, not API endpoint).
+
+---
+
+### US-008: Retrieve Discovery Summary
+
+**As an** SC Operator,
+**I want** to retrieve the current Discovery Summary for an experiment,
+**so that** I can review the aggregated interview findings, pain severity scores, and gate status.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment with a non-null `discovery_summary`, when I send `GET /experiments/:id/discovery/summary`, then the response includes the full Discovery Summary JSON
+- [ ] Given an experiment with a null `discovery_summary`, when I send `GET /experiments/:id/discovery/summary`, then the API returns a 404 with message "No discovery summary exists for this experiment"
+- [ ] Given a Discovery Summary in `draft` stage, when I retrieve it, then the `stage` field reads `draft`
+- [ ] Given a Discovery Summary in `final` stage, when I retrieve it, then the `stage` field reads `final`
+- [ ] Given a valid Discovery Summary, when I read it, then required fields are present: `experiment_id`, `hypothesis_card_version`, `interview_count`, `interview_count_weighted`, `mode_breakdown`, `problem_confirmed`, `pain_severity`, `current_alternatives_observed`, `top_quotes`, `assumption_updates`, `gate_status`, `saturation_reached`, `stage`
+
+**Business Rules:** BR-019
+
+**Out of Scope:** Auto-generating the Discovery Summary from interview records (AI agent workflow). Real-time incremental updates to the summary after each interview (Phase 2+ enhancement).
+
+---
+
+### US-009: Write a Discovery Summary
+
+**As an** SC Operator,
+**I want** to write or update the Discovery Summary for an experiment,
+**so that** I can record aggregated interview findings after analysis.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment in `discovery` status, when I send `PATCH /experiments/:id` with a valid `discovery_summary` JSON body, then the `discovery_summary` column is updated
+- [ ] Given a Discovery Summary JSON, when required fields are missing (`experiment_id`, `interview_count`, `problem_confirmed`, `pain_severity`, `gate_status`, `stage`), then the API returns a 400 error
+- [ ] Given a Discovery Summary with `interview_count_weighted`, when the value is provided, then it is accepted as a decimal number
+- [ ] Given a Discovery Summary with `pain_severity`, when it includes `functional`, `emotional`, `opportunity` scores, then each must be between 1.0 and 5.0
+- [ ] Given a Discovery Summary with `pain_severity`, when `composite` is provided, then it must equal the average of the three dimension scores (within rounding tolerance of 0.1)
+- [ ] Given a Discovery Summary with `pain_severity`, when `peak_dimension` is provided, then it must be one of `functional`, `emotional`, or `opportunity`
+- [ ] Given a Discovery Summary with `top_quotes`, when provided, then the array must not exceed 10 items
+- [ ] Given a Discovery Summary with `gate_status`, when provided, then it must include the `passed` boolean and `checks` object
+- [ ] Given a Discovery Summary with `stage` set to `final`, when the summary already has `stage: final`, then the API returns a 400 error (final summaries are immutable; see US-010)
+- [ ] Given a Discovery Summary with `stage` set to `draft`, when the summary is updated, then subsequent updates are allowed
+
+**Business Rules:** BR-019, BR-020, BR-021
+
+**Out of Scope:** Server-side computation of `composite` score from dimension scores (client is expected to compute and provide). Server-side computation of `interview_count_weighted` from `mode_breakdown` (client computes). Polarization flag calculation.
+
+---
+
+### US-010: Finalize a Discovery Summary
+
+**As an** SC Operator,
+**I want** to lock a Discovery Summary to "final" stage,
+**so that** the summary becomes immutable and serves as a formal input to Test Blueprint creation.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment with a `discovery_summary` in `draft` stage, when I send `POST /experiments/:id/discovery/finalize`, then the `stage` field is updated to `final`
+- [ ] Given an experiment with a `discovery_summary` already in `final` stage, when I send `POST /experiments/:id/discovery/finalize`, then the API returns a 400 error with message "Discovery summary is already finalized"
+- [ ] Given an experiment with no `discovery_summary`, when I send `POST /experiments/:id/discovery/finalize`, then the API returns a 400 error with message "No discovery summary to finalize"
+- [ ] Given a successful finalization, when I subsequently send `PATCH /experiments/:id` with changes to `discovery_summary`, then the API returns a 400 error with message "Cannot modify a finalized discovery summary"
+- [ ] Given a successful finalization, when a `discovery_summary_finalized` event is logged to `event_log`, then the event data includes `interview_count`, `weighted_count`, and `gate_passed`
+
+**Business Rules:** BR-022, BR-023
+
+**Out of Scope:** Reverting a finalized summary back to draft. Auto-finalizing based on saturation detection.
+
+---
+
+### US-011: Evaluate the Discovery Gate
+
+**As an** SC Operator,
+**I want** to evaluate the Discovery Gate for an experiment,
+**so that** I can determine whether the experiment has met the minimum discovery criteria to proceed to test design.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment with a non-null `discovery_summary`, when I send `GET /experiments/:id/discovery/gate`, then the response includes the evaluation of all 6 gate checks
+- [ ] Given the experiment's interviews, when the mode-weighted count is calculated as `(ai_count * 0.5) + (hybrid_count * 0.75) + (human_count * 1.0)`, then check #1 (minimum interviews) passes if the weighted count >= 5.0
+- [ ] Given the Discovery Summary's `pain_severity.composite`, when the composite >= 3.0, then check #2 (pain severity) passes
+- [ ] Given the Discovery Summary's `pain_severity`, when any single dimension (functional, emotional, opportunity) >= 4.0, then check #3 (peak dimension) passes regardless of composite score
+- [ ] Given checks #2 and #3, when either one passes, then the combined pain threshold is satisfied (OR logic)
+- [ ] Given the Discovery Summary's `problem_confirmed`, when it is `true`, then check #4 passes
+- [ ] Given the Discovery Summary's `assumption_updates`, when at least 1 assumption has been updated with evidence, then check #5 (assumption evidence) passes
+- [ ] Given the Discovery Summary's `saturation_reached`, when it is `true`, then check #6 passes
+- [ ] Given all 6 checks, when checks 1, 4, and 5 are required, and checks 2/3 are OR'd, and check 6 is recommended but not blocking, then `gate_status.passed` reflects the correct evaluation
+- [ ] Given an experiment with no `discovery_summary`, when I send `GET /experiments/:id/discovery/gate`, then the API returns a 400 error with message "No discovery summary available for gate evaluation"
+- [ ] Given the gate evaluation result, when the response is returned, then it includes the full `checks` object with `passed`, `value`, and `threshold` for each check
+
+**Business Rules:** BR-024, BR-025, BR-026, BR-027, BR-028
+
+**Out of Scope:** Gate override recording (allowed in the Discovery Summary but not enforced by the gate endpoint). Blocking experiment status transitions based on gate result (Phase 4). Per-category minimum interview counts (Demand Signal: 5.0, WTP: 8.0, Solution Validation: 10.0 -- deferred to Phase 4 when Test Blueprint is implemented).
+
+---
+
+### US-012: Query Interviews for an Experiment
+
+**As an** SC Operator,
+**I want** to list all interviews recorded for an experiment,
+**so that** I can review individual interview records and track discovery progress.
+
+**Acceptance Criteria:**
+
+- [ ] Given an experiment with recorded interviews, when I send `GET /experiments/:id/interviews` (implied by standard REST pattern), then the response includes an array of interview records
+- [ ] Given each interview record in the response, when I read it, then it includes `id`, `experiment_id`, `participant_id`, `mode`, `protocols_covered`, `duration_minutes`, `pain_scores`, `signal_extraction`, `transcript_ref`, `new_themes_detected`, `created_at`
+- [ ] Given an experiment with no interviews, when I query interviews, then the response is an empty array
+- [ ] Given multiple interviews exist, when I query them, then they are ordered by `created_at` ascending (chronological order)
+
+**Business Rules:** BR-016
+
+**Out of Scope:** Filtering interviews by mode or protocol. Pagination (not needed for MVP volumes -- typical discovery sprint has 5-30 interviews).
+
+---
+
+### US-013: Log Discovery Events to Event Log
+
+**As an** SC Operator,
+**I want** discovery activities to be automatically logged to the event log,
+**so that** there is a complete audit trail of the discovery process.
+
+**Acceptance Criteria:**
+
+- [ ] Given a discovery sprint is started, when the API call succeeds, then a `discovery_sprint_started` event is logged with experiment_id
+- [ ] Given an interview is recorded, when the API call succeeds, then an `interview_completed` event is logged with participant_id, mode, duration_minutes, and protocols_covered
+- [ ] Given an interview's AI analysis is completed (if signal_extraction is provided), when the interview is saved, then an `interview_analyzed` event is logged with new_themes count and pain_scores
+- [ ] Given a discovery summary is finalized, when the API call succeeds, then a `discovery_summary_finalized` event is logged with interview_count, weighted_count, and gate_passed
+- [ ] Given a discovery gate is evaluated, when the API call succeeds, then a `discovery_gate_evaluated` event is logged with the checks object and passed boolean
+- [ ] Given any discovery event is logged, when I query the event log for the experiment, then the events appear in chronological order with correct timestamps
+
+**Business Rules:** BR-029
+
+**Out of Scope:** `interview_scheduled` events (scheduling is out of platform scope for MVP). `saturation_detected` events (saturation is a client-side or AI-agent concern in Phase 1). Real-time event streaming.
+
+---
+
+## Business Rules
+
+| ID     | Rule                                                                                                                                                                                                      | Source                                             |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| BR-001 | All new columns added by Migration 0002 are nullable. Existing experiments continue to work without modification.                                                                                         | Functional Spec v2.0, Section 7                    |
+| BR-002 | The archetype `interview` is replaced by `fake_door`. Migration Step 2 converts draft/preflight interview experiments to `fake_door` and archives active ones.                                            | Functional Spec v2.0, Section 2.3; DD#2, Section 2 |
+| BR-003 | D1 does not enforce foreign keys by default. The `venture_id` column on experiments is advisory, not enforced at the database level until Phase 5.                                                        | Functional Spec v2.0, Section 2.1                  |
+| BR-004 | SQLite/D1 cannot ALTER CHECK constraints. Modifying archetype and status constraints requires the create-copy-drop-rename migration pattern.                                                              | Functional Spec v2.0, Section 2.3                  |
+| BR-005 | The Hypothesis Card has two tiers: Draft (Tier 1, 6 fields) and Full (Tier 2, 10 fields). Tier 1 is sufficient to enter discovery.                                                                        | DD#1, Section 3                                    |
+| BR-006 | The Hypothesis Card schema specifies `confidence` as an enum of `proceed`, `uncertain`, `abandon` with a required `confidence_rationale` string.                                                          | DD#1, Section 3.5; Schema Sketch Section 3.7       |
+| BR-007 | `key_assumptions` must have between 3 and 5 items when provided. Each assumption follows the structured format: claim, evidence, risk (high/medium/low), basis.                                           | DD#1, Section 3; Schema Sketch Section 3.7         |
+| BR-008 | The `one_liner` field has a maximum length of 200 characters. It is AI-generated, not template-interpolated.                                                                                              | DD#1, Section 4                                    |
+| BR-009 | When `hypothesis_card` is non-null on an experiment, the 4 Distill Brief columns (`target_audience`, `problem_statement`, `value_proposition`, `market_size_estimate`) become read-only projections.      | Functional Spec v2.0, Section 2.4                  |
+| BR-010 | Projection mapping: `target_audience` from `customer_segment`, `problem_statement` from `problem_statement`, `value_proposition` from `solution_hypothesis`, `market_size_estimate` from `market_sizing`. | Functional Spec v2.0, Section 2.4                  |
+| BR-011 | The status lifecycle gains a `discovery` state: `draft -> preflight -> discovery -> build -> launch -> run -> decide -> archive`.                                                                         | Functional Spec v2.0, Section 2.2                  |
+| BR-012 | Valid status transitions include `preflight -> discovery`, `preflight -> build` (with exception), `discovery -> build`, `discovery -> archive`. Any status except archive can transition to archive.      | Functional Spec v2.0, Section 2.2                  |
+| BR-013 | In Phase 3, `discovery` is added to valid transitions but Discovery Gate enforcement is not active. Gate enforcement is added in Phase 4.                                                                 | Functional Spec v2.0, Section 2.2, Phase 3 notes   |
+| BR-014 | A discovery sprint can only be started for experiments in `preflight` or `discovery` status.                                                                                                              | Functional Spec v2.0, Section 3.3                  |
+| BR-015 | Interview `mode` must be one of `ai`, `hybrid`, `human`. This is enforced by the CHECK constraint on the `interviews` table.                                                                              | Functional Spec v2.0, Section 2.7; DD#3, Section 3 |
+| BR-016 | Each interview is linked to exactly one experiment via `experiment_id`. Interviews cannot exist without a parent experiment.                                                                              | Functional Spec v2.0, Section 2.7                  |
+| BR-017 | `protocols_covered` is stored as a JSON array. Valid protocol names are: `problem_discovery`, `solution_fit`, `willingness_to_pay`, `icp_validation`.                                                     | DD#3, Section 4                                    |
+| BR-018 | `pain_scores` stores three dimensions: `functional`, `emotional`, `opportunity`. Each scored 1-5 per the rubric defined in DD#3, Section 5.                                                               | DD#3, Section 5                                    |
+| BR-019 | The Discovery Summary has two stages: `draft` (living document during sprint) and `final` (locked after sprint completes).                                                                                | DD#3, Section 6                                    |
+| BR-020 | Pain severity composite score is the unweighted average of `functional`, `emotional`, and `opportunity`, rounded to one decimal place. Range: 1.0 to 5.0.                                                 | DD#3, Section 5                                    |
+| BR-021 | Top quotes are capped at 10 items in the Discovery Summary. Each quote includes `quote`, `participant_id`, `dimension`, and `protocol` fields.                                                            | DD#3, Section 6                                    |
+| BR-022 | Once a Discovery Summary is finalized (stage = `final`), it is immutable. No further updates are accepted.                                                                                                | DD#3, Section 6                                    |
+| BR-023 | Finalization logs a `discovery_summary_finalized` event with interview_count, weighted_count, and gate_passed.                                                                                            | Functional Spec v2.0, Section 4                    |
+| BR-024 | Mode-weighted interview counting: AI = 0.5x, Hybrid = 0.75x, Human = 1.0x. Formula: `(ai_count * 0.5) + (hybrid_count * 0.75) + (human_count * 1.0)`.                                                     | DD#3, Section 7                                    |
+| BR-025 | Discovery Gate check #1: Minimum weighted interview count >= 5.0.                                                                                                                                         | DD#3, Section 7                                    |
+| BR-026 | Discovery Gate checks #2 and #3 are OR'd: Either composite pain severity >= 3.0 OR any peak dimension >= 4.0 satisfies the pain threshold.                                                                | DD#3, Section 7                                    |
+| BR-027 | Discovery Gate checks #1 (minimum interviews), #4 (problem confirmed), and #5 (assumption evidence) are required. Check #6 (saturation) is recommended but not blocking.                                  | DD#3, Section 7                                    |
+| BR-028 | The peak dimension rule: Any single dimension averaging >= 4.0 across interviews meets the Discovery Gate pain threshold, regardless of the composite score.                                              | DD#3, Section 5                                    |
+| BR-029 | All discovery activities must be logged to `event_log` with experiment_id, event_type, and structured event_data.                                                                                         | Functional Spec v2.0, Section 4                    |
+
+---
+
+## Edge Cases
+
+### EC-001: Migration with No Existing Interview Experiments
+
+If no experiments have `archetype = 'interview'` when Migration 0002 runs, the UPDATE statements in Step 2 affect zero rows. The migration proceeds without error. The verification query in Step 4 returns 0, which is the expected result.
+
+### EC-002: Hypothesis Card Written Before Discovery Summary
+
+An experiment can have a `hypothesis_card` and no `discovery_summary`. This is the normal flow -- the card is written at Step 1, discovery happens at Step 2. The gate evaluation endpoint should return a clear error ("No discovery summary available") rather than evaluating against empty data.
+
+### EC-003: Discovery Summary Without Hypothesis Card
+
+While the methodology expects a Hypothesis Card before discovery, the platform does not enforce this ordering in Phase 3. An operator could write a `discovery_summary` to an experiment that lacks a `hypothesis_card`. The API should accept this (backward compatibility with manual workflows) but the `hypothesis_card_version` field in the summary should be set to `draft` or `full` by the client based on the actual card state.
+
+### EC-004: Concurrent Writes to Discovery Summary
+
+If two API clients simultaneously PATCH an experiment's `discovery_summary`, D1's last-write-wins behavior means the second write overwrites the first. For MVP, this is acceptable because discovery sprints are operated by a single SC Operator per experiment. The risk is noted but not mitigated.
+
+### EC-005: Pain Score with Insufficient Data in a Dimension
+
+Per DD#3 Section 5 (AI Scoring Method), if fewer than 2 quotes exist for any pain dimension, that dimension should be scored as "insufficient data" rather than defaulting to 1. At the API level, the `pain_scores` JSON can represent insufficient data by omitting the dimension or setting it to `null`. The gate evaluation endpoint must handle null dimension scores: a null dimension does not count toward composite calculation and does not count as a peak dimension.
+
+### EC-006: Finalized Discovery Summary Prevents Experiment Status Rollback
+
+Once a Discovery Summary is finalized, it cannot be modified. However, the platform does not prevent the experiment from transitioning backward (e.g., `discovery -> preflight`). In Phase 3, status rollbacks are not blocked. If the experiment returns to an earlier status, the finalized summary remains attached but may be stale. This edge case will be addressed in Phase 4 with stricter lifecycle enforcement.
+
+### EC-007: Interview Recorded for Archived Experiment
+
+An experiment in `archive` status cannot accept new interviews (the experiment is not in `discovery` status). The API should return a 400 error. However, an experiment that transitions to `archive` after interviews have been recorded retains all historical interview data.
+
+### EC-008: Gate Evaluation with Zero Interviews
+
+If an experiment has a Discovery Summary with `interview_count: 0`, the gate evaluation should fail all checks and return `passed: false`. The weighted count is 0.0, composite pain severity cannot be computed (no data), problem_confirmed defaults to false, and no assumption evidence exists.
+
+### EC-009: Distill Brief Write Invariant with Null Hypothesis Card Fields
+
+If a `hypothesis_card` is written but `market_sizing` is null (because it is a Tier 2 field and the card is Tier 1), then `market_size_estimate` should be set to null via projection. If `market_size_estimate` previously had a value from direct population, the projection from a Tier 1 card overwrites it with null. The operator should be aware that writing a Tier 1 card clears the `market_size_estimate` column.
+
+### EC-010: Migration Preserves Existing Triggers and Indexes
+
+The create-copy-drop-rename migration pattern in Step 3 drops the original `experiments` table, which also drops associated triggers and indexes. Step 3 must explicitly recreate `idx_experiments_status`, `idx_experiments_slug`, and the `update_experiments_timestamp` trigger. If any trigger or index is missed, experiment updates may fail silently (no timestamp update) or query performance may degrade.
+
+### EC-011: Interview Mode Weighting with All-AI Interviews
+
+If all interviews are AI-moderated, the weighted count is halved relative to the raw count. For example, 8 AI interviews produce a weighted count of 4.0, which fails the minimum threshold of 5.0. The operator must run at least 10 AI-only interviews to pass the gate. This is by design -- the weighting creates an incentive to include human-led or hybrid interviews.
+
+### EC-012: Discovery Summary with Empty Assumption Updates
+
+The `assumption_updates` array is required per the schema, but it may be empty (`[]`). If it is empty, gate check #5 (assumption evidence) fails because no assumption has been updated with evidence. The operator must update at least one assumption with evidence for the gate to pass.
+
+---
+
+## Traceability Matrix
+
+This matrix maps user stories to functional spec sections, deep dive recommendations, and success metrics.
+
+| Story  | Feature Area                   | Functional Spec Sections | Deep Dive Recs                             | Success Metrics                                                                                               |
+| ------ | ------------------------------ | ------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| US-001 | Schema Migration               | 2.1, 2.3, 2.7, 7         | DD#1 R1-R3, DD#2 R1-R6, DD#3 R1-R2, R6, R8 | Migration completes without data loss; all verification queries pass                                          |
+| US-002 | Hypothesis Card Write          | 2.1, 3.1                 | DD#1 R1, R2                                | Hypothesis Cards can be persisted and retrieved; validation rejects malformed data                            |
+| US-003 | Distill Brief Write Invariant  | 2.4, 3.1                 | DD#1 R3                                    | Legacy Distill Brief columns stay consistent with Hypothesis Card; direct edits rejected when card is present |
+| US-004 | Hypothesis Card Read           | 2.1, 3.1                 | DD#1 R2                                    | Hypothesis Cards are returned correctly via experiment GET                                                    |
+| US-005 | Status Transition: Discovery   | 2.2, 3.1                 | DD#3 R6                                    | Experiments can transition to `discovery` status; invalid transitions are rejected                            |
+| US-006 | Discovery Sprint Start         | 3.3, 4                   | DD#3 R3                                    | Discovery sprints can be initialized; events are logged                                                       |
+| US-007 | Interview Recording            | 2.7, 3.3, 4              | DD#3 R2, R3                                | Interviews are persisted with all metadata; mode validation enforced                                          |
+| US-008 | Discovery Summary Read         | 3.3                      | DD#3 R1, R3                                | Discovery Summary is retrievable; null handling is correct                                                    |
+| US-009 | Discovery Summary Write        | 2.1, 3.1                 | DD#3 R1                                    | Discovery Summary JSON can be persisted; validation rejects malformed data                                    |
+| US-010 | Discovery Summary Finalization | 3.3, 4                   | DD#3 R3                                    | Finalization locks the summary; subsequent modifications are rejected                                         |
+| US-011 | Discovery Gate Evaluation      | 3.3                      | DD#3 R3, R4                                | Gate evaluates all 6 checks correctly; mode-weighted counting produces correct results                        |
+| US-012 | Interview Query                | 3.3                      | DD#3 R2, R3                                | Interview records are retrievable per experiment; ordering is chronological                                   |
+| US-013 | Discovery Event Logging        | 4                        | DD#3 R5                                    | Discovery events are logged to event_log with correct event_types and event_data                              |
+
+---
+
+## Open Questions
+
+| ID     | Question                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Impact                                                                                                                                                                                         | Recommended Resolution                                                                                                                                                                                                                                                                                                                               |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OQ-001 | Should the gate evaluation endpoint (`GET /discovery/gate`) compute the weighted interview count from the `interviews` table directly, or read the pre-computed value from `discovery_summary.interview_count_weighted`? The functional spec says "computed server-side when the gate is evaluated, not stored as a static value" (DD#3 Rec 4), which implies querying the interviews table. But the Discovery Summary also stores this value. Which is authoritative? | Gate evaluation accuracy; potential for stale data if summary is not updated after each interview.                                                                                             | Compute from the `interviews` table rows (count by mode, apply weights) for the gate endpoint. The Discovery Summary's `interview_count_weighted` is a snapshot, not the source of truth for gate evaluation.                                                                                                                                        |
+| OQ-002 | What happens to a Discovery Summary when a new interview is recorded after the summary has been written? Is the operator expected to re-write the summary with updated aggregations, or should the API auto-update draft summaries?                                                                                                                                                                                                                                    | Operator workflow complexity. If manual: risk of stale summaries. If auto: requires server-side aggregation logic in Phase 3.                                                                  | Phase 3 keeps it manual: the operator (or AI agent) writes an updated Discovery Summary after processing new interviews. Auto-aggregation is a Phase 4+ enhancement.                                                                                                                                                                                 |
+| OQ-003 | The `discovery_summary.pain_severity.composite` field is described as a simple average, but EC-005 (insufficient data in a dimension) means the composite may need to be computed from fewer than 3 dimensions. Should the composite be the average of available dimensions only, or should it require all 3 dimensions?                                                                                                                                               | Handling of incomplete pain data; affects gate check #2 accuracy.                                                                                                                              | Composite requires all 3 dimensions. If any dimension is insufficient, the composite is null, and the pain threshold can only be met via check #3 (peak dimension in a dimension that has sufficient data).                                                                                                                                          |
+| OQ-004 | Should the `POST /experiments/:id/interviews` endpoint accept `pain_scores` with individual dimension values of `null` to represent "insufficient data"? The DD#3 AI scoring method says score as "insufficient data" rather than defaulting to 1, but the schema sketch shows `minimum: 1, maximum: 5` for each score.                                                                                                                                                | API validation rules; affects EC-005 handling.                                                                                                                                                 | Accept `null` per dimension in `pain_scores` to represent insufficient data. Update the schema sketch to allow null per dimension while keeping the 1-5 range for non-null values.                                                                                                                                                                   |
+| OQ-005 | The functional spec says `PATCH /experiments/:id` should accept `discovery_summary` as an updatable field (Section 3.1), but also defines dedicated endpoints for discovery operations (Section 3.3). Which is the canonical write path for the Discovery Summary? Is it PATCH or a dedicated endpoint?                                                                                                                                                                | API design consistency; potential for conflicting write paths.                                                                                                                                 | Use `PATCH /experiments/:id` with `discovery_summary` as the primary write path, consistent with how `hypothesis_card` works. The `/discovery/summary` GET endpoint is read-only. The `/discovery/finalize` POST endpoint is the only endpoint that modifies the summary's stage field. This avoids creating a separate write API for each artifact. |
+| OQ-006 | Should Hypothesis Card validation be strict (reject cards missing required Tier 1 fields) or lenient (accept partial cards and leave completeness to the client)? The schema sketch marks 6 Tier 1 fields as `required: true`, but enforcing this in the API prevents incremental card building.                                                                                                                                                                       | Developer experience vs. data quality. Strict validation prevents partial cards. Lenient validation allows incremental workflow but may result in incomplete cards passing through the system. | Enforce required fields per tier. If `tier: draft`, require all 6 Tier 1 fields. If `tier: full`, require all 10 fields plus confidence and confidence_rationale. Reject cards with missing required fields. This matches the methodology: a Tier 1 card takes ~30 minutes and should be complete when submitted.                                    |
+| OQ-007 | The functional spec mentions CampaignPackage write invariant (Section 2.5) where `copy_pack` and `creative_brief` become read-only when `campaign_package` is non-null. Should this invariant be implemented in Phase 2 alongside the Distill Brief write invariant, or deferred to Phase 5 with the Campaign Factory?                                                                                                                                                 | Implementation scoping. Implementing the invariant early is cheaper (same code pattern as Distill Brief invariant) but the `campaign_package` column will not be populated until Phase 5.      | Defer to Phase 5. The invariant only matters when `campaign_package` is populated, which requires the Campaign Factory. Implementing it now would add unused code.                                                                                                                                                                                   |

--- a/docs/pm/prd-contributions/round-1/competitor-analyst.md
+++ b/docs/pm/prd-contributions/round-1/competitor-analyst.md
@@ -1,0 +1,282 @@
+# Competitor Analyst Contribution - PRD Review Round 1
+
+**Author:** Competitor Analyst (AI Panel)
+**Date:** 2026-03-02
+**Scope:** MVP / Phase 0 only (Silicon Crane as a Validation-as-a-Service offering)
+
+---
+
+## 1. Competitive Landscape
+
+Silicon Crane operates at the intersection of three established markets: AI idea validation tools, design/innovation sprint agencies, and venture studios. No single competitor occupies the exact same niche -- "productized, done-for-you validation sprints with structured GO/NO-GO methodology at sub-$5K price points" -- but the adjacent categories exert real competitive pressure because they address the same buyer pain: "I have an idea and I don't know if it's worth pursuing."
+
+### Market Map
+
+| Category                          | What They Sell                                                | Price Range                         | Delivery Model           | SC Overlap                                                        |
+| --------------------------------- | ------------------------------------------------------------- | ----------------------------------- | ------------------------ | ----------------------------------------------------------------- |
+| **AI Idea Validators**            | Instant AI-generated reports on idea viability                | $0 - $59/report                     | Self-serve SaaS          | Low-medium: addresses same initial impulse, but no execution      |
+| **Lean Startup Platforms**        | Software to manage experiments, canvases, customer interviews | $0 - $49/mo SaaS                    | Self-serve SaaS          | Low: tooling, not service                                         |
+| **Market Experiment Platforms**   | AI-assisted in-market testing (ad-based experiments)          | $2K - $18K/experiment set           | Hybrid SaaS + managed    | High: closest to SC's Run + Decide sprint                         |
+| **Design Sprint Agencies**        | Facilitated 5-day to 8-week sprints for product/brand         | $15K - $250K+                       | Done-for-you consulting  | Medium: similar sprint model, much higher price                   |
+| **MVP Dev Shops**                 | Build prototype/MVP to spec                                   | $20K - $140K+                       | Done-for-you development | Medium: SC explicitly is NOT this, but buyers confuse them        |
+| **Venture Studios**               | Build companies from scratch, take equity                     | $25K-$50K validation phase + equity | Equity partnership       | Low-medium: different business model, but overlapping methodology |
+| **Startup Consultants / Coaches** | Advisory, mentorship, strategy                                | $150-$500/hr or retainers           | Coaching/advisory        | Low: SC does the work, not just advises                           |
+
+---
+
+## 2. Competitor Deep Dives
+
+### 2.1 Heatseeker.ai
+
+**What they do:** AI-powered market experiment platform. Users define hypotheses, Heatseeker generates ad creatives and runs real paid experiments (social media A/B tests) to measure actual market demand.
+
+| Attribute        | Detail                                                                                                                                                                                 |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Target User**  | Product teams, innovation teams, startup founders with budget for ad spend                                                                                                             |
+| **Pricing**      | Contact sales; reported $16K-$18K for 6-8 experiments; avg $1,500 ad spend per experiment. Free tier available for basic features                                                      |
+| **Platform**     | Web SaaS + managed ad experiments                                                                                                                                                      |
+| **Funding**      | $2.3M pre-seed (2024)                                                                                                                                                                  |
+| **Strengths**    | Real in-market data (not just AI analysis); synthetic customer personas; scientific experiment design; scales well for portfolio/enterprise use                                        |
+| **Weaknesses**   | Expensive for solo founders; requires sales call; no strategic framing (no hypothesis sharpening or kill criteria); tests demand only, not solution fit or willingness to pay at depth |
+| **Threat Level** | **HIGH**                                                                                                                                                                               |
+
+**Why high threat:** Heatseeker directly automates the "Run + Decide" phase that SC charges for. Their AI-generated experiments produce real market signals. If a founder discovers Heatseeker, they may skip SC entirely for demand validation. Heatseeker's weakness is that it is a tool, not a partner -- it does not help you define what to test, interpret results holistically, or make the GO/NO-GO call. SC's methodology (Hypothesis Card through Validation Report) is genuinely more comprehensive. But Heatseeker is automating the most expensive part of SC's offering.
+
+---
+
+### 2.2 DimeADozen.ai
+
+**What they do:** AI-generated 40+ page business validation reports. Enter an idea, get a comprehensive analysis covering market size, competition, SWOT, financial projections.
+
+| Attribute        | Detail                                                                                                                                                     |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Target User**  | First-time entrepreneurs, idea-stage founders, business students                                                                                           |
+| **Pricing**      | Free (basic); $59 (Entrepreneur -- full report); Enterprise (custom, white-label)                                                                          |
+| **Platform**     | Web SaaS                                                                                                                                                   |
+| **User Base**    | 85K+ entrepreneurs                                                                                                                                         |
+| **Strengths**    | Instant results; very low price; 40+ page reports feel substantial; commercial use rights; good for initial gut-check                                      |
+| **Weaknesses**   | AI-only analysis (no real market data); no execution; reports can be generic; no kill criteria or structured decision framework; "validation theater" risk |
+| **Threat Level** | **MEDIUM**                                                                                                                                                 |
+
+**Why medium threat:** DimeADozen sits at the top of the funnel. A founder who pays $59 and gets a positive AI report may feel "validated" enough to skip SC's Preflight sprint entirely. The threat is not that DimeADozen is better -- it is not -- but that it is dramatically cheaper and "good enough" for founders who do not yet understand the difference between AI analysis and real market evidence. SC's counter: position Preflight as the step AFTER the AI report, where you test the AI's optimistic assumptions with real humans.
+
+---
+
+### 2.3 IdeaProof.io
+
+**What they do:** AI-powered startup validator with market intelligence from 50+ sources. Delivers TAM/SAM/SOM, competitor SWOT, financial projections, brand strategy, and even logo/ad creative generation.
+
+| Attribute        | Detail                                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Target User**  | Early-stage founders, solopreneurs                                                                                                  |
+| **Pricing**      | Free (90 credits); Explorer at EUR 9.99 (150 credits); subscriptions $9-$24/mo                                                      |
+| **Platform**     | Web SaaS                                                                                                                            |
+| **Strengths**    | Very fast (120 seconds); real-time market intelligence; includes brand strategy and creative generation; extremely low cost         |
+| **Weaknesses**   | No real market testing; AI-generated brand assets are generic; no human judgment; no execution support; can create false confidence |
+| **Threat Level** | **MEDIUM**                                                                                                                          |
+
+**Why medium threat:** Similar to DimeADozen -- addresses the same initial impulse at a fraction of SC's cost. The brand/creative generation feature is notable because it overlaps with SC's Campaign Factory (DD#4). IdeaProof generates ad creatives for Meta, Google, LinkedIn, and TikTok in minutes, which is exactly what SC's async campaign generation pipeline does. However, IdeaProof's creatives are not connected to real experiments or validated messaging.
+
+---
+
+### 2.4 ValidatorAI
+
+**What they do:** AI validation of startup ideas with scoring, roadmap generation, and AI mentor chatbot ("Val").
+
+| Attribute        | Detail                                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| **Target User**  | Aspiring entrepreneurs, idea-stage founders                                                      |
+| **Pricing**      | Free (Standard); $25/mo (PRO -- 5 reports/mo, AI mentor, custom roadmaps)                        |
+| **Platform**     | Web SaaS                                                                                         |
+| **Strengths**    | AI mentor chatbot for ongoing guidance; launch simulation feature; roadmap generation; low price |
+| **Weaknesses**   | No real market data; limited to AI analysis; no execution; roadmaps are generic                  |
+| **Threat Level** | **LOW**                                                                                          |
+
+**Why low threat:** ValidatorAI is a consumer-grade tool targeting the most price-sensitive, earliest-stage founders. Anyone willing to pay $2,500+ for SC is past the ValidatorAI stage. However, ValidatorAI's "launch simulation" feature is interesting competitive intelligence -- SC should consider whether the methodology could produce a simulated launch scenario as a lower-cost entry point.
+
+---
+
+### 2.5 GLIDR / LaunchPad
+
+**What they do:** Lean startup platform for managing experiments, business model canvases, and validation processes. Primarily serves universities and accelerators.
+
+| Attribute        | Detail                                                                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Target User**  | Universities (400+), accelerators, enterprise innovation teams                                                                 |
+| **Pricing**      | Not publicly listed; enterprise/institutional pricing                                                                          |
+| **Platform**     | Web SaaS                                                                                                                       |
+| **Strengths**    | Established in academic/accelerator ecosystem; comprehensive lean methodology tooling; portfolio tracking for program managers |
+| **Weaknesses**   | Tool, not service; academic-focused; no execution support; not designed for independent founders                               |
+| **Threat Level** | **LOW**                                                                                                                        |
+
+**Why low threat:** Different market entirely (institutional vs. individual founder). However, GLIDR's existence means that many founders coming out of accelerator programs already have a validation framework they are familiar with. SC needs to articulate why its methodology is better than what they learned in their program, or position as the execution layer on top of whatever framework they already know.
+
+---
+
+### 2.6 Design Sprint Agencies (AJ&Smart, Zypsy, Character)
+
+**What they do:** Facilitated innovation sprints (typically 5 days to 8 weeks) combining design thinking, prototyping, and user testing.
+
+| Attribute        | Detail                                                                                                                                                                             |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Target User**  | Funded startups, enterprise teams, product teams with budget                                                                                                                       |
+| **Pricing**      | $15K-$75K (boutique); $75K-$250K (mid-tier); $250K+ (premium). Some offer equity arrangements for early startups                                                                   |
+| **Platform**     | In-person or remote facilitation                                                                                                                                                   |
+| **Strengths**    | Proven methodology (Google Ventures Sprint); high-touch; produce tangible prototypes; strong brand recognition; established market                                                 |
+| **Weaknesses**   | Very expensive; sprint scope is narrow (usually one design problem, not business validation); heavy on design, light on market testing; require significant client time commitment |
+| **Threat Level** | **MEDIUM**                                                                                                                                                                         |
+
+**Why medium threat:** Design sprints are the closest analog to SC's sprint model, but at 5-30x the price. The real threat is perceptual: a founder searching for "validation sprint" will find design sprint agencies and may assume SC is either (a) a cheaper, lower-quality version, or (b) something fundamentally different. SC needs clear positioning against design sprints: "We test whether your business works, not just whether your prototype is usable."
+
+---
+
+### 2.7 MVP Development Shops
+
+**What they do:** Build MVPs and prototypes to spec. Some (like VeryCreatives) offer structured "MVP Validation Sprints" that include user testing.
+
+| Attribute        | Detail                                                                                                                                    |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Target User**  | Funded founders who want a working product                                                                                                |
+| **Pricing**      | $20K-$55K (simple MVP); $55K-$140K (SaaS MVP); structured sprints ~6 weeks                                                                |
+| **Platform**     | Custom development                                                                                                                        |
+| **Strengths**    | Produce working software; technical execution; some include validation feedback loops                                                     |
+| **Weaknesses**   | Expensive; scope creep risk; "building" orientation rather than "validating" orientation; success metric is delivery, not GO/NO-GO signal |
+| **Threat Level** | **MEDIUM**                                                                                                                                |
+
+**Why medium threat:** This is the category SC most needs to distance itself from. The project instructions explicitly state "Silicon Crane is NOT a dev shop." But the Build-to-Launch sprint ("working prototype/MVP deployed") blurs this line. Founders may compare SC's $2,500 founding client rate to a $30K MVP shop and conclude SC is suspiciously cheap, or they may expect SC to build production software. Clear scope definition in the SOW is critical.
+
+---
+
+## 3. Feature Comparison Matrix (MVP / Phase 0)
+
+This matrix compares SC's planned MVP features against the most relevant competitors.
+
+| Feature                         | SC (MVP)                | Heatseeker                   | DimeADozen            | IdeaProof                     | Design Sprint Agency  |
+| ------------------------------- | ----------------------- | ---------------------------- | --------------------- | ----------------------------- | --------------------- |
+| Hypothesis sharpening           | Yes (Hypothesis Card)   | No                           | Partial (AI analysis) | Partial (AI analysis)         | Yes (facilitated)     |
+| Kill criteria defined upfront   | Yes                     | No                           | No                    | No                            | Sometimes             |
+| Customer interviews / discovery | Yes (Discovery Engine)  | Synthetic personas           | No                    | No                            | Yes (user testing)    |
+| Landing page experiments        | Yes (Launchpad)         | Yes (ad experiments)         | No                    | No                            | Sometimes (prototype) |
+| Real market data collection     | Yes (Run + Decide)      | Yes                          | No                    | Partial (market intelligence) | Limited               |
+| GO/NO-GO decision framework     | Yes (Verdict)           | No                           | No                    | No                            | No                    |
+| AI-generated campaign assets    | Yes (Campaign Factory)  | Yes                          | No                    | Yes                           | No                    |
+| Structured methodology          | Yes (6 deep dives)      | Partial                      | No                    | No                            | Yes (design sprint)   |
+| Done-for-you execution          | Yes                     | Hybrid (tool + some managed) | No (self-serve)       | No (self-serve)               | Yes                   |
+| Price for comparable scope      | $2,500 (founding) / TBD | $16K-$18K                    | $59                   | $9-$24/mo                     | $15K-$75K             |
+| Time to result                  | 3-21 days               | Days-weeks                   | Seconds               | 2 minutes                     | 5 days - 8 weeks      |
+
+---
+
+## 4. Differentiation Analysis
+
+### Where SC Genuinely Differs
+
+1. **End-to-end methodology with decision framework.** No competitor in this price range offers a complete chain from hypothesis through evidence-based GO/NO-GO verdict. AI tools stop at analysis. Design sprint agencies stop at prototype testing. Heatseeker stops at experiment data. SC's artifact chain (Hypothesis Card -> Discovery Summary -> Test Blueprint -> Campaign Package -> Live Experiment -> Validation Report) is architecturally unique.
+
+2. **Kill criteria as a first-class concept.** SC is the only offering that makes kill criteria mandatory and structural. This is a genuine philosophical differentiator. Every other tool or service is incentivized to keep the founder optimistic. SC's explicit "kill bad ideas fast" positioning is counter-positioned against the market.
+
+3. **Price point for done-for-you service.** At $2,500 (founding rate), SC undercuts design sprint agencies by 6-30x while offering comparable or greater depth. This is either a compelling value proposition or a credibility problem (see Uncomfortable Truths).
+
+4. **Practitioner credibility (eat-your-own-cooking).** SC uses its own methodology for its own ventures (DFG case study). This is a legitimate differentiator that most AI tools and agencies cannot claim.
+
+### Where SC Does NOT Differ (or Claims Differentiation That Is Weak)
+
+1. **"We do the work, not just advise."** This is table stakes for any agency or dev shop. It only differentiates against coaches and consultants, who are not the primary competitive threat.
+
+2. **"Speed: 2 weeks vs 6 months."** AI tools deliver in seconds to minutes. Heatseeker runs experiments in days. SC's 2-week timeline is only fast compared to the "founder floundering alone for 6 months" scenario, not compared to tooling alternatives.
+
+3. **"Structured sprints with clear deliverables."** Every design sprint agency says this. Every productized service says this. This is not differentiation; it is baseline professionalism.
+
+4. **AI-generated campaign assets.** IdeaProof already generates ad creatives across major platforms in under 10 minutes. SC's Campaign Factory (DD#4) is more sophisticated (connected to validated hypothesis, brand-aware, A/B variants), but the raw capability is not unique.
+
+---
+
+## 5. Pricing and Business Model Benchmarks
+
+### What Competitors Actually Charge
+
+| Competitor / Category       | Pricing Model          | Actual Price                  | What You Get                                    |
+| --------------------------- | ---------------------- | ----------------------------- | ----------------------------------------------- |
+| DimeADozen.ai               | Per-report             | $59                           | 40+ page AI analysis report                     |
+| IdeaProof.io                | Credits / subscription | $9-$24/mo                     | AI validation + brand strategy + creatives      |
+| ValidatorAI                 | Subscription           | $25/mo                        | AI validation + roadmap + mentor chatbot        |
+| FounderPal                  | Subscription           | $29/mo                        | AI idea validation + persona generation         |
+| IdeaSmokeTest               | Per-test               | EUR 49                        | AI-generated landing page + form + traffic plan |
+| Heatseeker                  | Custom / contact sales | $16K-$18K for 6-8 experiments | Real in-market ad experiments with data         |
+| Design Sprint (boutique)    | Per-sprint             | $15K-$75K                     | 5-day to 8-week facilitated sprint              |
+| MVP Dev Shop (simple)       | Per-project            | $20K-$55K                     | Working prototype in 5-8 weeks                  |
+| Venture Studio (validation) | Equity + capital       | $25K-$50K + equity            | Full validation phase with studio resources     |
+| LEANSTACK coaching          | Per-certification      | $2,500/workshop               | 3-30 day training + methodology                 |
+
+### What This Means for SC
+
+SC's founding client rate of $2,500 sits in a pricing no-man's-land:
+
+- **50x more expensive** than AI validation tools ($25-$59)
+- **6-7x cheaper** than Heatseeker or design sprint agencies ($15K-$18K)
+- **8-22x cheaper** than MVP dev shops ($20K-$55K)
+
+This creates a positioning challenge. At $2,500, SC is too expensive for the "just checking my idea" crowd (who will use AI tools) and potentially too cheap to be credible for the "serious founder with budget" crowd (who expect to pay $15K+ for professional services).
+
+### Price Expectations by Buyer Segment
+
+| Segment                    | Expected Price | SC Fit                                 |
+| -------------------------- | -------------- | -------------------------------------- |
+| Idea-stage dreamer         | $0-$100        | Poor -- will use AI tools              |
+| Serious first-time founder | $1K-$5K        | Good -- SC's sweet spot                |
+| Funded early-stage startup | $10K-$50K      | Weak -- may question quality at $2,500 |
+| Enterprise innovation team | $50K-$200K     | Poor -- no enterprise credentials      |
+
+---
+
+## 6. Uncomfortable Truths
+
+These are honest assessments of competitive weaknesses that need to be addressed, not ignored.
+
+### 6.1 The AI Tools Are "Good Enough" for Most Buyers
+
+The harsh reality is that most people with a startup idea will never pay $2,500 for validation. They will pay $59 for a DimeADozen report, feel validated (or not), and move on. The total addressable market for SC is not "everyone with a startup idea" -- it is the much smaller subset of founders who (a) understand that AI analysis is not real validation, (b) have $2,500+ to spend, and (c) are willing to accept a NO-GO answer. This is a very small market.
+
+### 6.2 The Founding Client Rate Creates a Credibility Trap
+
+$2,500 for a done-for-you validation sprint is extraordinarily cheap. A sophisticated buyer will ask: "How can you do all this for $2,500?" The answer -- "I'm a solo operator subsidizing early clients for case studies" -- is honest but fragile. It positions SC as a side project, not a professional service. When SC raises prices to market rates (presumably $5K-$15K per sprint), early positioning at $2,500 may make the jump feel unjustified to referral prospects who heard "it's only $2,500."
+
+### 6.3 Heatseeker Is Automating SC's Highest-Value Phase
+
+SC's Run + Decide sprint (14-21 days, highest price) is where the real value lives -- actual market testing with real ad spend and data. Heatseeker automates this with AI-generated experiments, synthetic personas, and real ad platforms. As Heatseeker matures and drops in price, the technology layer of SC's offering becomes a commodity. SC's remaining moat is the human judgment layer: hypothesis framing, kill criteria, interpretation, and the GO/NO-GO call.
+
+### 6.4 The SC Console Is Internal Tooling, Not a Product
+
+The functional spec (v2.0) describes sophisticated internal tooling: 7 implementation phases, 61 recommendations, 4 new database tables, 20+ API endpoints. But SC is selling a service, not software. Clients never see the console. This means SC is building $100K+ of engineering infrastructure to support a service that charges $2,500 per client. The unit economics only work at scale, and productized consulting services are notoriously hard to scale past the founder's personal capacity.
+
+### 6.5 No Case Studies, No Social Proof, No Track Record
+
+Every competitor -- even the AI tools -- has user counts, testimonials, or case studies. DimeADozen claims 85K+ entrepreneurs. Heatseeker has a $2.3M raise and enterprise clients. SC has zero completed client engagements and one internal case study (DFG) that is not yet written. In a market where trust is the primary purchase driver, SC is starting from zero.
+
+### 6.6 "Kill Bad Ideas Fast" Is a Hard Sell
+
+SC's positioning -- "we'll tell you your idea is bad" -- is intellectually honest but commercially difficult. Founders want to hear "yes." Services that tell founders "no" do not get referrals from those founders. The entire AI validation tool market is built on telling people what they want to hear (positive reports with upside projections). SC is swimming against the current of human psychology.
+
+### 6.7 The Methodology Is the Moat, But Methodologies Are Copyable
+
+SC's 6-deep-dive methodology is genuinely rigorous. But methodologies can be copied. Lean Startup, Design Sprint, and Jobs-to-be-Done were all proprietary methodologies that became commoditized. If SC succeeds, larger players (Heatseeker, design sprint agencies) can adopt similar structured frameworks. SC's sustainable moat is execution quality and practitioner expertise, not the methodology itself.
+
+---
+
+## 7. Recommendations for PRD
+
+Based on this competitive analysis:
+
+1. **Position SC explicitly against AI validation tools**, not alongside them. Messaging should be: "You got the AI report. Now let's find out if it's actually true." Make Preflight the bridge between a $59 AI report and real-world testing.
+
+2. **Address the price credibility gap.** Consider positioning the $2,500 founding rate as a limited-time, named-client program with explicit conditions (case study rights, testimonial, feedback), not as "the price." Future pricing should be visible as the "real" rate to anchor expectations.
+
+3. **Prioritize the DFG case study above all other work.** Without social proof, nothing else matters. One real case study with real metrics beats all positioning statements.
+
+4. **De-scope the SC Console engineering.** The functional spec v2.0 is building for a future state where SC has dozens of concurrent clients. At zero clients, the console is premature infrastructure. Validate the service with manual processes first, then automate what works.
+
+5. **Define the actual sprint pricing before launch.** "TBD" on all sprint prices is not a competitive position. Competitors have clear pricing. SC needs numbers, even if they change.
+
+---
+
+_Analysis based on competitor research conducted 2026-03-02. Pricing and feature data sourced from competitor websites, search results, and public sources. All pricing subject to change._

--- a/docs/pm/prd-contributions/round-1/product-manager.md
+++ b/docs/pm/prd-contributions/round-1/product-manager.md
@@ -1,0 +1,343 @@
+# Product Manager Contribution - PRD Review Round 1
+
+**Author:** Product Manager
+**Date:** 2026-03-02
+**Scope:** MVP / Phase 0 only
+**Source Documents:** `docs/process/sc-project-instructions.md`, `docs/technical/sc-functional-spec-v2.md`
+
+---
+
+## Executive Summary
+
+**Problem:** Entrepreneurs burn months of runway and tens of thousands of dollars building products before discovering their idea does not work. There is no productized, evidence-based service that provides a fast, structured validation outcome a founder can act on.
+
+**Solution:** Silicon Crane (SC) is a Validation-as-a-Service (VaaS) offering that runs structured sprints -- Preflight, Build-to-Launch, Run + Decide, and Scale Readiness -- to produce a clear GO/NO-GO signal backed by real market data. SC Console is the internal platform that powers these sprints: it manages experiments end-to-end from hypothesis definition through market testing to evidence-based verdicts.
+
+**Value:** Founders get a defensible validation outcome in 2-3 weeks for a fraction of the cost of building blindly. SC gets a repeatable, methodology-driven delivery model that scales across ventures and clients. The console codifies the entire validation artifact chain -- Hypothesis Card through Validation Report -- so that every sprint is traceable, every decision is evidence-backed, and every learning compounds into better calibration over time.
+
+---
+
+## Product Vision & Identity
+
+### Name & Tagline
+
+- **Product Name:** SC Console
+- **Service Brand:** Silicon Crane
+- **Tagline:** "Kill bad ideas in 2 weeks instead of 6 months."
+
+### Positioning
+
+SC Console is the internal operating system for Silicon Crane's validation sprints. It is not a customer-facing SaaS product. It is the engine that lets SC run structured experiments, capture market signals, and produce evidence-based verdicts for clients and internal ventures.
+
+SC Console sits in the Venture Crane ecosystem alongside DFG and other ventures. It shares the Cloudflare-native infrastructure pattern (Workers, D1, R2, Pages) but intentionally diverges on frontend framework (Astro instead of Next.js) because SC is a content-heavy marketing and landing page system, not a data-heavy dashboard.
+
+### What This Is
+
+- An internal experiment management platform for running validation sprints
+- A structured artifact pipeline from raw idea through market verdict
+- A landing page generation and signal capture system for experiment archetypes
+- A measurement and decision support system that produces evidence-backed GO/NO-GO recommendations
+
+### What This Is NOT
+
+- Not a customer-facing SaaS product (clients see deliverables, not the console)
+- Not a dev shop tool (we validate hypotheses, not build to spec)
+- Not a general-purpose CMS or website builder
+- Not an ad platform (we integrate with ad platforms, not replace them)
+- Not a CRM (we capture leads for experiments, not manage sales pipelines)
+
+---
+
+## Product Principles
+
+These principles are ordered by priority. When two principles conflict, the higher-ranked one wins.
+
+### 1. Evidence Over Opinion
+
+Every experiment must produce measurable data. Every decision must reference that data. The system must never allow a GO/KILL/PIVOT decision without a metrics snapshot. If we cannot measure it, we do not ship it.
+
+### 2. Kill Fast, Kill Cheap
+
+The entire system is optimized to surface failure signals as early and inexpensively as possible. Kill criteria are defined before launch, not after. Hard kill triggers are non-negotiable. The system biases toward protecting the client's capital over protecting the hypothesis.
+
+### 3. Backward Compatibility Is Non-Negotiable
+
+All schema changes are additive (nullable columns). Existing experiments continue to work without modification. Write invariants only activate when new columns are populated. The functional spec v2.0 is additive to tech spec v1.2, not a replacement. No migration may break existing data.
+
+### 4. Methodology Is the Product
+
+The artifact chain (Hypothesis Card -> Discovery Summary -> Test Blueprint -> Campaign Package -> Live Experiment -> Validation Report) is the core intellectual property. Every feature must reinforce the methodology. Features that bypass the chain (e.g., launching without kill criteria) are bugs, not shortcuts.
+
+### 5. Internal-First, Client-Sanitized
+
+The console is an internal tool. Client visibility follows Option B (sanitized): clients see weekly updates and deliverable documents, not GitHub issues or the Command Center. The system must produce clean, portable deliverables (case studies, validation reports, decision memos) without exposing internal tooling.
+
+### 6. Operational Simplicity Over Feature Richness
+
+Cloudflare-native stack was chosen for lowest operational complexity. No recurring infrastructure costs at low traffic. Single deployment target. Every infrastructure addition (Queues, R2 buckets, cron triggers) must justify its operational overhead. Defer complexity to later phases when it is proven necessary.
+
+### 7. Compound Learning
+
+Every completed experiment calibrates the system. Threshold registries improve with data. Venture benchmarks accumulate. The system gets better at predicting outcomes as the portfolio grows. Design for learning accumulation from day one, even if Phase 1 uses hardcoded defaults.
+
+---
+
+## Success Metrics & Kill Criteria
+
+### MVP Success Metrics (Phase 0 / Tier 1 Buildout)
+
+The MVP goal defined in the project instructions is: **accept first paying client.**
+
+| Metric                          | Target                            | Measurement Method              | Timeline                      |
+| ------------------------------- | --------------------------------- | ------------------------------- | ----------------------------- |
+| First paying client acquired    | 1 client                          | Stripe payment received         | Within 4 weeks of site launch |
+| Intake form submissions         | >= 5                              | Tally/Typeform submission count | Within 4 weeks of site launch |
+| Warm network outreach completed | 20 contacts reached               | Manual tracking                 | Week 1 post-launch            |
+| Services page live              | Deployed at siliconcrane.com      | URL reachable, content reviewed | End of Tier 1 sprint          |
+| Payment mechanism functional    | Stripe checkout/invoice working   | Test transaction                | End of Tier 1 sprint          |
+| Contract/SOW template complete  | Signed template exists            | Document review                 | End of Tier 1 sprint          |
+| DFG case study drafted          | Published draft with real metrics | Content review                  | End of Tier 1 sprint          |
+
+### Platform Success Metrics (v2.0-alpha / Milestone A)
+
+These measure whether the console platform is functioning after Phases 1-3:
+
+| Metric                                                      | Target                                                     | Measurement Method                            |
+| ----------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------- |
+| Experiments created and progressed through status lifecycle | >= 1 experiment reaches `run` status                       | D1 query                                      |
+| Hypothesis Cards populated                                  | 100% of new experiments have `hypothesis_card`             | D1 query: `WHERE hypothesis_card IS NOT NULL` |
+| Discovery interviews recorded                               | >= 3 interviews per experiment entering discovery          | `interviews` table count per experiment       |
+| Landing pages rendering per archetype                       | All 7 archetypes render correctly                          | Manual QA per archetype                       |
+| Signal capture operational                                  | `event_log` receiving `page_view` and `form_submit` events | D1 query on `event_log`                       |
+| Leads captured via landing pages                            | >= 1 lead per launched experiment                          | `leads` table count                           |
+
+### Kill Criteria for the SC Venture Itself
+
+These determine whether Silicon Crane as a business is viable. They come directly from the project instructions' emphasis on GO/NO-GO signals with evidence.
+
+| Kill Criterion                                          | Threshold                                                              | Evaluation Point           |
+| ------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------- |
+| Zero paying clients after outreach to 20+ warm contacts | 0 conversions from 20 contacts                                         | 6 weeks post-launch        |
+| Intake form submissions with zero qualified leads       | 0 leads pass qualification criteria after 10+ submissions              | 8 weeks post-launch        |
+| Founding client rate ($2,500) generates zero interest   | 0 expressions of interest at founding rate                             | 6 weeks post-launch        |
+| Capacity conflict kills delivery quality                | DFG priority arbitration causes missed client deadlines more than once | First client engagement    |
+| Sprint delivery takes 2x or more the estimated duration | Preflight exceeds 10 days, Build-to-Launch exceeds 20 days             | First 2 client engagements |
+
+---
+
+## Risks & Mitigations
+
+### Business Risks
+
+| Risk                                                                                                                                                  | Likelihood | Impact | Mitigation                                                                                                                                                                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pricing not validated.** All sprint prices are TBD. Founding rate of $2,500 is a guess.                                                             | High       | High   | Lock pricing before launch (Tier 1, Day 1). Start with founding rate for first 3-5 clients. Use those engagements to calibrate real pricing. Do not launch without specific numbers.                                                            |
+| **Capacity conflict with DFG.** Project instructions flag this as an open question: if DFG needs urgent work AND a client needs attention, what wins? | High       | High   | Define priority arbitration rules before accepting first client. Recommendation: client-facing deadlines always win over internal venture work. If this is untenable, limit to 1 concurrent client engagement until DFG reaches a steady state. |
+| **No case study at launch.** DFG case study is drafted in Tier 1 but may not have compelling enough metrics.                                          | Medium     | Medium | Ship DFG case study even if metrics are modest -- frame it as "Experiment #1" with transparency about what was learned. Honesty about methodology is more compelling than inflated numbers.                                                     |
+| **Market positioning confusion.** Prospects may confuse SC with agencies, accelerators, or consultants.                                               | Medium     | Medium | The "What SC Is Not" section is already well-defined. Bake it into the services page, FAQ, and outreach messaging. Lead with methodology differentiation: "We use kill criteria, you get evidence."                                             |
+
+### Technical Risks
+
+| Risk                                                                                                                                                                            | Likelihood | Impact   | Mitigation                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1 CHECK constraint migration is destructive.** The create-copy-drop-rename pattern for updating CHECK constraints risks data loss if executed incorrectly.                   | Medium     | Critical | Run full migration in local D1 first. Verify row counts before and after. Run in preview environment second. Production last. Step 4 verification queries are mandatory in every environment. Never skip verification.                                                                                                                   |
+| **Async pipeline complexity.** Cloudflare Queue for campaign generation adds operational surface area.                                                                          | Medium     | Medium   | Deferred to Phase 5. Not an MVP concern. When implemented, start with synchronous fallback and add Queue only after proving the pipeline works end-to-end.                                                                                                                                                                               |
+| **Write invariant enforcement creates API surface complexity.** Two write invariant patterns (Distill Brief, CampaignPackage) mean PATCH behavior varies based on column state. | Medium     | Medium   | Document invariant behavior exhaustively in API docs. Add clear error messages when invariant rejects a write (e.g., "Cannot update target_audience directly when hypothesis_card is present. Update hypothesis_card.customer_segment instead."). Add comprehensive test coverage for both paths (invariant active, invariant inactive). |
+| **Schema migration on production D1 with live data.** Migration 0002 modifies the experiments table structure.                                                                  | Low        | Critical | Migration is additive (new nullable columns) for Steps 1 and 2. Step 3 (table recreation) is the risk point. Schedule migration during low-traffic window. Take D1 export before migration. Verify foreign key PRAGMA state before deploying.                                                                                            |
+
+### Execution Risks
+
+| Risk                                                                                                                                                      | Likelihood | Impact | Mitigation                                                                                                                                                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **7-phase implementation plan is too long.** Phases 1-7 span the entire methodology. Real value delivery is delayed until late phases.                    | High       | High   | Milestone A (Phases 1-3) is the checkpoint. Target 2-3 weeks. If Milestone A takes more than 4 weeks, re-evaluate Phase 4-7 scope. Ship incremental value: Phase 1 (schema) enables manual workflows even without UI.                                         |
+| **Scope creep from 61 recommendations.** The functional spec consolidates 61 deep-dive recommendations. Temptation to implement everything in each phase. | High       | Medium | Each phase has explicit scope boundaries (see Phased Development Plan below). A feature is in one phase, not "partially in Phase 0." Phase boundaries are enforced in PR review. Discover additional work mid-task -- finish current scope, file a new issue. |
+| **Single-operator dependency.** SC is currently a one-person operation with no redundancy.                                                                | High       | High   | Accept this constraint for MVP. Founding client rate acknowledges early-stage limitations. Do not oversell capacity. Limit to 1 concurrent engagement until process is proven.                                                                                |
+
+---
+
+## Open Decisions / ADRs
+
+These decisions must be resolved before or during development. Each is assigned a decision deadline relative to the phase that depends on it.
+
+### ADR-001: Sprint Pricing
+
+- **Decision needed:** Specific dollar amounts for each sprint type (Preflight, Build-to-Launch, Run + Decide, Scale Readiness)
+- **Depends on:** Tier 1 launch (cannot launch without prices)
+- **Deadline:** Before first outreach
+- **Options:** (a) Fixed per-sprint pricing, (b) Time-and-materials with cap, (c) Value-based pricing tied to outcomes
+- **Recommendation:** Fixed per-sprint pricing for simplicity. Founding rate of $2,500 for any sprint type for the first 3-5 clients.
+
+### ADR-002: Capacity and Priority Arbitration
+
+- **Decision needed:** How many engagements can run in parallel with DFG work? If DFG needs urgent work AND a client needs attention, what wins?
+- **Depends on:** First client acceptance
+- **Deadline:** Before signing first client contract
+- **Options:** (a) Client always wins, (b) DFG always wins, (c) Case-by-case with SLA-based rules
+- **Recommendation:** Client-facing deadlines always win. Cap at 1 concurrent client engagement until DFG reaches steady state.
+
+### ADR-003: Client Tooling Access
+
+- **Decision needed:** Do clients see the factory? (Option A: Transparent, B: Sanitized, C: Graduated)
+- **Depends on:** First client kickoff
+- **Deadline:** Before first client kickoff call
+- **Recommendation:** Start with Option B (sanitized). Weekly updates and deliverable docs only. Revisit after 3 completed engagements.
+
+### ADR-004: Equity Option
+
+- **Decision needed:** Does SC ever take equity instead of or in addition to cash?
+- **Depends on:** Not blocking for MVP, but must be decided before it comes up in a client conversation
+- **Deadline:** Before 5th client outreach
+- **Recommendation:** No equity for MVP. Cash only. Equity introduces legal complexity and misaligns incentives with the "kill fast" methodology.
+
+### ADR-005: Discovery Gate Enforcement Timing
+
+- **Decision needed:** When does the Discovery Gate become a hard gate vs. advisory?
+- **Depends on:** Phase 3 (Discovery Engine) and Phase 4 (Gate enforcement)
+- **Deadline:** Before Phase 4 development begins
+- **Current plan:** Phase 3 adds `discovery` status with no gate logic. Phase 4 adds enforcement. The `discovery_gate_exception` flag allows bypassing.
+- **Recommendation:** Keep the phased approach. Do not enforce gates until there is enough data (at least 3 completed experiments) to calibrate what "good" discovery looks like.
+
+### ADR-006: Archetype Migration for Existing Data
+
+- **Decision needed:** How to handle active experiments with `interview` archetype during migration
+- **Depends on:** Phase 1 (Schema Foundation)
+- **Deadline:** Before Migration 0002 executes
+- **Current plan:** Draft/preflight `interview` experiments migrate to `fake_door`. Active `interview` experiments get archived.
+- **Risk:** If any active experiment is mid-sprint with `interview` archetype, archiving it disrupts the engagement.
+- **Recommendation:** Audit all experiments before migration. If any active `interview` experiments exist, coordinate with the engagement owner before migrating.
+
+---
+
+## Phased Development Plan
+
+### Phase 0: Business Foundation (Tier 1 -- "Accept First Paying Client")
+
+**Goal:** Everything needed to accept money from the first client. No platform development; this is business infrastructure.
+
+**In scope:**
+
+- Lock pricing for all 4 sprint types
+- Services page on siliconcrane.com (copy + layout)
+- Intake form (Typeform/Tally with notification setup)
+- Contract/SOW template (legal-enough to start work)
+- Payment mechanism (Stripe product + checkout/invoice link)
+- DFG case study draft (Hypothesis -> Test -> Data -> Decision -> Current State)
+- Warm network outreach (first 20 targets)
+
+**Not in scope:**
+
+- Any console platform development
+- Any schema migrations
+- Any API changes
+- FAQ page, process explainer, cold outreach templates (Tier 2/3)
+
+**Exit criteria:** siliconcrane.com has a services page with prices, intake form captures submissions, Stripe can process a payment, SOW template is ready to send, DFG case study is published.
+
+**Dependencies:** None. This is the starting point.
+
+---
+
+### Phase 1: Schema Foundation
+
+**Goal:** Run Migration 0002 to lay the data model groundwork for all subsequent phases. No application code changes.
+
+**In scope:**
+
+- Execute all 4 migration steps (add columns, data migration, CHECK constraint recreation, verification)
+- 10 new columns on `experiments` table (6 artifact, 4 supporting)
+- 1 new column on `decision_memos` table (`decision_detail`)
+- 4 new tables (`interviews`, `ventures`, `threshold_registry`, `venture_benchmarks`)
+- Updated CHECK constraints (`archetype`: replace `interview` with `fake_door`; `status`: add `discovery`)
+- Verification queries in local, preview, and production
+
+**Not in scope:**
+
+- Any API endpoint changes
+- Any frontend changes
+- Any write invariant enforcement
+- Ventures CRUD API (deferred to Phase 5)
+
+**Exit criteria:** Migration 0002 passes all Step 4 verification queries in all 3 environments. Zero `interview` archetype rows remain. Row counts preserved. Triggers fire correctly. Existing experiments continue to work via existing API.
+
+**Dependencies:** ADR-006 resolved (audit existing `interview` experiments before migration).
+
+---
+
+### Phase 2: Hypothesis Card
+
+**Goal:** Experiments gain structured hypothesis definition via the Hypothesis Card artifact.
+
+**In scope:**
+
+- `hypothesis_card` column read/write via `PATCH /experiments/:id`
+- Distill Brief write invariant: reject direct updates to `problem_statement`, `target_audience`, `value_proposition`, `market_size_estimate` when `hypothesis_card` is non-null
+- Auto-extraction of projections on `hypothesis_card` write
+- Confidence score validation (`proceed` / `uncertain` / `abandon`)
+- `abandon` confidence triggers archive recommendation (advisory only, not enforced)
+
+**Not in scope:**
+
+- AI agent scaffolding for hypothesis generation (advisory mention in spec, not a Phase 2 deliverable)
+- Key Assumptions bridge to kill_criteria (Phase 4)
+- Ventures CRUD (Phase 5)
+
+**Exit criteria:** Creating an experiment with a `hypothesis_card` auto-populates Distill Brief columns. Directly updating Distill Brief columns on an experiment with a `hypothesis_card` returns a 400 error with a clear message. Experiments without `hypothesis_card` continue to work as before.
+
+**Dependencies:** Phase 1 complete.
+
+---
+
+### Phase 3: Discovery Engine
+
+**Goal:** Experiments can enter a `discovery` phase with recorded interviews and a gate evaluation.
+
+**In scope:**
+
+- `interviews` table CRUD (`POST /experiments/:id/interviews`, query by experiment)
+- `discovery_summary` column read/write
+- Discovery API endpoints: `/discovery/start`, `/discovery/summary`, `/discovery/finalize`, `/discovery/gate`
+- `discovery` added to `VALID_STATUS_TRANSITIONS`
+- Basic Discovery Gate logic (6 checks: minimum interviews, pain severity, peak dimension, problem confirmed, assumption evidence, saturation)
+- Mode-weighted counting (`ai * 0.5 + hybrid * 0.75 + human * 1.0`)
+- Discovery event types in `event_log`
+
+**Not in scope:**
+
+- Discovery Gate enforcement on status transitions (Phase 4)
+- R2 transcript storage (infrastructure addition deferred; use `transcript_ref` as placeholder)
+
+**Exit criteria:** An experiment can transition `preflight -> discovery`. Interviews can be recorded against it. Discovery gate endpoint returns a structured evaluation with 6 checks. Discovery summary can be finalized.
+
+**Dependencies:** Phase 1 complete (tables exist). Phase 2 recommended but not strictly required.
+
+---
+
+### Phases 4-7: Deferred (Post-MVP)
+
+The following phases are defined in the functional spec but are explicitly out of MVP scope. They are listed here for roadmap visibility only.
+
+| Phase | Name                               | Key Deliverables                                                                                                                                  | Dependency |
+| ----- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 4     | Test Blueprint + Validation Ladder | `test_blueprint` read/write, archetype defaults, Discovery Gate enforcement, Hard/Soft Kill severity                                              | Phase 3    |
+| 5     | Campaign Factory                   | `campaign_package` read/write, CampaignPackage write invariant, Ventures CRUD API, Cloudflare Queue async pipeline, R2 asset storage              | Phase 4    |
+| 6     | The Launchpad                      | `page_config` read/write, archetype-aware template router, SignalCapture component, A/B variant support, preview mode                             | Phase 5    |
+| 7     | The Verdict                        | `validation_report` read/write, `decision_detail`, measurement endpoints, Bayesian confidence, threshold registry population, PII purge extension | Phase 6    |
+
+**Milestone A (v2.0-alpha):** Phases 1-3 complete. Target: 2-3 weeks after Phase 0.
+**Milestone B (v2.0-beta):** Phases 4-7 complete. Target: incremental after Milestone A.
+
+---
+
+## Appendix: Scope Boundary Enforcement
+
+To prevent scope creep, the following rules apply:
+
+1. **A feature lives in exactly one phase.** No "partially in Phase 2, completed in Phase 3" allowances. If it spans phases, split it into discrete deliverables and assign each to one phase.
+
+2. **Phase 0 has no platform development.** It is pure business infrastructure. The temptation to "just add one endpoint" is the enemy.
+
+3. **Discover additional work mid-task -- finish current scope, file a new issue.** This is a project instruction and it is binding.
+
+4. **All changes through PRs.** Never push directly to main. Branch, PR, CI, QA, merge. This applies to documentation, schema changes, and code equally.
+
+5. **MVP scope is Phase 0 (business foundation) plus Milestone A (Phases 1-3).** Everything in Phases 4-7 is explicitly deferred and requires a separate planning cycle before development begins.

--- a/docs/pm/prd-contributions/round-1/target-customer.md
+++ b/docs/pm/prd-contributions/round-1/target-customer.md
@@ -1,0 +1,147 @@
+# Target Customer Contribution - PRD Review Round 1
+
+**Author:** Target Customer Persona (composite)
+**Date:** 2026-03-02
+**Scope:** MVP / Phase 0 only
+
+---
+
+## Who I Am
+
+I'm a mid-career product manager at a mid-size SaaS company. I have ten years of experience watching products succeed and fail, and for the last three years I've had a side project rattling around in my head -- a B2B tool for independent insurance agents that I believe could be a real business. I know the domain because my wife's family runs an agency. I can read code, I can set up a Stripe checkout, I can fumble through a landing page, but I am not a developer and I do not want to become one to test whether this idea has legs.
+
+I've been burned before. Two years ago I spent four months and about $12,000 building a prototype for a different idea -- a meal planning tool for families with food allergies. I hired a freelancer, we built the thing, I put up some Facebook ads, and got absolutely nothing. Crickets. The freelancer got paid. I got a lesson. The worst part wasn't the money, it was the four months of evenings and weekends I spent on something I should have killed in week two.
+
+So now I'm gun-shy. I have this new idea and I genuinely believe in it, but I'm terrified of repeating the same mistake. I follow a few indie hacker communities. I've read The Lean Startup. I know intellectually that I should "validate before building." But I don't actually know how to do that in practice. Running Facebook ads to a landing page with a waitlist? Sure, I've heard of it. But setting up the tracking, interpreting the results, knowing what number means "go" versus "stop" -- that's where I get lost.
+
+---
+
+## My Current Pain
+
+Right now, my validation process is basically Googling and vibes. I've talked to a few people in my wife's family about the insurance agent problem and they all nod enthusiastically, but they're family -- of course they nod. I don't trust that signal.
+
+I've looked at hiring a marketing agency to run some test campaigns, but the ones I've talked to want $5,000-10,000/month retainers and a 3-month commitment. They want to "build my brand." I don't have a brand. I have a hypothesis. They don't understand the difference.
+
+I've also looked at doing it myself. I spent a weekend trying to set up a landing page with Carrd and connect it to Google Ads and... I got overwhelmed. Not by any single step, but by the combination of decisions: What should the headline say? What's the right audience targeting? How much should I spend? What conversion rate means this idea is worth pursuing? **I don't have frameworks for any of this, and I know that "just winging it" is how I ended up $12,000 poorer last time.**
+
+The emotional reality is this: I think about this idea every single day. I daydream about quitting my job to build it. And then I remember the meal planning disaster and I do nothing. I've been stuck in this loop for eight months. I'm not making progress because I'm afraid of making the wrong kind of progress.
+
+---
+
+## First Reactions
+
+### What Excites Me
+
+**The structured sprint model hits me right where it hurts.** "Kill bad ideas in 2 weeks instead of 6 months" -- that's exactly what I needed to hear two years ago. The idea that there's a defined process with clear milestones and a verdict at the end is enormously appealing. I don't want hand-holding. I don't want coaching calls. I want someone to actually do the work of testing my idea and give me a straight answer.
+
+The Preflight sprint (3-5 days, hypothesis sharpened, kill criteria defined, test plan ready) feels like the exact entry point I need. I don't even know how to frame my idea properly. Having someone structure it into a testable hypothesis before spending money on ads? That alone might be worth the price.
+
+**The kill criteria concept is weirdly reassuring.** Defining upfront what "failure" looks like means I won't be able to rationalize away bad results the way I did with the meal planning thing ("well, maybe I just need to tweak the targeting..."). Having someone external enforce intellectual honesty is something I cannot do for myself.
+
+### What Confuses Me
+
+I read the functional spec and I honestly got lost about a third of the way through. There's a lot of technical architecture in there -- D1 databases, Cloudflare Workers, Hono routes, migration patterns -- and I cannot tell what I'm supposed to interact with versus what's under the hood. **Is SC Console a product I log into? Or is it the internal tooling the SC team uses to run my sprint?** The project instructions say clients might get "sanitized weekly updates and deliverable docs only" or might see the full "Command Center." I need to know which one, because it completely changes my expectations.
+
+The seven archetypes (fake_door, waitlist, content_magnet, priced_waitlist, presale, concierge, service_pilot) -- I don't know what half of those mean. "Fake door" sounds deceptive. "Content magnet" sounds like marketing jargon. If I'm going to be involved in choosing which test to run, these names need plain-English explanations. If the SC team picks for me and I never see these labels, then fine, but that's not clear from what I read.
+
+The "Venture Narrative" / "Hypothesis Card" / "Discovery Summary" terminology is a lot. It feels like a branded methodology that's designed to impress other consultants, not to help me understand what's happening with my idea. **I don't care what the internal framework is called. I care about: is my idea worth pursuing?**
+
+### What Scares Me
+
+**Pricing is TBD.** The founding client rate is $2,500, but for which sprint? All of them? That feels too cheap for a 14-21 day engagement and too expensive for 3-5 days if I'm being honest about my risk tolerance. The fact that regular pricing isn't even defined yet tells me this service is very early. Am I going to be a guinea pig?
+
+The AI-conducted customer discovery interviews concern me. If you're telling me that an AI chatbot is going to interview potential insurance agents about their pain points... I'm skeptical. These are people in their 50s and 60s who barely use email. They're not going to open up to a bot the way they would to a human. If the discovery phase is heavily AI-driven, I worry the signal quality will be garbage, and then every decision downstream is built on sand.
+
+---
+
+## Feature Reactions
+
+### Preflight Sprint (3-5 days) -- Hypothesis + Kill Criteria + Test Plan
+
+**Would I use this? Absolutely yes.** This is the single most valuable thing in the entire offering. I would pay for this even if I never bought another sprint. Getting my messy idea turned into a structured hypothesis with defined kill criteria and a concrete test plan? That's the bridge between "I have an idea" and "I'm running a real test." Right now I'm stuck on that bridge.
+
+### Build-to-Launch Sprint (7-10 days) -- Working Prototype/MVP
+
+I'm less sure about this one. The description says "working prototype/MVP deployed, ready for market test." But I thought Silicon Crane wasn't a dev shop? If they're building me a landing page with tracking and signal capture, great. If "prototype" means a functional product... that doesn't match the rest of the positioning. **I need clarity on what "build" means in a validation context.** A landing page with a waitlist form is not the same as a working product, and I need to know which one I'm getting.
+
+### Run + Decide Sprint (14-21 days) -- Market Test Executed + GO/NO-GO
+
+**This is where the real value is, but it's also the scariest commitment.** 14-21 days plus ad spend ($300-500 based on what I read) means I'm looking at the sprint fee plus a few hundred in ad budget. If the total is around $3,000 all-in for a clear GO/NO-GO answer backed by real data? **That is a fraction of what I wasted last time, and I'd get an actual answer instead of a half-built product nobody wanted.**
+
+What I need to know: what does the deliverable actually look like? Is it a PDF report? A dashboard I can view? A call where someone walks me through the results? "Validation Report + Decision Memo" means nothing to me without seeing a sample.
+
+### Scale Readiness (Follow-on)
+
+Not relevant to me right now. I can't think about scaling something that hasn't been validated yet. Skip.
+
+### Hypothesis Card (The Venture Narrative)
+
+Sounds useful in concept. Taking my raw idea and structuring it into customer segment, problem statement, stakes, solution, and why-now -- that's genuinely good thinking. The two-tier approach (draft card to start discovery, full card after) makes sense. **My concern is whether this happens collaboratively with me or whether it's done to me.** If someone hands me a completed Hypothesis Card and says "here's your idea, structured," I might disagree with how they framed it. I need to be in the room for this step.
+
+### Customer Discovery Interviews
+
+I mentioned this above. The concept is right -- you need to talk to real people before spending on ads. The AI interview mode makes me nervous. "Hybrid" mode (AI + human) I could live with if it means a real person reviews the AI's findings and does at least a couple of live calls. Pure AI interviews for my target market (independent insurance agents, not tech-savvy, relationship-oriented)? **That feels like it would produce systematically misleading data.** I need confidence that the interview approach matches my customer's comfort level.
+
+### Landing Page + Signal Capture
+
+Yes. This is exactly what I couldn't do myself. A professionally built landing page matched to my test type, with proper tracking, connected to my ad campaigns, that captures real intent signals? **This is the capability gap that stopped me cold when I tried on my own.** The archetype-aware template system sounds smart in theory -- different test types need different page structures. As long as the output looks professional and not like a generic template, I'm sold.
+
+### A/B Testing + Channel Variants
+
+Nice to have but honestly not something I would have asked for. If you're running a $300-500 campaign, splitting that across A/B variants and multiple channels means each variant gets very little traffic. I'd rather concentrate spend on one strong approach than dilute across variants. **If the team thinks A/B testing is the right call at this budget level, I'll trust them, but I'm skeptical it'll produce statistically meaningful results on $300 of ad spend.**
+
+### Measurement + Decision System (The Verdict)
+
+The concept of having defined thresholds and a structured decision process is exactly what I need. The Bayesian confidence calculations, threshold registries, and venture benchmarks described in the spec sound rigorous. **But I don't want to see any of that.** I want to see: "Here's what happened. Here's what it means. Here's our recommendation and the evidence behind it." If the deliverable is a clean report with a clear verdict, great. If I need to understand what "Beta-Binomial model with Beta(1,1) prior" means, you've lost me.
+
+### PII Handling / 90-Day Retention
+
+This matters to me more than you'd think. If you're collecting email addresses and contact info from people who signed up on my landing page, those are potential future customers. **I need to know I'm getting that data before you purge it.** The 90-day retention policy for archived experiments makes sense for data hygiene, but if my experiment gets a GO verdict, I need to walk away with a clean lead list. This needs to be explicit in the deliverables.
+
+---
+
+## What I Need to See
+
+**Before I put down money on day one, I need these things:**
+
+1. **A real case study with real numbers.** The DFG case study mentioned in the project instructions is the single most important piece of content for converting me. I need to see: what was the idea, what test did you run, what were the metrics, what was the verdict, and what happened next. If the answer is "we killed it" -- great, that's even more convincing than a success story. Show me you actually practice what you preach.
+
+2. **A sample deliverable.** I want to see what a Validation Report and Decision Memo actually look like. Not a template. A real one. With real data (anonymized if needed). If I'm paying for a verdict, I want to know what shape that verdict takes.
+
+3. **Clear pricing.** "TBD" doesn't work for me. I need to know the exact cost of each sprint type and what's included versus extra (like ad spend). The $2,500 founding rate is interesting but confusing -- is that per sprint or for the whole package?
+
+4. **A human conversation before I commit.** I'm not going to fill out a form and get auto-qualified by an AI. I want to talk to someone who understands validation methodology and can tell me whether my specific idea (B2B tool for insurance agents) is a good fit for this service. If the qualification call is just a sales pitch, I'll walk. If it's genuinely diagnostic -- "here's why your idea is or isn't a good candidate for our sprints" -- that's incredibly valuable and builds trust.
+
+5. **Proof that the methodology works at small scale.** The functional spec describes infrastructure designed for a portfolio of ventures -- benchmark tables, cross-venture analytics, threshold recalibration. That's great for the long term. But you're asking me to be one of the first paying clients. **I need to know this works for one idea, tested once, at a budget of under $3,000.** The sophisticated portfolio features are irrelevant to me right now.
+
+---
+
+## Make-or-Break Concerns
+
+**I would abandon this product if:**
+
+- **The process feels like a black box.** If I hand over $2,500 and hear nothing for two weeks and then get a report, that's a bad experience. I need visibility into what's happening -- not GitHub issues, but at minimum a weekly update that says "here's where we are, here's what we're seeing, here's what comes next." The "sanitized weekly updates" option from the project instructions is the right model.
+
+- **The verdict feels like it was decided before the test ran.** If the kill criteria are so aggressive that almost everything gets killed, I'll feel like I paid $2,500 for someone to tell me "no." The thresholds need to feel fair and evidence-based, not designed to generate a kill so the engagement ends quickly.
+
+- **AI replaces human judgment at the decision point.** I'm fine with AI helping generate campaign copy, build landing pages, even conduct preliminary interviews. But when it comes to the final GO/NO-GO recommendation, **I need a human who has looked at my specific data and applied real judgment.** A Bayesian model spitting out a confidence percentage is input, not a decision.
+
+- **I can't get my data out.** If the experiment produces leads, metrics, interview transcripts, and creative assets -- I need to own all of that. If the platform holds my data hostage or makes it hard to export, that's a dealbreaker. These are my potential customers and my intellectual property.
+
+- **Scope creep disguised as methodology.** If every sprint ends with "you should also do this next sprint," I'll feel like I'm being upsold. The whole point of kill criteria is to help me stop. If the recommendation is always "do more," the methodology is broken.
+
+---
+
+## Willingness to Pay
+
+**The honest truth:** $2,500 is in my comfort zone for the founding client rate, but only if it's clear what I'm getting. At my income level, $2,500 is "significant but not terrifying" -- it's roughly what I'd spend on a family vacation. I'd pay it for a clear, evidence-based answer to "should I pursue this idea."
+
+For the Preflight sprint alone (3-5 days, structured hypothesis + test plan), I'd pay $500-750 without blinking. That's a no-brainer compared to fumbling around on my own.
+
+For the full Run + Decide sprint (14-21 days with real market testing), $2,000-3,000 feels fair plus ad spend. If you told me $5,000 all-in for a complete validation cycle from raw idea to GO/NO-GO verdict with evidence, I'd seriously consider it -- because the alternative is spending $12,000 and four months like I did last time.
+
+**What I would not pay for:** a report full of jargon that I have to interpret myself. Strategy decks. Frameworks without execution. "Here's what you should do next" without having actually done anything. I've bought consulting before. I'm not buying advice. I'm buying answers.
+
+**The $2,500 founding client rate is smart pricing.** It's low enough that I'd take the risk on an unproven service. The exchange (case study rights + testimonial + feedback) feels fair. But you need to close that loop: once you have founding clients, regular pricing needs to be published immediately. "TBD" pricing signals that you don't know what this is worth yet, and if you don't know, I definitely don't know.
+
+**One more thing on pricing:** the sprint types are confusing as separate products. I don't want to choose between Preflight, Build-to-Launch, and Run + Decide. I want to say "here's my idea, tell me if it's worth building" and have someone tell me which sprints I need. If the answer is "you need all three for $X," that's fine. But making me pick before I understand the methodology? That's asking me to make a decision I'm not qualified to make. **Package it for me. I'll pay more for simplicity.**

--- a/docs/pm/prd-contributions/round-1/technical-lead.md
+++ b/docs/pm/prd-contributions/round-1/technical-lead.md
@@ -1,0 +1,864 @@
+# Technical Lead Contribution - PRD Review Round 1
+
+**Author:** Technical Lead
+**Date:** 2026-03-02
+**Scope:** MVP / Phase 0 only (Functional Spec v2.0, Phases 1-3)
+**Source Documents:** `sc-project-instructions.md`, `sc-functional-spec-v2.md`
+**Baseline:** Tech Spec v1.2 (implemented), `0001_initial_schema.sql`
+
+---
+
+## 1. Architecture & Technical Design
+
+### 1.1 System Boundaries (Current State)
+
+The v1.2 system is deployed and operational. The architecture diagram below shows the current production state plus the v2.0 additions for MVP scope (Phases 1-3).
+
+```
+                           siliconcrane.com
+                         (Cloudflare Pages)
+  ┌──────────────────────────────────────────────────────┐
+  │                                                      │
+  │  Static SSG Pages    SSR Landing Pages    Lead Forms │
+  │  (marketing)         [slug].astro         (HTML+JS)  │
+  │                                                      │
+  └──────────────────────┬───────────────────────────────┘
+                         │ HTTPS (public + internal)
+                         v
+  ┌──────────────────────────────────────────────────────┐
+  │                     sc-api                           │
+  │               (Cloudflare Worker / Hono)             │
+  │                                                      │
+  │  Public:             Internal (X-SC-Key):            │
+  │  POST /leads         GET/POST/PATCH /experiments     │
+  │  POST /events        GET /experiments/:id/leads      │
+  │  POST /contact       POST /metrics                   │
+  │  GET /exp/by-slug/*  */decision_memos                │
+  │  POST /pay/webhook   */learning_memos                │
+  │                                                      │
+  │  v2.0 MVP additions (Phase 3):                       │
+  │  POST /experiments/:id/discovery/start               │
+  │  POST /experiments/:id/interviews                    │
+  │  GET  /experiments/:id/discovery/summary             │
+  │  POST /experiments/:id/discovery/finalize            │
+  │  GET  /experiments/:id/discovery/gate                │
+  │                                                      │
+  └───────┬──────────────────┬───────────────────────────┘
+          │                  │
+          v                  v
+    ┌──────────┐       ┌──────────┐
+    │  sc-db   │       │ sc-assets│
+    │   (D1)   │       │   (R2)   │
+    └──────────┘       └──────────┘
+
+  ┌──────────────────────────────────────────────────────┐
+  │                sc-maintenance                        │
+  │          (Cloudflare Worker, cron 2AM UTC)           │
+  │  - event_log.user_agent 90-day purge (existing)     │
+  └──────────────────────────────────────────────────────┘
+```
+
+### 1.2 Key Design Decisions
+
+**Decision 1: All v2.0 artifact columns are TEXT (JSON), nullable.**
+Rationale: D1/SQLite does not support native JSON columns. Storing JSON as TEXT with application-layer validation follows the established v1.2 pattern (`copy_pack`, `creative_brief`, `kill_criteria`). Nullable columns ensure zero-downtime migration -- existing experiments continue to function without modification.
+
+**Decision 2: Write invariant pattern over column deprecation.**
+The Distill Brief columns (`problem_statement`, `target_audience`, `value_proposition`, `market_size_estimate`) are not dropped. Instead, when `hypothesis_card` is non-null, those 4 columns become read-only projections auto-extracted from the card. This preserves backward compatibility with the existing Coda admin pack and any scripts that read Distill Brief fields directly.
+
+**Decision 3: CHECK constraint migration via create-copy-drop-rename.**
+SQLite/D1 cannot ALTER CHECK constraints. The `archetype` and `status` constraint changes require recreating the `experiments` table. This is the only supported approach in D1 and must be executed carefully in a single migration file with verification queries.
+
+**Decision 4: No Cloudflare Queue in MVP.**
+Campaign generation (Phase 5) and threshold recalculation (Phase 7) require Cloudflare Queue. These are explicitly out of MVP scope. MVP delivers schema foundation, Hypothesis Card, and Discovery Engine only.
+
+**Decision 5: interviews table uses R2 for transcript storage.**
+Interview transcripts contain PII and can be large. The `transcript_ref` column stores an R2 key, not the transcript body. This matches the established `creative_brief.assets[].r2_key` pattern from v1.2.
+
+### 1.3 Layers
+
+| Layer          | Technology                 | Responsibility                              |
+| -------------- | -------------------------- | ------------------------------------------- |
+| Frontend       | Astro 5 SSR + Tailwind CSS | Landing pages, lead forms, marketing        |
+| API            | Cloudflare Worker (Hono)   | All business logic, validation, persistence |
+| Database       | Cloudflare D1 (SQLite)     | Structured data, schema enforcement         |
+| Object Storage | Cloudflare R2              | Creative assets, interview transcripts      |
+| Scheduled Jobs | sc-maintenance Worker      | Data retention, PII anonymization           |
+
+---
+
+## 2. Proposed Data Model
+
+### 2.1 Migration 0002: New Columns on `experiments`
+
+```sql
+-- Artifact Columns (all TEXT/JSON, nullable)
+ALTER TABLE experiments ADD COLUMN hypothesis_card TEXT;
+ALTER TABLE experiments ADD COLUMN test_blueprint TEXT;
+ALTER TABLE experiments ADD COLUMN discovery_summary TEXT;
+ALTER TABLE experiments ADD COLUMN campaign_package TEXT;
+ALTER TABLE experiments ADD COLUMN page_config TEXT;
+ALTER TABLE experiments ADD COLUMN validation_report TEXT;
+
+-- Supporting Columns
+ALTER TABLE experiments ADD COLUMN venture_id TEXT;
+ALTER TABLE experiments ADD COLUMN category TEXT;
+ALTER TABLE experiments ADD COLUMN sequence_position INTEGER;
+ALTER TABLE experiments ADD COLUMN prior_test_ref TEXT;
+```
+
+**Notes:**
+
+- `venture_id` is a TEXT reference to `ventures.id`. Not enforced as FK (D1 does not enforce FKs by default; PRAGMA foreign_keys is OFF).
+- `category` will have an application-layer CHECK: `demand_signal | willingness_to_pay | solution_validation`. Not a DB constraint initially because adding it requires table recreation -- defer to the same migration step that handles `archetype`/`status`.
+- `sequence_position` is INTEGER (1-based). Populated on experiment creation when the Test Blueprint is built (Phase 4). NULL for MVP.
+- `prior_test_ref` is a self-referencing TEXT to `experiments.id`. NULL for first tests in a sequence.
+
+### 2.2 Migration 0002: New Column on `decision_memos`
+
+```sql
+ALTER TABLE decision_memos ADD COLUMN decision_detail TEXT;
+```
+
+`decision_detail` is TEXT (JSON) conforming to the DD#6 Section 6.5 schema. Nullable. Not populated until Phase 7.
+
+### 2.3 Migration 0002: New Table `interviews`
+
+```sql
+CREATE TABLE IF NOT EXISTS interviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  experiment_id TEXT NOT NULL REFERENCES experiments(id),
+  participant_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK(mode IN ('ai', 'hybrid', 'human')),
+  protocols_covered TEXT NOT NULL,         -- JSON array: ["problem_discovery", "solution_fit", ...]
+  duration_minutes INTEGER,
+  pain_scores TEXT,                        -- JSON: { functional: N, emotional: N, opportunity: N }
+  signal_extraction TEXT,                  -- JSON: full extraction report
+  transcript_ref TEXT,                     -- R2 key to transcript file
+  new_themes_detected INTEGER DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX idx_interviews_experiment ON interviews(experiment_id);
+```
+
+**Column details:**
+
+| Column                | Type        | Nullable | Description                                                              |
+| --------------------- | ----------- | -------- | ------------------------------------------------------------------------ |
+| `id`                  | INTEGER     | No (PK)  | Auto-incrementing primary key                                            |
+| `experiment_id`       | TEXT        | No       | FK to experiments.id                                                     |
+| `participant_id`      | TEXT        | No       | Opaque identifier for the interviewee (not PII -- use pseudonym or hash) |
+| `mode`                | TEXT        | No       | `ai`, `hybrid`, or `human` -- determines weighting in gate calculations  |
+| `protocols_covered`   | TEXT (JSON) | No       | Array of protocol names covered in this interview                        |
+| `duration_minutes`    | INTEGER     | Yes      | Interview length (null for AI-only)                                      |
+| `pain_scores`         | TEXT (JSON) | Yes      | `{ functional: 0-10, emotional: 0-10, opportunity: 0-10 }`               |
+| `signal_extraction`   | TEXT (JSON) | Yes      | Full AI extraction report (themes, quotes, WTP signals)                  |
+| `transcript_ref`      | TEXT        | Yes      | R2 object key for full transcript (PII -- 90-day retention)              |
+| `new_themes_detected` | INTEGER     | No       | Count of new themes found in this interview (for saturation tracking)    |
+| `created_at`          | INTEGER     | No       | Unix epoch milliseconds                                                  |
+
+### 2.4 Migration 0002: New Table `ventures`
+
+```sql
+CREATE TABLE IF NOT EXISTS ventures (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  brand_profile TEXT,                      -- JSON: BrandProfile schema
+  brand_profile_version INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE TRIGGER update_ventures_timestamp
+AFTER UPDATE ON ventures
+BEGIN
+  UPDATE ventures SET updated_at = (strftime('%s', 'now') * 1000)
+  WHERE id = NEW.id;
+END;
+```
+
+**Note:** The `ventures` table is created in Phase 1 (schema foundation) but the CRUD API is deferred to Phase 5. The table exists so `venture_id` has a valid target, but no endpoints or application logic reference it during MVP.
+
+### 2.5 Migration 0002: New Table `threshold_registry`
+
+```sql
+CREATE TABLE IF NOT EXISTS threshold_registry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  phase INTEGER NOT NULL CHECK(phase IN (1, 2, 3)),
+  go_threshold INTEGER NOT NULL,
+  kill_threshold INTEGER NOT NULL,
+  metric TEXT NOT NULL,
+  sample_count INTEGER NOT NULL,
+  percentile_25 INTEGER,
+  percentile_75 INTEGER,
+  mean_value INTEGER,
+  std_dev INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  effective_from TEXT NOT NULL,
+  superseded_at TEXT,
+  calculation_notes TEXT,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX idx_threshold_archetype ON threshold_registry(archetype);
+CREATE INDEX idx_threshold_phase ON threshold_registry(phase);
+```
+
+**Note:** Created in Phase 1 but not populated until Phase 7. Phase 4 uses hardcoded per-archetype defaults in application code.
+
+### 2.6 Migration 0002: New Table `venture_benchmarks`
+
+```sql
+CREATE TABLE IF NOT EXISTS venture_benchmarks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  industry TEXT,
+  price_range TEXT,
+  channel TEXT,
+  test_count INTEGER NOT NULL,
+  mean_cvr_bp INTEGER,
+  median_cvr_bp INTEGER,
+  p25_cvr_bp INTEGER,
+  p75_cvr_bp INTEGER,
+  std_dev_cvr_bp INTEGER,
+  mean_cpl_cents INTEGER,
+  median_cpl_cents INTEGER,
+  go_rate_pct INTEGER,
+  kill_rate_pct INTEGER,
+  pivot_rate_pct INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  last_updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  calculation_notes TEXT
+);
+
+CREATE INDEX idx_benchmarks_archetype ON venture_benchmarks(archetype);
+CREATE INDEX idx_benchmarks_industry ON venture_benchmarks(industry);
+```
+
+**Note:** Created in Phase 1 but not populated until Phase 7.
+
+### 2.7 Migration 0002: CHECK Constraint Recreation
+
+The `experiments` table must be recreated to update `archetype` and `status` CHECK constraints. Full SQL is specified in Functional Spec v2.0, Section 7, Step 3. Key changes:
+
+**archetype:** Remove `interview`, add `fake_door`, reorder to match Validation Ladder.
+
+```sql
+-- v1.2: CHECK(archetype IN ('waitlist','priced_waitlist','presale','service_pilot','content_magnet','concierge','interview'))
+-- v2.0: CHECK(archetype IN ('fake_door','waitlist','content_magnet','priced_waitlist','presale','concierge','service_pilot'))
+```
+
+**status:** Add `discovery` between `preflight` and `build`.
+
+```sql
+-- v1.2: CHECK(status IN ('draft','preflight','build','launch','run','decide','archive'))
+-- v2.0: CHECK(status IN ('draft','preflight','discovery','build','launch','run','decide','archive'))
+```
+
+**category** should also be added as a CHECK on the recreated table:
+
+```sql
+category TEXT CHECK(category IS NULL OR category IN ('demand_signal','willingness_to_pay','solution_validation'))
+```
+
+**Data migration** runs BEFORE table recreation:
+
+```sql
+-- Move draft/preflight interview experiments to fake_door
+UPDATE experiments SET archetype = 'fake_door'
+  WHERE archetype = 'interview' AND status IN ('draft', 'preflight');
+
+-- Archive active interview experiments that cannot be migrated
+UPDATE experiments SET status = 'archive'
+  WHERE archetype = 'interview' AND status NOT IN ('draft', 'preflight');
+
+-- Catch any remaining
+UPDATE experiments SET archetype = 'fake_door'
+  WHERE archetype = 'interview';
+```
+
+### 2.8 Status Transition Map v2.0
+
+```
+draft --> preflight --> discovery --> build --> launch --> run --> decide --> archive
+                    \                 ^
+                     \-> build ------/  (requires discovery_gate_exception)
+```
+
+Updated transition table (application layer enforcement in `VALID_STATUS_TRANSITIONS`):
+
+| From      | To        | Condition                                                                  |
+| --------- | --------- | -------------------------------------------------------------------------- |
+| draft     | preflight | None                                                                       |
+| draft     | archive   | None                                                                       |
+| preflight | discovery | None                                                                       |
+| preflight | build     | Phase 4: requires `discovery_gate_exception` flag. Phase 3: unconditional. |
+| preflight | draft     | None (rollback)                                                            |
+| preflight | archive   | None                                                                       |
+| discovery | build     | Phase 4: requires Discovery Gate pass. Phase 3: unconditional.             |
+| discovery | archive   | None                                                                       |
+| build     | launch    | None                                                                       |
+| build     | preflight | None (rollback)                                                            |
+| build     | archive   | None                                                                       |
+| launch    | run       | None                                                                       |
+| launch    | archive   | None                                                                       |
+| run       | decide    | None                                                                       |
+| run       | archive   | None                                                                       |
+| decide    | archive   | None                                                                       |
+
+**MVP (Phase 3) implementation:** Add `discovery` to `VALID_STATUS_TRANSITIONS` without gate enforcement. Gate logic is advisory only until Phase 4.
+
+### 2.9 Distill Brief Write Invariant
+
+When `hypothesis_card` is non-null on an experiment:
+
+| Distill Brief Column   | Projected From                        | Behavior             |
+| ---------------------- | ------------------------------------- | -------------------- |
+| `target_audience`      | `hypothesis_card.customer_segment`    | Read-only projection |
+| `problem_statement`    | `hypothesis_card.problem_statement`   | Read-only projection |
+| `value_proposition`    | `hypothesis_card.solution_hypothesis` | Read-only projection |
+| `market_size_estimate` | `hypothesis_card.market_sizing`       | Read-only projection |
+
+`PATCH /experiments/:id` MUST reject direct updates to these 4 columns when `hypothesis_card` is non-null, returning:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "WRITE_INVARIANT_VIOLATION",
+    "message": "Cannot update problem_statement directly when hypothesis_card is set. Update hypothesis_card instead.",
+    "request_id": "req_..."
+  }
+}
+```
+
+HTTP status: `409 Conflict`.
+
+---
+
+## 3. API Surface
+
+All endpoints use the established v1.2 patterns: Hono router, JSON request/response, `X-Request-Id` header on all responses, consistent `ErrorResponse` / `SuccessResponse` shapes.
+
+### 3.1 Modified Endpoints (MVP)
+
+#### POST /experiments
+
+**Changes:**
+
+- Validate archetype against v2.0 enum: `fake_door | waitlist | content_magnet | priced_waitlist | presale | concierge | service_pilot`
+- Accept optional `hypothesis_card` in request body
+- When `hypothesis_card` is provided, auto-extract projections into Distill Brief columns
+
+```
+POST /experiments
+Auth: X-SC-Key
+Content-Type: application/json
+
+Request:
+{
+  "name": "Accessibility Auditor",
+  "slug": "accessibility-auditor",
+  "archetype": "waitlist",
+  "hypothesis_card": { ... }  // optional, JSON conforming to DD#1 Section 3.7
+}
+
+Response 201:
+{
+  "success": true,
+  "data": { <full experiment record> }
+}
+
+Error 400: INVALID_REQUEST (missing required fields, invalid archetype)
+Error 409: DUPLICATE_SLUG
+```
+
+#### PATCH /experiments/:id
+
+**Changes:**
+
+- Add to updatable fields: `hypothesis_card`, `test_blueprint`, `discovery_summary`, `campaign_package`, `page_config`, `validation_report`, `venture_id`, `category`, `sequence_position`, `prior_test_ref`
+- Enforce Distill Brief write invariant (see Section 2.9)
+- Add `discovery` to valid status transitions
+- When `hypothesis_card` is written, auto-extract projections into Distill Brief columns
+
+```
+PATCH /experiments/:id
+Auth: X-SC-Key
+Content-Type: application/json
+
+Request:
+{
+  "hypothesis_card": { ... },
+  "status": "discovery"
+}
+
+Response 200:
+{
+  "success": true,
+  "data": { <full experiment record with projections applied> }
+}
+
+Error 400: INVALID_STATUS_TRANSITION, INVALID_REQUEST
+Error 404: EXPERIMENT_NOT_FOUND
+Error 409: WRITE_INVARIANT_VIOLATION (direct Distill Brief update when hypothesis_card set)
+```
+
+### 3.2 New Discovery Endpoints (Phase 3)
+
+#### POST /experiments/:id/discovery/start
+
+Transitions experiment status to `discovery`. Must be in `preflight` status.
+
+```
+POST /experiments/:id/discovery/start
+Auth: X-SC-Key
+
+Request: {} (empty body)
+
+Response 200:
+{
+  "success": true,
+  "data": {
+    "experiment_id": "SC-2026-001",
+    "status": "discovery",
+    "discovery_summary": null
+  }
+}
+
+Error 400: INVALID_STATUS_TRANSITION (not in preflight)
+Error 404: EXPERIMENT_NOT_FOUND
+```
+
+Side effect: Inserts `discovery_sprint_started` event into `event_log`.
+
+#### POST /experiments/:id/interviews
+
+Records a completed interview.
+
+```
+POST /experiments/:id/interviews
+Auth: X-SC-Key
+Content-Type: application/json
+
+Request:
+{
+  "participant_id": "P-001",
+  "mode": "human",
+  "protocols_covered": ["problem_discovery", "solution_fit"],
+  "duration_minutes": 45,
+  "pain_scores": {
+    "functional": 8,
+    "emotional": 6,
+    "opportunity": 7
+  },
+  "signal_extraction": { ... },
+  "transcript_ref": "interviews/SC-2026-001/P-001-20260302.txt",
+  "new_themes_detected": 2
+}
+
+Response 201:
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "experiment_id": "SC-2026-001",
+    "participant_id": "P-001",
+    "mode": "human",
+    "protocols_covered": ["problem_discovery", "solution_fit"],
+    "duration_minutes": 45,
+    "pain_scores": { "functional": 8, "emotional": 6, "opportunity": 7 },
+    "signal_extraction": { ... },
+    "transcript_ref": "interviews/SC-2026-001/P-001-20260302.txt",
+    "new_themes_detected": 2,
+    "created_at": 1740000000000
+  }
+}
+
+Error 400: INVALID_REQUEST (missing required fields, invalid mode)
+Error 404: EXPERIMENT_NOT_FOUND
+```
+
+Validation rules:
+
+- `participant_id`: Required, non-empty string
+- `mode`: Required, must be one of `ai | hybrid | human`
+- `protocols_covered`: Required, non-empty JSON array of strings
+- `pain_scores`: Optional, each value 0-10 integer
+- `duration_minutes`: Optional, positive integer
+- `new_themes_detected`: Optional, defaults to 0, non-negative integer
+
+Side effect: Inserts `interview_completed` event into `event_log`.
+
+#### GET /experiments/:id/discovery/summary
+
+Returns the current Discovery Summary for an experiment. The summary is stored in `experiments.discovery_summary`.
+
+```
+GET /experiments/:id/discovery/summary
+Auth: X-SC-Key
+
+Response 200:
+{
+  "success": true,
+  "data": {
+    "experiment_id": "SC-2026-001",
+    "discovery_summary": { ... } | null,
+    "interview_count": 5,
+    "weighted_interview_count": 3.75,
+    "stage": "draft" | "final"
+  }
+}
+
+Error 404: EXPERIMENT_NOT_FOUND
+```
+
+The `weighted_interview_count` is computed on the fly using the mode-weighted formula:
+
+- `ai` interviews count as 0.5
+- `hybrid` interviews count as 0.75
+- `human` interviews count as 1.0
+
+#### POST /experiments/:id/discovery/finalize
+
+Locks the Discovery Summary to "final" stage. After finalization, the summary cannot be modified.
+
+```
+POST /experiments/:id/discovery/finalize
+Auth: X-SC-Key
+
+Request: {} (empty body)
+
+Response 200:
+{
+  "success": true,
+  "data": {
+    "experiment_id": "SC-2026-001",
+    "discovery_summary": { ... },
+    "stage": "final"
+  }
+}
+
+Error 400: INVALID_REQUEST (no discovery_summary to finalize, already finalized)
+Error 404: EXPERIMENT_NOT_FOUND
+```
+
+Side effect: Inserts `discovery_summary_finalized` event into `event_log`.
+
+#### GET /experiments/:id/discovery/gate
+
+Evaluates 6 gate checks and returns pass/fail status with details. Does NOT enforce the gate (enforcement is Phase 4).
+
+```
+GET /experiments/:id/discovery/gate
+Auth: X-SC-Key
+
+Response 200:
+{
+  "success": true,
+  "data": {
+    "experiment_id": "SC-2026-001",
+    "gate_status": "pass" | "fail",
+    "checks": [
+      {
+        "name": "minimum_interviews",
+        "status": "pass",
+        "detail": "5 weighted interviews (threshold: 3)"
+      },
+      {
+        "name": "pain_severity",
+        "status": "pass",
+        "detail": "Mean pain score 7.2 (threshold: 5)"
+      },
+      {
+        "name": "peak_dimension",
+        "status": "pass",
+        "detail": "Functional pain is peak at 8.1"
+      },
+      {
+        "name": "problem_confirmed",
+        "status": "pass",
+        "detail": "4/5 participants confirmed core problem"
+      },
+      {
+        "name": "assumption_evidence",
+        "status": "fail",
+        "detail": "2 key assumptions lack evidence"
+      },
+      {
+        "name": "saturation",
+        "status": "pass",
+        "detail": "3 consecutive interviews with 0 new themes"
+      }
+    ],
+    "recommendation": "fail -- 1 check did not pass"
+  }
+}
+
+Error 404: EXPERIMENT_NOT_FOUND
+```
+
+Side effect: Inserts `discovery_gate_evaluated` event into `event_log`.
+
+### 3.3 Auth Summary for New Endpoints
+
+| Method | Path                                  | Auth     | Public? |
+| ------ | ------------------------------------- | -------- | ------- |
+| POST   | `/experiments/:id/discovery/start`    | X-SC-Key | No      |
+| POST   | `/experiments/:id/interviews`         | X-SC-Key | No      |
+| GET    | `/experiments/:id/discovery/summary`  | X-SC-Key | No      |
+| POST   | `/experiments/:id/discovery/finalize` | X-SC-Key | No      |
+| GET    | `/experiments/:id/discovery/gate`     | X-SC-Key | No      |
+
+All new endpoints are internal (require `X-SC-Key`). No new public endpoints in MVP.
+
+### 3.4 Updated Public Endpoint: GET /experiments/by-slug/:slug
+
+The sanitized public response should include `page_config` when it is non-null, so the frontend can render archetype-specific landing page configurations:
+
+```
+GET /experiments/by-slug/:slug
+
+Response 200 (updated fields):
+{
+  "success": true,
+  "data": {
+    "id": "SC-2026-001",
+    "name": "Accessibility Auditor",
+    "slug": "accessibility-auditor",
+    "status": "launch",
+    "archetype": "waitlist",
+    "copy_pack": { ... },
+    "page_config": { ... } | null,      // NEW: v2.0 addition
+    "price_cents": 0,
+    "stripe_price_id": null,
+    "created_at": 1740000000000
+  }
+}
+```
+
+**Note:** `hypothesis_card`, `discovery_summary`, `test_blueprint`, `campaign_package`, and `validation_report` are NOT included in the public endpoint response. These are internal artifacts.
+
+---
+
+## 4. Non-Functional Requirements
+
+### 4.1 Performance Budgets
+
+| Metric                          | Target  | Measurement                                                   |
+| ------------------------------- | ------- | ------------------------------------------------------------- |
+| API response time (p50)         | < 50ms  | Cloudflare Worker analytics                                   |
+| API response time (p99)         | < 200ms | Cloudflare Worker analytics                                   |
+| D1 query time (single row)      | < 10ms  | D1 analytics dashboard                                        |
+| D1 query time (list, paginated) | < 30ms  | D1 analytics dashboard                                        |
+| Discovery gate evaluation       | < 100ms | Application-level timing (aggregates across interviews table) |
+| Migration 0002 execution time   | < 30s   | Manual timing during deployment                               |
+| Landing page TTFB               | < 200ms | Cloudflare Speed analytics                                    |
+| Landing page LCP                | < 2.5s  | Core Web Vitals                                               |
+
+### 4.2 Data Size Budgets
+
+| Column                         | Max Payload Size | Enforcement                       |
+| ------------------------------ | ---------------- | --------------------------------- |
+| `hypothesis_card`              | 50 KB            | Application-layer JSON size check |
+| `discovery_summary`            | 100 KB           | Application-layer JSON size check |
+| `test_blueprint`               | 50 KB            | Application-layer JSON size check |
+| `campaign_package`             | 200 KB           | Application-layer JSON size check |
+| `page_config`                  | 100 KB           | Application-layer JSON size check |
+| `validation_report`            | 200 KB           | Application-layer JSON size check |
+| `interviews.signal_extraction` | 50 KB            | Application-layer JSON size check |
+
+D1 has a 1 MB row size limit. With all JSON columns populated, worst case is ~750 KB per experiment row. This is within limits but should be monitored.
+
+### 4.3 Security Requirements
+
+| Requirement                            | Implementation                                                   | Status   |
+| -------------------------------------- | ---------------------------------------------------------------- | -------- |
+| All new endpoints behind X-SC-Key auth | Auth middleware allowlist (no additions to PUBLIC_ROUTES)        | MVP      |
+| Parameterized queries only             | `.bind()` on all D1 queries -- no string interpolation           | MVP      |
+| No PII in JSON artifact columns        | `participant_id` uses pseudonyms, not real names                 | MVP      |
+| Interview transcript PII retention     | R2 objects under `interviews/` prefix, 90-day TTL rule           | MVP      |
+| JSON payload validation                | Validate structure before INSERT/UPDATE -- reject malformed JSON | MVP      |
+| No secrets in experiment data          | Stripe keys, API keys never stored in experiment columns         | Existing |
+| CORS unchanged                         | Only `siliconcrane.com` in production                            | Existing |
+| Rate limiting unchanged                | Existing WAF rules sufficient -- no new public endpoints         | Existing |
+
+### 4.4 Scalability Targets (MVP context)
+
+These are not scaling for high traffic -- SC is a validation service with low volume. Targets reflect correctness at small scale.
+
+| Metric                    | Target   | Rationale                       |
+| ------------------------- | -------- | ------------------------------- |
+| Concurrent experiments    | 50       | Far exceeds near-term need      |
+| Interviews per experiment | 100      | Discovery typically needs 5-20  |
+| Events per day            | 10,000   | Covers moderate ad traffic      |
+| D1 database size          | < 500 MB | Well within D1 free tier (5 GB) |
+| R2 storage                | < 1 GB   | Transcripts + creative assets   |
+
+### 4.5 Reliability
+
+| Requirement             | Target                                                        |
+| ----------------------- | ------------------------------------------------------------- |
+| Worker uptime           | 99.9% (Cloudflare SLA)                                        |
+| Migration rollback plan | Manual restore from D1 backup snapshot (taken pre-migration)  |
+| Data loss tolerance     | Zero -- D1 automatic backups, verify pre-migration row counts |
+
+---
+
+## 5. Technical Risks
+
+### 5.1 Critical Risks
+
+| #   | Risk                                                                                                                                                                                 | Severity | Likelihood | Mitigation                                                                                                                                                                                                                 |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | **Table recreation loses data during Migration 0002 Step 3.** The create-copy-drop-rename pattern on `experiments` could fail mid-execution, leaving the database in a broken state. | Critical | Low        | Run migration on local D1 first. Take D1 backup snapshot before remote execution. Verify row counts in Step 4. D1 executes migration SQL as a single batch -- partial failures roll back.                                  |
+| R2  | **Existing experiments with `archetype = 'interview'` in active states (build, launch, run, decide) get archived during data migration.** This could interrupt live experiments.     | High     | Low        | Query production D1 for `SELECT count(*), status FROM experiments WHERE archetype = 'interview' GROUP BY status` BEFORE running migration. If any are in `launch` or `run`, coordinate with stakeholder before proceeding. |
+| R3  | **JSON schema drift between application code and stored data.** Hypothesis Card schema evolves but old records have stale schema versions.                                           | Medium   | Medium     | Include `version` field in all JSON artifact schemas (DD#1 already specifies this). Application code must handle version migration on read.                                                                                |
+
+### 5.2 Moderate Risks
+
+| #   | Risk                                                                                                                                                                                                                  | Severity | Likelihood | Mitigation                                                                                                                                                                                                             |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R4  | **D1 row size limit (1 MB) approached with all JSON columns populated.** If `campaign_package` (200 KB) + `validation_report` (200 KB) + other columns are all large, a single experiment row could hit limits.       | Medium   | Low        | Enforce per-column size budgets (Section 4.2). Log warnings when a column exceeds 80% of its budget. Long term: move large payloads to R2 with a reference key.                                                        |
+| R5  | **Mode-weighted interview counting produces non-intuitive results.** An experiment with 6 AI interviews (weight 0.5) = 3.0 weighted count, which meets the minimum threshold but may not represent genuine discovery. | Medium   | Medium     | Gate evaluation response includes both raw count and weighted count. Documentation should clarify that AI-only discovery is acceptable but lower confidence. Consider raising the minimum threshold for AI-only modes. |
+| R6  | **Trigger cascade on table recreation.** Dropping `experiments` drops the `update_experiments_timestamp` trigger. The migration must explicitly recreate it on `experiments` after rename.                            | High     | Low        | Migration Step 3 already includes trigger recreation. Verify trigger exists as part of Step 4 verification: `SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'experiments'`.                      |
+
+### 5.3 Low Risks
+
+| #   | Risk                                                                                                                                                                                                      | Severity | Likelihood | Mitigation                                                                                                                                |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| R7  | **FK references from 6 tables (leads, payments, metrics_daily, decision_memos, learning_memos, event_log) break during table recreation.** If PRAGMA foreign_keys is ON, dropping experiments would fail. | Medium   | Very Low   | Verify `PRAGMA foreign_keys` returns 0 (OFF, the D1 default) before running migration. If ON, the migration script must disable it first. |
+
+---
+
+## 6. Open Decisions / ADRs
+
+### ADR-001: JSON Schema Validation Location
+
+**Status:** PROPOSED
+**Context:** v2.0 adds 6 JSON artifact columns. Where should schema validation happen?
+**Options:**
+
+- (A) Full JSON Schema validation in the API layer (using a library like `ajv`)
+- (B) Lightweight structural checks only (presence of required top-level keys, `version` field)
+- (C) No validation -- trust the caller (internal endpoints only)
+
+**Recommendation:** Option B for MVP. Full JSON Schema validation adds bundle size and complexity. Since all new endpoints are internal (X-SC-Key), the callers are controlled. Validate `version` field and top-level structure. Defer comprehensive validation to post-MVP.
+
+**Consequences:** Malformed JSON could be stored if an API consumer sends bad data. Mitigated by controlled access (X-SC-Key only) and the `version` field enabling future migration.
+
+---
+
+### ADR-002: Discovery Summary Computation Strategy
+
+**Status:** PROPOSED
+**Context:** The Discovery Summary aggregates data from multiple interviews. Should it be computed on-write (when interviews are added) or on-read (when the summary endpoint is called)?
+**Options:**
+
+- (A) Compute on read: `GET /experiments/:id/discovery/summary` aggregates from `interviews` table each time
+- (B) Compute on write: `POST /experiments/:id/interviews` updates `experiments.discovery_summary` after each interview insert
+- (C) Explicit command: A separate `POST /experiments/:id/discovery/recompute` endpoint
+
+**Recommendation:** Option B (compute on write). Interview volume is low (5-20 per experiment). Recomputing after each insert ensures the summary column is always current and the GET endpoint is a simple column read. The `/discovery/finalize` endpoint locks the summary, preventing further updates.
+
+**Consequences:** The `POST /experiments/:id/interviews` endpoint does more work (read all interviews, recompute summary, update experiment). Acceptable given the low volume.
+
+---
+
+### ADR-003: Discovery Gate Enforcement Timing
+
+**Status:** DECIDED (per Functional Spec v2.0, Section 2.2)
+**Decision:** Phase 3 adds `discovery` status and gate evaluation endpoint. Phase 4 adds enforcement on `-> build` transitions.
+**Rationale:** Decoupling the gate evaluation from enforcement allows the team to validate the gate logic against real interview data before it becomes a hard blocker. In Phase 3, the gate is advisory: the endpoint returns pass/fail but does not block status transitions.
+
+---
+
+### ADR-004: Handling `category` CHECK Constraint
+
+**Status:** PROPOSED
+**Context:** The `category` column has a defined set of valid values (`demand_signal`, `willingness_to_pay`, `solution_validation`). Should this be a SQL CHECK constraint or application-layer only?
+**Options:**
+
+- (A) Add CHECK constraint during table recreation in Migration 0002 Step 3
+- (B) Application-layer validation only
+
+**Recommendation:** Option A. Since we are already recreating the table for `archetype` and `status` CHECK changes, adding the `category` CHECK is zero incremental cost. It provides defense-in-depth against bad data.
+
+---
+
+### ADR-005: Interview Transcript R2 Key Convention
+
+**Status:** PROPOSED
+**Context:** Interview transcripts are stored in R2 with a key referenced in `interviews.transcript_ref`. What key format should be used?
+**Recommendation:** `interviews/{experiment_id}/{participant_id}-{ISO_DATE}.txt`
+Example: `interviews/SC-2026-001/P-001-2026-03-02.txt`
+**Rationale:** Groups by experiment for easy bulk operations (e.g., 90-day purge of all transcripts for archived experiments). The date suffix prevents overwrites if a participant has multiple sessions.
+
+---
+
+### ADR-006: Pre-Migration Backup Protocol
+
+**Status:** PROPOSED
+**Context:** Migration 0002 includes a destructive table recreation (create-copy-drop-rename). D1 does not support transactional DDL across multiple statements in the same way that PostgreSQL does.
+**Recommendation:**
+
+1. Before executing migration on any remote environment, export D1 data via `wrangler d1 export sc-db --remote`
+2. Run migration on local D1 first and execute all Step 4 verification queries
+3. Run migration on preview environment and verify
+4. Run migration on production and verify
+5. Keep the export for 7 days as rollback insurance
+
+---
+
+## 7. Implementation Notes
+
+### 7.1 Code Changes Required for MVP
+
+**workers/sc-api/src/index.ts:**
+
+- Update `validArchetypes` array (line ~905): replace `interview` with `fake_door`, add reordering
+- Update `VALID_STATUS_TRANSITIONS` (line ~112): add `discovery` state
+- Add `hypothesis_card` and other v2.0 columns to `updatableFields` in PATCH handler (line ~1058)
+- Implement Distill Brief write invariant logic in PATCH handler
+- Add 5 new route handlers for discovery endpoints
+- Add `page_config` to sanitized public response in `GET /experiments/by-slug/:slug` (line ~791)
+
+**workers/sc-api/src/middleware/auth.ts:**
+
+- No changes needed. All new endpoints are internal (require X-SC-Key). No additions to `PUBLIC_ROUTES`.
+
+**workers/sc-api/migrations/0002_v2_schema.sql:**
+
+- New migration file containing all 4 steps from Functional Spec Section 7
+
+**workers/sc-maintenance/src/index.ts:**
+
+- No changes for MVP. Extended PII purge for archived experiments is Phase 7.
+
+### 7.2 Test Coverage Requirements
+
+| Endpoint/Feature                       | Test Cases                                                                          |
+| -------------------------------------- | ----------------------------------------------------------------------------------- |
+| Migration 0002                         | Row count preserved, no `interview` archetypes remain, triggers fire, indexes exist |
+| PATCH write invariant                  | Reject direct Distill Brief update when hypothesis_card set; allow when not set     |
+| POST /experiments archetype validation | Reject `interview`, accept `fake_door` and all others                               |
+| Status transition: discovery           | preflight -> discovery (pass), draft -> discovery (fail), discovery -> build (pass) |
+| POST /interviews                       | Valid insert, missing required fields, invalid mode, experiment not found           |
+| GET /discovery/gate                    | All 6 checks evaluated, weighted counting correct, pass/fail logic                  |
+| POST /discovery/finalize               | Locks summary, rejects re-finalization                                              |
+
+### 7.3 Migration Execution Order
+
+1. **Phase 1:** Run `0002_v2_schema.sql` (all steps). Verify in local, preview, production.
+2. **Phase 2:** Deploy updated `sc-api` with hypothesis_card support and write invariant.
+3. **Phase 3:** Deploy discovery endpoints and status transition updates.
+
+Phases 2 and 3 can be deployed incrementally. The schema supports all phases from the moment Migration 0002 completes (all columns exist, all are nullable, all new tables exist empty).
+
+---
+
+**End of Technical Lead Contribution**

--- a/docs/pm/prd-contributions/round-1/ux-lead.md
+++ b/docs/pm/prd-contributions/round-1/ux-lead.md
@@ -1,0 +1,490 @@
+# UX Lead Contribution - PRD Review Round 1
+
+**Author:** UX Lead
+**Date:** 2026-03-02
+**Scope:** MVP / Phase 0 only
+**Source Documents:** `docs/process/sc-project-instructions.md`, `docs/technical/sc-functional-spec-v2.md`
+**Supporting References:** Deep Dive #1 (The Venture Narrative), Deep Dive #5 (The Launchpad), Tech Spec v1.2, existing codebase at `apps/sc-web/`
+
+---
+
+## Target User Personas
+
+### Persona 1: Marcus Chen -- The Technical Founder with Too Many Ideas
+
+Marcus is a 34-year-old senior software engineer at a mid-size fintech company in Austin. He has been building side projects for six years, shipping three to production, and watching all three flatline after launch. His GitHub is full of well-architected codebases that nobody uses. He has a new idea every quarter -- an accessibility auditing SaaS, a competitor-tracking tool for marketers, a niche CRM for freelance consultants -- and he cannot tell which one deserves his nights and weekends.
+
+**Frustration:** Marcus builds first and validates never. He spent four months and $3,200 on AWS costs building a full product for his last idea before discovering that his target customers already had a "good enough" spreadsheet workflow. He knows he should validate before building but does not have a framework, the marketing skills, or the patience to run a proper demand test. He reads about lean startup methodology but cannot translate it into a concrete next step.
+
+**Goal:** Marcus wants someone to tell him, with evidence, whether his current idea is worth building. He wants a GO/NO-GO signal he can trust, delivered fast enough that he does not lose momentum. He is willing to pay $2,500 if it saves him from burning another $10K+ and six months on the wrong idea.
+
+**Relationship to SC:** Marcus is the prototypical Preflight + Build-to-Launch client. He arrives with a specific idea, can articulate the problem, and is ready to define kill criteria. He does not need hand-holding on basic business concepts. He needs execution and objectivity. He is the "Good Fit" profile described in the project instructions (Section 3, Qualification Criteria).
+
+**How he finds SC:** LinkedIn post from a founder friend, Indie Hackers community thread, or cold outreach targeting founders who launched and failed publicly.
+
+**Landing page behavior:** Marcus will read the entire page. He cares about the process ("How does this work?"), not the emotional pitch. He wants to see a case study with real metrics. He will scroll past urgency hooks but will carefully read the value props and FAQ. He converts on `waitlist` or `priced_waitlist` archetypes after 2-3 minutes of reading.
+
+---
+
+### Persona 2: Priya Kapoor -- The Non-Technical Domain Expert
+
+Priya is a 41-year-old operations director at a regional healthcare staffing agency. She has spent 15 years watching her industry solve scheduling, credentialing, and compliance problems with Excel spreadsheets and phone calls. She believes a purpose-built tool could save agencies like hers 20+ hours per week, but she does not know how to build software and does not trust agencies that quote $80K for an MVP.
+
+**Frustration:** Priya has talked to two dev shops. Both produced SOWs that would take 4-6 months and cost more than her annual bonus. She does not know if the problem is big enough to justify that investment, or if the nurses and schedulers she imagines as users would actually adopt a new tool. She is stuck between "I know this is a real problem" and "I have no idea if anyone would pay for the solution."
+
+**Goal:** Priya wants to know if her idea has legs before she risks her savings or seeks outside investment. She wants someone who will do the validation work -- run the interviews, build the test page, measure the demand -- because she does not have the technical skills or the time to learn growth hacking while running a full-time job.
+
+**Relationship to SC:** Priya is the ideal full-stack engagement client: Preflight through Run + Decide. She needs the most hand-holding during intake and scoping, but once the sprint starts, she is a responsive decision-maker. She maps to the "Non-technical people with domain expertise + idea" target segment from the project instructions' marketing strategy (Section 5).
+
+**How she finds SC:** Warm introduction from someone in the Venture Crane network, or a targeted LinkedIn DM referencing healthcare staffing pain points she has posted about.
+
+**Landing page behavior:** Priya will scan, not read. She needs the headline and subheadline to immediately tell her this is for people like her (domain experts, not developers). She will look for social proof and a clear "How it works" process section. She will not tolerate jargon ("archetypes," "kill criteria," "conversion rate"). She converts on `concierge` or `service_pilot` archetypes after confirming that SC does the work, not just advises.
+
+---
+
+### Persona 3: Jordan Reeves -- The Repeat Founder Validating a Pivot
+
+Jordan is a 29-year-old founder who shut down their first startup (a D2C subscription box) after 18 months and $140K burned. They are now sitting on two new ideas and a dwindling runway of personal savings. They have founder scars: they know what it feels like to build the wrong thing. They are hyper-aware of vanity metrics, sunk cost fallacy, and the emotional trap of falling in love with an idea.
+
+**Frustration:** Jordan knows how to validate -- they have read The Mom Test, run Facebook ads, built landing pages on Carrd. But they are exhausted and do not trust their own judgment anymore. They want external objectivity and a structured process with predefined kill criteria so that their emotional attachment cannot override the data. They have done this before and know they need a forcing function.
+
+**Goal:** Jordan wants to run two cheap, fast validation tests on their two ideas and kill the loser within two weeks. They want evidence they can show a potential co-founder or angel investor. They value speed above all else.
+
+**Relationship to SC:** Jordan is the most sophisticated buyer. They understand the methodology and will evaluate SC on execution speed, data quality, and the rigor of the decision framework. They map to the "Founders who launched something that didn't work" target segment. They are likely a Preflight + Build-to-Launch client who may run two experiments in parallel.
+
+**How he finds SC:** Content marketing (Twitter/X thread about validation frameworks, blog post about the DFG case study), or Indie Hackers / Hacker News discussion.
+
+**Landing page behavior:** Jordan will skip the hero section and scroll directly to the case study, pricing, and process details. They will evaluate the kill criteria methodology and want to see real numbers (conversion rates, cost per lead, time to decision). They convert fast on `presale` archetypes if the price is right, or on `fake_door` if they just want to test demand. They are the most likely persona to click through from a specific ad with high message-match expectations.
+
+---
+
+## User Journey
+
+### Journey Map: First Touch to Core Value Delivery
+
+This journey traces a new prospect (using Marcus as the primary persona) from first encountering SC to receiving a GO/NO-GO decision. MVP scope only -- no client portal, no automated campaign generation, no discovery engine.
+
+---
+
+**Step 1: Discovery (External)**
+
+- **Trigger:** Marcus sees a LinkedIn post about SC's DFG case study, or receives a cold outreach email with the value prop: "Kill bad ideas in 2 weeks instead of 6 months."
+- **Action:** Clicks link to siliconcrane.com.
+- **Screen:** `index.astro` (homepage at siliconcrane.com).
+- **Content consumed:** Hero headline ("From Hypothesis to Working Software in 30 Days"), problem statement ("The average startup spends $250K and 18 months before realizing they built the wrong thing"), service overview (Landing Pages, MVPs & Prototypes, Validation Infrastructure), and "Why Silicon Crane" proof points.
+- **Signal captured:** GA4 page_view (existing).
+- **Decision point:** "Is this for me?" -- Marcus needs to see that SC validates ideas, not just builds software.
+
+**Step 2: Services Exploration**
+
+- **Action:** Marcus clicks "How It Works" anchor link, or navigates to `/services`.
+- **Screen:** `services.astro` or the "#how-it-works" section on index.
+- **Content consumed:** Sprint types (Preflight, Build-to-Launch, Run + Decide), what each includes, timeline, and pricing (once Tier 1 items are complete per project instructions Section 2).
+- **Missing today (Tier 1 blocker):** Pricing is not locked. Services page exists but does not have specific prices or clear "next steps" CTAs. The intake form does not exist yet.
+- **Decision point:** "What would I buy, and what does it cost?"
+
+**Step 3: Trust Building**
+
+- **Action:** Marcus looks for proof that SC has done this before.
+- **Screen:** Case study page (does not exist yet -- Tier 2 per project instructions).
+- **Content consumed:** DFG case study with the 5-part structure from project instructions Section 4: Hypothesis, Test, Data, Decision, Current State. Real metrics: time from idea to prototype, cost to reach market test, key pivots.
+- **Missing today (Tier 2 blocker):** Case study page does not exist. FAQ page does not exist.
+- **Decision point:** "Do they have the track record to execute?"
+
+**Step 4: Intake**
+
+- **Action:** Marcus clicks "Start Your Sprint" CTA or navigates to the intake form.
+- **Screen:** Intake form (does not exist yet -- Tier 1 per project instructions).
+- **Form fields:** Idea description (free text), current stage (select: just an idea / have done some research / have a prototype / have launched and need validation), budget range (select), timeline preference (select), name, email, company.
+- **Post-submission:** Confirmation page with expected response time (24-48 hours) and what happens next.
+- **Signal captured:** `POST /leads` with `custom_fields` containing intake responses.
+- **Decision point:** "Am I willing to fill this out?" -- The form must feel lightweight, not like an enterprise procurement questionnaire.
+
+**Step 5: Qualification (Internal)**
+
+- **Action:** SC operator reviews the intake submission against qualification criteria (project instructions Section 3).
+- **Screen:** Coda admin interface (Phase 1 admin per tech spec Section 9).
+- **Operator evaluates:** Does Marcus have a specific idea? Can he articulate the problem? Is the budget aligned? Can he make decisions quickly?
+- **Output:** GO/NO-GO on fit. If GO, schedule a scoping call. If NO-GO, send a polite decline with alternative resources.
+- **Touchpoint with Marcus:** Email with either a Calendly link for a scoping call or a decline message.
+
+**Step 6: Scoping Call**
+
+- **Action:** Marcus and SC operator have a 30-minute call.
+- **Screen:** None (video call, external to SC Console).
+- **Discussion:** Align on sprint type, define preliminary kill criteria, agree on timeline.
+- **Output:** Draft SOW with sprint type, deliverables, timeline, price, and kill criteria.
+
+**Step 7: Contract + Payment**
+
+- **Action:** Marcus reviews and signs SOW, pays via Stripe.
+- **Screen:** Stripe Checkout (hosted by Stripe, not SC Console).
+- **Trigger:** SC operator sends Stripe invoice or checkout link.
+- **Post-payment:** Marcus receives confirmation email and kickoff scheduling link.
+- **Signal captured:** `payments` table via Stripe webhook.
+
+**Step 8: Sprint Execution (Opaque to Client)**
+
+- **Action:** SC executes the sprint. Per project instructions Section 3, start with Option B (Sanitized): weekly updates and deliverable docs only. No client access to Command Center or GitHub issues.
+- **Client touchpoints:** Weekly email updates with progress summary. No screen in SC Console -- this is email-based for MVP.
+- **Output:** Experiment landing page deployed at `/e/[slug]`, ad campaign live, data collecting.
+
+**Step 9: Landing Page Live**
+
+- **Action:** The experiment landing page goes live, driving traffic from ad campaigns.
+- **Screen:** `[slug].astro` -- the experiment landing page, rendered per archetype.
+- **Visitors:** Marcus's target audience arrives from ads. They see the landing page, interact with the form or payment CTA, and generate signal data.
+- **Signals captured:** `page_view`, `form_start`, `form_submit` (or `payment_complete`) via `POST /events`. Leads captured via `POST /leads`.
+- **Marcus's role:** Passive. He may check in on weekly updates but does not interact with SC Console.
+
+**Step 10: Decision Delivery**
+
+- **Action:** SC operator compiles results and delivers GO/NO-GO recommendation.
+- **Screen:** None for Marcus -- he receives a deliverable document (PDF or email) with the 5-part case study structure.
+- **Content delivered:** Hypothesis tested, test methodology, data collected (conversion rate, cost per lead, total spend, time elapsed), decision recommendation (GO/KILL/PIVOT), evidence supporting the decision, and next steps.
+- **Signal captured:** `decision_memos` table entry via Coda admin.
+- **Marcus's outcome:** He now has evidence-based signal on whether to build. This is the core value delivery moment.
+
+---
+
+## Information Architecture
+
+### Screen Inventory
+
+The following screens exist or must exist for MVP. Each screen lists its content blocks and their data sources.
+
+---
+
+#### Public Marketing Site (siliconcrane.com)
+
+**Screen 1: Homepage** (`/` -- `index.astro`)
+
+- Status: Exists
+- Content blocks:
+  1. Hero section: headline, subheadline, primary CTA ("Start Your Sprint"), secondary CTA ("How It Works")
+  2. Problem statement: single-paragraph pain point
+  3. Services grid: 3 cards (Landing Pages, MVPs & Prototypes, Validation Infrastructure)
+  4. "Why Silicon Crane" proof points: 3 stat cards (30 Days, Evidence-Focused, Go/Kill/Pivot)
+  5. Contact/intake form: name, email, company, message, honeypot, submit
+  6. Footer: copyright, Privacy link, Venture Crane link
+
+**Screen 2: Services** (`/services` -- `services.astro`)
+
+- Status: Exists (content needs Tier 1 completion: pricing, specific deliverables)
+- Content blocks:
+  1. Sprint type breakdown: Preflight, Build-to-Launch, Run + Decide, Scale Readiness
+  2. Per-sprint details: duration, deliverables, price point
+  3. Founding client offer: $2,500 rate with case study/testimonial exchange
+  4. CTA to intake form
+
+**Screen 3: About** (`/about` -- `about.astro`)
+
+- Status: Exists
+- Content blocks: Company background, methodology overview, team
+
+**Screen 4: Case Study** (does not exist -- Tier 2)
+
+- Content blocks:
+  1. DFG case study header: venture name, archetype, sprint type
+  2. The Hypothesis: what was believed
+  3. The Test: what was built/run
+  4. The Data: metrics (time to prototype, cost to market test, key pivots)
+  5. The Decision: GO/NO-GO and rationale
+  6. Current State: where it is now
+- Data source: Static content (pre-rendered)
+
+**Screen 5: Intake Form** (does not exist -- Tier 1)
+
+- Content blocks:
+  1. Form header: "Tell us about your idea"
+  2. Idea description (textarea)
+  3. Current stage (select)
+  4. Budget range (select)
+  5. Timeline preference (select)
+  6. Contact fields: name, email, company
+  7. Honeypot field
+  8. Submit button
+  9. Confirmation/thank-you state
+- Data source: `POST /leads` with `custom_fields` for intake-specific responses
+
+---
+
+#### Experiment Landing Pages (siliconcrane.com/e/[slug])
+
+**Screen 6: Landing Page** (`/e/[slug]` -- `[slug].astro`)
+
+- Status: Exists (single-template, needs archetype-aware evolution per func spec Phase 6)
+- MVP content blocks (current template):
+  1. Headline (from `copy_pack.headline` or `experiment.name`)
+  2. Subheadline (from `copy_pack.subheadline`)
+  3. Price badge (conditional: if `stripe_price_id` and `price_cents` are set)
+  4. Value props list (from `copy_pack.value_props`)
+  5. Lead capture form (email, name, company, honeypot) OR Payment CTA
+  6. Form message area (success/error/duplicate states)
+- Data source: `GET /experiments/by-slug/:slug` (public endpoint)
+- MVP evolution (per func spec Phase 6): Archetype-aware sections, SignalCapture component, social proof, FAQ, pricing section, qualification form, content preview, process steps
+
+**Screen 7: Thank You** (`/e/[slug]/thank-you` -- `thank-you.astro`)
+
+- Status: Exists
+- Content blocks:
+  1. Success icon
+  2. Thank you heading
+  3. "What happens next" list (3 items)
+  4. Back to homepage link
+- Data source: `getExperimentBySlug(slug)` for experiment name
+
+**Screen 8: Payment** (`/e/[slug]/payment` -- `payment.astro`)
+
+- Status: Exists
+- Content blocks: Stripe Checkout redirect
+- Data source: Experiment's `stripe_price_id`
+
+---
+
+#### Admin Interface
+
+**Screen 9: Coda Admin Dashboard** (external -- Coda Pack)
+
+- Status: Phase 1 per tech spec Section 9
+- Content blocks:
+  1. Experiment list with status filters
+  2. Experiment detail view (all fields)
+  3. Status transition controls
+  4. Metrics import form
+  5. Lead list per experiment
+  6. Decision memo creation form
+  7. Learning memo creation form
+- Data source: sc-api internal endpoints via `X-SC-Key` auth
+
+---
+
+### Navigation Structure
+
+**Primary navigation** (visible on marketing pages):
+
+- Homepage (`/`)
+- Services (`/services`)
+- About (`/about`)
+- Case Study (Tier 2 -- not yet built)
+- Contact (`/#contact` anchor or separate intake page)
+
+**Landing page navigation:** None. Experiment landing pages at `/e/[slug]` are standalone -- no site navigation, no header links, no distractions. This is intentional: landing pages must minimize exit paths to maximize conversion signal quality. The only navigation is the form CTA and the post-submission thank-you page.
+
+**Footer navigation** (all pages):
+
+- Privacy Policy
+- Venture Crane (external)
+
+---
+
+## Interaction Patterns
+
+### Pattern 1: Lead Capture Form (Experiment Landing Page)
+
+**Flow:** Visitor arrives -> reads page -> interacts with form -> submits -> receives confirmation
+
+**States:**
+
+| State              | UI Presentation                                                                                           | Trigger                                 |
+| ------------------ | --------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Default            | Form visible with empty fields. Submit button active with CTA text from `copy_pack.cta_primary`.          | Page load                               |
+| Form start         | No visible change. `form_start` event fired to `POST /events` on first field focus.                       | First field interaction                 |
+| Submitting         | Submit button disabled, text changes to "Submitting...", all fields disabled.                             | Form submit click                       |
+| Success            | Redirect to `/e/[slug]/thank-you`.                                                                        | `POST /leads` returns `success: true`   |
+| Error (duplicate)  | Yellow message box: "You're already on the list! Check your email for updates." Submit button re-enabled. | API returns `DUPLICATE_LEAD` error code |
+| Error (validation) | Red message box with error message from API. Submit button re-enabled.                                    | API returns `VALIDATION_ERROR`          |
+| Error (network)    | Red message box: "Network error. Please check your connection and try again." Submit button re-enabled.   | Fetch throws exception                  |
+| Honeypot triggered | Silent redirect to thank-you page. No API call.                                                           | Hidden `website` field has value        |
+
+**Error handling notes:**
+
+- The submit button text reverts to the CTA text on error, not a generic fallback. Currently the code falls back to "Get Early Access" -- this should use the experiment's `copy_pack.cta_primary` value.
+- Duplicate lead handling is a yellow warning, not a red error -- the visitor should not feel punished for submitting twice.
+- Network errors should suggest checking connectivity, not "something went wrong" (which implies a server problem the visitor cannot fix).
+
+---
+
+### Pattern 2: Payment CTA (Priced Experiments)
+
+**Flow:** Visitor arrives -> reads page -> clicks payment CTA -> redirected to Stripe Checkout -> completes payment -> redirected to confirmation
+
+**States:**
+
+| State                 | UI Presentation                                                                           | Trigger                                  |
+| --------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------- |
+| Default               | Payment CTA button with price display: "Proceed to Payment". Price badge visible in hero. | Page load                                |
+| Navigating to payment | Browser navigates to `/e/[slug]/payment`.                                                 | CTA click                                |
+| Stripe Checkout       | Stripe-hosted checkout page. SC Console has no control over this UI.                      | Payment page loads Stripe session        |
+| Payment success       | Stripe redirects to success URL (currently `/e/[slug]/thank-you`).                        | Stripe confirms payment                  |
+| Payment failure       | Stripe shows error on checkout page. Visitor can retry or cancel.                         | Card declined or payment error           |
+| Payment cancel        | Stripe redirects to cancel URL (back to landing page).                                    | Visitor clicks cancel on Stripe checkout |
+
+**Notes:**
+
+- The current flow uses a separate `/e/[slug]/payment` page as an intermediary before Stripe Checkout. This adds a click to the flow. For MVP this is acceptable. Phase 6 evolution should evaluate whether a direct Stripe Checkout redirect from the landing page CTA reduces friction.
+- Post-payment confirmation should differ from post-signup confirmation: it should include the amount paid, expected delivery timeline, and "what happens next" specific to the purchase, not the generic "We'll be in touch" message.
+
+---
+
+### Pattern 3: Contact Form (Homepage)
+
+**Flow:** Visitor arrives at homepage -> scrolls to contact section -> fills form -> submits -> receives confirmation
+
+**States:**
+
+| State              | UI Presentation                                                                                                               | Trigger                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| Default            | Form with 4 fields: name (required), email (required), company (optional), message (required). Submit button: "Get in Touch". | Page load or scroll to `#contact` |
+| Submitting         | Submit button disabled, text changes to "Sending...".                                                                         | Form submit click                 |
+| Success            | Green message box: "Thanks! We'll be in touch soon." Form fields reset.                                                       | `POST /contact` returns 200       |
+| Error (fallback)   | Browser opens `mailto:launch@siliconcrane.com` with prefilled subject and body.                                               | Fetch fails                       |
+| Honeypot triggered | Fake success message displayed. No API call.                                                                                  | Hidden `website` field has value  |
+
+**Design note:** The mailto fallback on network error is a smart degradation pattern. The visitor still gets to communicate their interest even if the API is down. This should be preserved in any future redesign.
+
+---
+
+### Pattern 4: Preview Mode (Operator Review)
+
+**Flow:** Operator appends `?preview=true` to any experiment URL -> page renders regardless of experiment status -> operator reviews -> transitions status to `launch` when satisfied
+
+**States:**
+
+| State                              | UI Presentation                                                                                                                                                                       | Trigger                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Preview active                     | Page renders normally but includes `<meta name="robots" content="noindex">`. Visual indicator (e.g., banner) should show "PREVIEW MODE - Not visible to public" for operator clarity. | `?preview=true` query parameter                                              |
+| Status not launch/run (no preview) | Redirect to 404.                                                                                                                                                                      | Experiment status is not `launch` or `run`, and no `?preview=true` parameter |
+
+**Notes:**
+
+- Preview mode currently does not exist in the codebase. The current `[slug].astro` redirects to 404 for any experiment not in `launch` or `run` status.
+- The preview banner must be visually obvious but must not affect the page layout -- the operator needs to see exactly what visitors will see, with a non-intrusive overlay indicating preview mode.
+
+---
+
+## Platform-Specific Design Constraints
+
+### Primary Platform: Mobile Web
+
+Per DD#5 Section 3: "DD#2 specifies mobile-first for all archetypes -- the majority of ad traffic arrives on mobile." Landing pages receive traffic primarily from paid social ads (Facebook, Instagram, TikTok, LinkedIn) where the majority of users are on mobile devices.
+
+**Constraints:**
+
+1. **Viewport:** All landing page content must be legible and interactive at 320px minimum width. The current template uses `container mx-auto px-4` which provides adequate padding, but form inputs at `px-4 py-2` may be undersized for mobile touch targets.
+
+2. **Touch targets:** All interactive elements (buttons, form fields, links) must meet a minimum 44x44px touch target (Apple HIG / WCAG 2.5.5). The current submit button (`py-3 px-6`) meets this requirement. Form inputs (`py-2`) may fall below the 44px minimum height on some devices.
+
+3. **Form input sizing:** On iOS Safari, form inputs with font-size below 16px trigger automatic zoom, which disrupts the page layout. All form inputs must use `text-base` (16px) or larger to prevent this.
+
+4. **Scroll performance:** The `scroll_depth` tracking event listener must use `{ passive: true }` to avoid blocking scroll on mobile. The DD#5 signal capture spec already specifies this.
+
+5. **Connection reliability:** Mobile users on cellular connections may have intermittent connectivity. The `navigator.sendBeacon` approach for event tracking (specified in DD#5) is correct -- it survives page navigation and is fire-and-forget. Form submissions use `fetch`, which can fail on poor connections. The existing error handling ("Network error. Please check your connection and try again.") is appropriate.
+
+6. **Page weight:** Landing pages must load within 3 seconds on a 3G connection. Astro's zero-JS-by-default architecture helps. The only client-side JS should be: form handling, signal capture (sendBeacon), and A/B variant assignment (Phase 6). No JavaScript frameworks, no heavy libraries.
+
+7. **Above the fold:** On mobile, the headline, subheadline, and primary CTA must be visible without scrolling. For `fake_door` (the lightest archetype), the entire conversion path (headline + email field + submit button) should be above the fold on a standard mobile viewport (375x667px).
+
+### Secondary Platform: Desktop Web
+
+Desktop is the secondary consumption context, primarily for direct traffic (bookmarks, email links, organic search).
+
+**Adaptations:**
+
+- Use the existing responsive breakpoint pattern (`md:` prefix in Tailwind) for two-column layouts where appropriate (e.g., hero image beside hero text, form beside value props).
+- Maximum content width is constrained to `max-w-2xl` (672px) on the current landing page template, which is appropriate for readability but may waste space on wide monitors. Consider `max-w-3xl` or `max-w-4xl` for pages with more sections (presale, concierge, service_pilot).
+- Desktop users are more likely to read long-form content (case studies, FAQ). Prioritize scannable formatting: clear headings, short paragraphs, bullet lists.
+
+---
+
+## Accessibility Requirements
+
+### WCAG Compliance Target
+
+**WCAG 2.1 Level AA** -- This is the baseline for all public-facing pages (marketing site and experiment landing pages). Level AAA is not targeted for MVP but specific AAA criteria should be adopted where low-effort (e.g., 4.5:1 contrast ratios over the 3:1 AA minimum for large text).
+
+### Specific Requirements
+
+**1. Color Contrast (WCAG 1.4.3)**
+
+- All text must meet 4.5:1 contrast ratio against its background for normal text, 3:1 for large text (18px+ or 14px+ bold).
+- The current color scheme uses `text-gray-600` on white (`#4B5563` on `#FFFFFF` = 5.9:1 ratio -- passes) and `text-slate-300` on `bg-slate-900` (`#CBD5E1` on `#0F172A` = 11.1:1 ratio -- passes).
+- The `text-slate-500` used for footnotes on dark backgrounds (`#64748B` on `#0F172A` = 4.5:1 -- borderline, must be verified).
+- Form validation error colors (`text-red-800` on `bg-red-50`) and duplicate warning colors (`text-yellow-800` on `bg-yellow-50`) must be verified for contrast.
+- The tone-based styling system (Phase 6) must enforce contrast minimums for all three registers: `rational` (blue/gray), `empathetic` (teal), `urgent` (red). The `tone-urgent` red palette (`bg-red-600`) with white text passes at 4.6:1 but is close to the threshold.
+
+**2. Keyboard Navigation (WCAG 2.1.1)**
+
+- All interactive elements must be reachable and operable via keyboard (Tab, Enter, Escape).
+- The current form implementation uses standard HTML form elements, which are keyboard-accessible by default.
+- The honeypot field uses `tabindex="-1"` to remove it from the tab order -- correct.
+- Focus indicators must be visible. The current `focus:ring-2 focus:ring-blue-500` provides a visible focus ring. Do not remove or suppress default focus outlines without providing a custom alternative.
+
+**3. Form Labels (WCAG 1.3.1, 3.3.2)**
+
+- All form inputs must have associated `<label>` elements with matching `for`/`id` attributes. The current implementation does this correctly.
+- Required fields must be programmatically indicated, not just visually. The current pattern uses `*` in label text and the `required` attribute on the input. Both should be present.
+- Error messages must be associated with their fields using `aria-describedby` or `aria-live` regions. The current implementation uses a generic message div (`#form-message`) that is not associated with specific fields. For MVP this is acceptable for single-form pages; Phase 6 should add per-field validation with `aria-describedby`.
+
+**4. Semantic HTML (WCAG 1.3.1)**
+
+- Landing pages must use proper heading hierarchy: one `<h1>` per page (the headline), `<h2>` for section headings, `<h3>` for subsections.
+- The current template uses `<h1>` for the headline and `<h2>` for the form section heading -- correct.
+- Lists of value props must use `<ul>`/`<li>` elements -- the current implementation does this correctly.
+- The thank-you page uses proper heading hierarchy with `<h1>` and `<h2>`.
+
+**5. Alternative Text (WCAG 1.1.1)**
+
+- All images must have meaningful `alt` text. Decorative SVG icons should have `aria-hidden="true"`.
+- The current template's checkmark SVGs do not have `aria-hidden="true"` -- these should be added since the checkmarks are decorative (the meaning is conveyed by the list text).
+- Hero images (Phase 6, from `asset_references`) must have `alt` text derived from the `creative_brief.primary_subject` field or a fallback description.
+
+**6. Screen Reader Compatibility (WCAG 4.1.2)**
+
+- Form submission states (submitting, success, error) must be announced to screen readers. Use `aria-live="polite"` on the `#form-message` div so state changes are announced without interrupting the user.
+- The current implementation does not include `aria-live` on the message div -- this must be added.
+- Loading states on the submit button should use `aria-busy="true"` and update `aria-label` to "Submitting, please wait" during submission.
+
+**7. Motion and Animation (WCAG 2.3.1, 2.3.3)**
+
+- The A/B variant no-flicker protocol (Phase 6) uses `opacity` transitions. These must respect `prefers-reduced-motion`:
+  ```css
+  @media (prefers-reduced-motion: reduce) {
+    .ab-pending {
+      opacity: 1;
+      transition: none;
+    }
+  }
+  ```
+- No auto-playing animations, carousels, or videos on landing pages.
+
+**8. Touch Target Size (WCAG 2.5.5 -- Level AAA, adopted for MVP)**
+
+- All interactive elements must be at least 44x44 CSS pixels. This is Level AAA but is critical for mobile-first landing pages where the majority of traffic is touch-based.
+- The current submit button meets this requirement. Form inputs should be audited.
+
+### Assistive Technology Support
+
+- **Screen readers:** VoiceOver (iOS/macOS), NVDA (Windows), TalkBack (Android). Test with at least VoiceOver for MVP since the primary developer environment is macOS.
+- **Keyboard-only navigation:** Full form completion and submission must be possible without a mouse or touch input.
+- **Zoom:** Pages must remain functional and legible at 200% browser zoom (WCAG 1.4.4). The responsive Tailwind layout handles this inherently, but fixed-width elements and absolute-positioned elements (like the honeypot) should be verified.
+
+---
+
+## UX Risks and Open Items
+
+### Risk 1: No Signal Capture on Current Landing Pages
+
+The existing `[slug].astro` template fires zero events to `event_log`. No `page_view`, no `form_start`, no `scroll_depth`. This means the metrics pipeline has no landing-page-side data -- `sessions` and `conversions` in `metrics_daily` must be populated manually or from ad platform data only. The func spec identifies `SignalCapture` as "the highest-priority item" (Phase 6). From a UX perspective, this means the operator has no visibility into visitor behavior until SignalCapture is implemented. Recommendation: prioritize `SignalCapture` ahead of archetype-specific templates.
+
+### Risk 2: Thank-You Page is Generic
+
+The current thank-you page shows the same "We'll be in touch" message for all archetypes. For `content_magnet`, it should show a download link. For `presale`, it should show payment confirmation and delivery timeline. For `concierge`/`service_pilot`, it should promise personal founder outreach within 24 hours. These archetype-specific thank-you variants should ship alongside the archetype-aware template router in Phase 6.
+
+### Risk 3: No Intake Form Exists
+
+The Tier 1 blockers from the project instructions list an intake form as a must-have to accept money. The current homepage has a contact form, but it captures free-text "What are you looking to validate?" without structured fields for stage, budget, or timeline. A proper intake form is needed before the first client engagement. This is a UX deliverable that must precede the func spec v2.0 implementation work.
+
+### Risk 4: Accessibility Debt in Current Template
+
+The decorative SVG icons lack `aria-hidden="true"`, the form message div lacks `aria-live`, and submit button loading states are not announced to screen readers. These are small fixes that should be addressed in the next PR touching `[slug].astro` or `thank-you.astro`, not deferred to a dedicated accessibility sprint.

--- a/docs/pm/prd.md
+++ b/docs/pm/prd.md
@@ -1,0 +1,1381 @@
+# Silicon Crane -- Product Requirements Document
+
+> Synthesized from 1-round, 6-role PRD review process. Generated 2026-03-02.
+
+## Table of Contents
+
+1. Executive Summary
+2. Product Vision & Identity
+3. Target Users & Personas
+4. Core Problem
+5. Product Principles
+6. Competitive Positioning
+7. MVP User Journey
+8. MVP Feature Specifications
+9. Information Architecture
+10. Architecture & Technical Design
+11. Proposed Data Model
+12. API Surface
+13. Non-Functional Requirements
+14. Platform-Specific Design Constraints
+15. Success Metrics & Kill Criteria
+16. Risks & Mitigations
+17. Open Decisions / ADRs
+18. Phased Development Plan
+19. Glossary
+    Appendix: Unresolved Issues
+
+---
+
+## 1. Executive Summary
+
+Entrepreneurs burn months of runway and tens of thousands of dollars building products before discovering their ideas do not work. There is no productized, evidence-based service that provides a fast, structured validation outcome a founder can act on.
+
+Silicon Crane (SC) is a Validation-as-a-Service (VaaS) offering that runs structured sprints -- Preflight, Build-to-Launch, Run + Decide, and Scale Readiness -- to produce a clear GO/NO-GO signal backed by real market data. SC Console is the internal platform that powers these sprints: it manages experiments end-to-end from hypothesis definition through market testing to evidence-based verdicts.
+
+Founders get a defensible validation outcome in 2-3 weeks for a fraction of the cost of building blindly. SC gets a repeatable, methodology-driven delivery model that scales across ventures and clients. The console codifies the entire validation artifact chain -- Hypothesis Card through Validation Report -- so that every sprint is traceable, every decision is evidence-backed, and every learning compounds into better calibration over time.
+
+The MVP scope is Phase 0 (business foundation: pricing, services page, intake form, contract template, payment mechanism, DFG case study) plus Milestone A (Phases 1-3: schema foundation, Hypothesis Card, Discovery Engine). Phase 0 contains zero platform development -- it is pure business infrastructure required to accept the first paying client.
+
+---
+
+## 2. Product Vision & Identity
+
+### Name & Tagline
+
+- **Product Name:** SC Console
+- **Service Brand:** Silicon Crane
+- **Tagline:** "Kill bad ideas in 2 weeks instead of 6 months."
+
+### Positioning
+
+SC Console is the internal operating system for Silicon Crane's validation sprints. It is not a customer-facing SaaS product. It is the engine that lets SC run structured experiments, capture market signals, and produce evidence-based verdicts for clients and internal ventures.
+
+SC Console sits in the Venture Crane ecosystem alongside DFG and other ventures. It shares the Cloudflare-native infrastructure pattern (Workers, D1, R2, Pages) but intentionally diverges on frontend framework (Astro instead of Next.js) because SC is a content-heavy marketing and landing page system, not a data-heavy dashboard.
+
+### What This Is
+
+- An internal experiment management platform for running validation sprints
+- A structured artifact pipeline from raw idea through market verdict
+- A landing page generation and signal capture system for experiment archetypes
+- A measurement and decision support system that produces evidence-backed GO/NO-GO recommendations
+
+### What This Is NOT
+
+- Not a customer-facing SaaS product (clients see deliverables, not the console)
+- Not a dev shop tool (we validate hypotheses, not build to spec)
+- Not a general-purpose CMS or website builder
+- Not an ad platform (we integrate with ad platforms, not replace them)
+- Not a CRM (we capture leads for experiments, not manage sales pipelines)
+
+> **Target Customer Validation:** "Is SC Console a product I log into? Or is it the internal tooling the SC team uses to run my sprint?" The answer must be unambiguous in all client-facing materials: SC Console is internal tooling. Clients receive deliverables -- weekly updates, validation reports, decision memos -- not platform access. This aligns with the sanitized delivery model (Option B) where clients see deliverable documents, not GitHub issues or the Command Center.
+
+---
+
+## 3. Target Users & Personas
+
+### Persona 1: Marcus Chen -- The Technical Founder with Too Many Ideas
+
+Marcus is a 34-year-old senior software engineer at a mid-size fintech company. He has been building side projects for six years, shipping three to production, and watching all three flatline after launch. His GitHub is full of well-architected codebases that nobody uses.
+
+**Frustration:** Marcus builds first and validates never. He spent four months and $3,200 on AWS costs building a full product for his last idea before discovering that his target customers already had a "good enough" spreadsheet workflow. He knows he should validate before building but does not have a framework, the marketing skills, or the patience to run a proper demand test.
+
+**Goal:** Someone to tell him, with evidence, whether his current idea is worth building. A GO/NO-GO signal he can trust, delivered fast enough that he does not lose momentum. He is willing to pay $2,500 if it saves him from burning another $10K+ and six months on the wrong idea.
+
+**Relationship to SC:** Prototypical Preflight + Build-to-Launch client. Arrives with a specific idea, can articulate the problem, is ready to define kill criteria. He is the "Good Fit" profile: has a specific idea, willing to define kill criteria upfront, can make decisions quickly, budget aligned.
+
+**Landing page behavior:** Reads the entire page. Cares about the process ("How does this work?"), not the emotional pitch. Wants to see a case study with real metrics. Converts on `waitlist` or `priced_waitlist` archetypes after 2-3 minutes of reading.
+
+### Persona 2: Priya Kapoor -- The Non-Technical Domain Expert
+
+Priya is a 41-year-old operations director at a regional healthcare staffing agency. She has spent 15 years watching her industry solve scheduling, credentialing, and compliance problems with Excel spreadsheets and phone calls. She believes a purpose-built tool could save agencies like hers 20+ hours per week, but she does not know how to build software.
+
+**Frustration:** Two dev shops have quoted her $80K and 4-6 months for an MVP. She does not know if the problem is big enough to justify that investment, or if the nurses and schedulers she imagines as users would actually adopt a new tool.
+
+**Goal:** Know if her idea has legs before she risks her savings or seeks outside investment. She wants someone who will do the validation work -- run the interviews, build the test page, measure the demand -- because she does not have the technical skills or the time to learn growth hacking while running a full-time job.
+
+**Relationship to SC:** Ideal full-stack engagement client: Preflight through Run + Decide. Needs the most hand-holding during intake and scoping, but once the sprint starts, she is a responsive decision-maker. Maps to the "Non-technical people with domain expertise + idea" target segment.
+
+**Landing page behavior:** Scans, does not read. Needs the headline and subheadline to immediately tell her this is for people like her (domain experts, not developers). Will not tolerate jargon ("archetypes," "kill criteria," "conversion rate"). Converts on `concierge` or `service_pilot` archetypes after confirming SC does the work, not just advises.
+
+### Persona 3: Jordan Reeves -- The Repeat Founder Validating a Pivot
+
+Jordan is a 29-year-old founder who shut down their first startup (a D2C subscription box) after 18 months and $140K burned. They are now sitting on two new ideas and dwindling personal savings. They have founder scars: they know what it feels like to build the wrong thing.
+
+**Frustration:** Jordan knows how to validate -- they have read The Mom Test, run Facebook ads, built landing pages on Carrd. But they are exhausted and do not trust their own judgment anymore. They want external objectivity and a structured process with predefined kill criteria so that their emotional attachment cannot override the data.
+
+**Goal:** Run two cheap, fast validation tests on two ideas and kill the loser within two weeks. They want evidence they can show a potential co-founder or angel investor. They value speed above all else.
+
+**Relationship to SC:** Most sophisticated buyer. Understands the methodology and will evaluate SC on execution speed, data quality, and the rigor of the decision framework. Likely a Preflight + Build-to-Launch client who may run two experiments in parallel.
+
+**Landing page behavior:** Skips the hero section and scrolls directly to the case study, pricing, and process details. Evaluates the kill criteria methodology and wants to see real numbers. Converts fast on `presale` archetypes if the price is right.
+
+---
+
+## 4. Core Problem
+
+> "I think about this idea every single day. I daydream about quitting my job to build it. And then I remember the [last] disaster and I do nothing. I've been stuck in this loop for eight months. I'm not making progress because I'm afraid of making the wrong kind of progress."
+
+Entrepreneurs with viable business ideas are stuck between two bad options:
+
+1. **Build blind.** Spend months and tens of thousands of dollars building a product before discovering whether anyone wants it. The average startup spends $250K and 18 months before realizing they built the wrong thing.
+
+2. **Validate alone.** Attempt to validate using free tools, blog posts, and fragmented lean startup advice. Founders without marketing expertise get overwhelmed by the combination of decisions: What should the headline say? What is the right audience targeting? How much should I spend? What conversion rate means the idea is worth pursuing? Without frameworks for any of this, "just winging it" is how they end up thousands of dollars poorer with nothing to show for it.
+
+The gap is that no productized service exists at an accessible price point that provides:
+
+- **Structured hypothesis framing** (not just "tell me your idea")
+- **Real market testing** (not AI-generated analysis reports)
+- **Predefined kill criteria** (not post-hoc rationalization)
+- **An evidence-backed GO/NO-GO verdict** (not "here's what you should do next")
+- **Done-for-you execution** (not "here's a toolkit, good luck")
+
+> **Target Customer Validation:** "I've looked at hiring a marketing agency to run some test campaigns, but the ones I've talked to want $5,000-10,000/month retainers and a 3-month commitment. They want to 'build my brand.' I don't have a brand. I have a hypothesis. They don't understand the difference."
+
+---
+
+## 5. Product Principles
+
+These principles are ordered by priority. When two principles conflict, the higher-ranked one wins.
+
+### 1. Evidence Over Opinion
+
+Every experiment must produce measurable data. Every decision must reference that data. The system must never allow a GO/KILL/PIVOT decision without a metrics snapshot. If we cannot measure it, we do not ship it.
+
+### 2. Kill Fast, Kill Cheap
+
+The entire system is optimized to surface failure signals as early and inexpensively as possible. Kill criteria are defined before launch, not after. Hard kill triggers are non-negotiable. The system biases toward protecting the client's capital over protecting the hypothesis.
+
+### 3. Backward Compatibility Is Non-Negotiable
+
+All schema changes are additive (nullable columns). Existing experiments continue to work without modification. Write invariants only activate when new columns are populated. The functional spec v2.0 is additive to tech spec v1.2, not a replacement. No migration may break existing data.
+
+### 4. Methodology Is the Product
+
+The artifact chain (Hypothesis Card -> Discovery Summary -> Test Blueprint -> Campaign Package -> Live Experiment -> Validation Report) is the core intellectual property. Every feature must reinforce the methodology. Features that bypass the chain (e.g., launching without kill criteria) are bugs, not shortcuts.
+
+### 5. Internal-First, Client-Sanitized
+
+The console is an internal tool. Client visibility follows Option B (sanitized): clients see weekly updates and deliverable documents, not GitHub issues or the Command Center. The system must produce clean, portable deliverables (case studies, validation reports, decision memos) without exposing internal tooling.
+
+### 6. Operational Simplicity Over Feature Richness
+
+Cloudflare-native stack was chosen for lowest operational complexity. No recurring infrastructure costs at low traffic. Single deployment target. Every infrastructure addition (Queues, R2 buckets, cron triggers) must justify its operational overhead. Defer complexity to later phases when it is proven necessary.
+
+### 7. Compound Learning
+
+Every completed experiment calibrates the system. Threshold registries improve with data. Venture benchmarks accumulate. The system gets better at predicting outcomes as the portfolio grows. Design for learning accumulation from day one, even if Phase 1 uses hardcoded defaults.
+
+---
+
+## 6. Competitive Positioning
+
+### Market Map
+
+Silicon Crane operates at the intersection of three established markets: AI idea validation tools, design/innovation sprint agencies, and venture studios. No single competitor occupies the exact same niche -- "productized, done-for-you validation sprints with structured GO/NO-GO methodology at sub-$5K price points" -- but the adjacent categories exert real competitive pressure because they address the same buyer pain.
+
+| Category                      | What They Sell                                                | Price Range               | SC Overlap |
+| ----------------------------- | ------------------------------------------------------------- | ------------------------- | ---------- |
+| AI Idea Validators            | Instant AI-generated reports on idea viability                | $0 - $59/report           | Low-medium |
+| Lean Startup Platforms        | Software to manage experiments, canvases, customer interviews | $0 - $49/mo SaaS          | Low        |
+| Market Experiment Platforms   | AI-assisted in-market testing (ad-based experiments)          | $2K - $18K/experiment set | High       |
+| Design Sprint Agencies        | Facilitated 5-day to 8-week sprints for product/brand         | $15K - $250K+             | Medium     |
+| MVP Dev Shops                 | Build prototype/MVP to spec                                   | $20K - $140K+             | Medium     |
+| Venture Studios               | Build companies from scratch, take equity                     | $25K-$50K + equity        | Low-medium |
+| Startup Consultants / Coaches | Advisory, mentorship, strategy                                | $150-$500/hr or retainers | Low        |
+
+### Key Competitors
+
+**Heatseeker.ai (HIGH threat):** AI-powered market experiment platform. Users define hypotheses, Heatseeker generates ad creatives and runs real paid experiments. At $16K-$18K for 6-8 experiments, they directly automate SC's "Run + Decide" phase. Heatseeker's weakness: it is a tool, not a partner -- no hypothesis sharpening, no kill criteria, no holistic GO/NO-GO call. SC's methodology chain is genuinely more comprehensive.
+
+**DimeADozen.ai (MEDIUM threat):** AI-generated 40+ page validation reports for $59. Addresses the same initial impulse at a fraction of SC's cost. The threat is not quality -- it is price anchoring. A founder who pays $59 for a positive AI report may feel "validated enough" to skip SC entirely.
+
+**IdeaProof.io (MEDIUM threat):** AI-powered validator with market intelligence from 50+ sources, including brand strategy and ad creative generation, for $9-$24/mo. Overlaps with SC's Campaign Factory but without real market testing or validated messaging.
+
+**Design Sprint Agencies (MEDIUM threat):** Closest analog to SC's sprint model at 5-30x the price ($15K-$250K). The real threat is perceptual: founders searching for "validation sprint" will find design sprint agencies and may assume SC is a cheaper, lower-quality version.
+
+### Where SC Genuinely Differs
+
+1. **End-to-end methodology with decision framework.** No competitor in this price range offers a complete chain from hypothesis through evidence-based GO/NO-GO verdict. AI tools stop at analysis. Design sprint agencies stop at prototype testing. Heatseeker stops at experiment data.
+
+2. **Kill criteria as a first-class concept.** SC is the only offering that makes kill criteria mandatory and structural. Every other tool or service is incentivized to keep the founder optimistic. SC's explicit "kill bad ideas fast" positioning is counter-positioned against the market.
+
+3. **Price point for done-for-you service.** At the founding rate, SC undercuts design sprint agencies by 6-30x while offering comparable or greater depth.
+
+4. **Practitioner credibility.** SC uses its own methodology for its own ventures (DFG case study). This is a legitimate differentiator that most AI tools and agencies cannot claim.
+
+### Pricing Position
+
+SC's founding client rate of $2,500 sits in a pricing gap: 50x more expensive than AI validation tools ($25-$59), 6-7x cheaper than Heatseeker or design sprint agencies ($15K-$18K). The sweet spot buyer segment is the "serious first-time founder" willing to spend $1K-$5K for a structured answer.
+
+**Recommended positioning:** The $2,500 founding rate is a limited-time, named-client program with explicit conditions (case study rights, testimonial, feedback), not "the price." Future pricing should be visible as the standard rate to anchor expectations. Position SC's Preflight sprint explicitly against AI validation tools: "You got the AI report. Now let's find out if it's actually true."
+
+### Uncomfortable Truths
+
+These competitive weaknesses must be addressed, not ignored:
+
+- **The AI tools are "good enough" for most buyers.** The total addressable market for SC is not "everyone with a startup idea" -- it is the smaller subset who understand that AI analysis is not real validation, have $2,500+, and are willing to accept a NO-GO answer.
+- **The founding client rate creates a credibility trap.** $2,500 for a done-for-you sprint is extraordinarily cheap. Sophisticated buyers will ask how it is possible. The answer -- "solo operator subsidizing early clients for case studies" -- is honest but fragile.
+- **Heatseeker is automating SC's highest-value phase.** As Heatseeker matures and drops in price, the technology layer of SC's offering becomes a commodity. SC's remaining moat is the human judgment layer.
+- **No case studies, no social proof, no track record.** Every competitor has user counts, testimonials, or case studies. SC has zero completed client engagements. Prioritize the DFG case study above all other content work.
+- **"Kill bad ideas fast" is a hard sell.** Founders want to hear "yes." Services that tell founders "no" do not get referrals from those founders.
+
+---
+
+## 7. MVP User Journey
+
+This journey traces a new prospect from first encountering SC to receiving a GO/NO-GO decision. MVP scope only -- no client portal, no automated campaign generation, no discovery engine UI.
+
+### Step 1: Discovery (External)
+
+- **Trigger:** Prospect sees a LinkedIn post about SC's DFG case study, or receives a cold outreach email with the value prop: "Kill bad ideas in 2 weeks instead of 6 months."
+- **Action:** Clicks link to siliconcrane.com.
+- **Screen:** Homepage (`index.astro`).
+- **Content consumed:** Hero headline, problem statement, service overview, "Why Silicon Crane" proof points.
+- **Decision point:** "Is this for me?"
+
+### Step 2: Services Exploration
+
+- **Action:** Navigates to services page or "How It Works" section.
+- **Screen:** `services.astro` or `#how-it-works` section.
+- **Content consumed:** Sprint types (Preflight, Build-to-Launch, Run + Decide), deliverables, timeline, pricing.
+- **Blocker (Tier 1):** Pricing must be locked. Services page must have specific prices and clear CTAs.
+- **Decision point:** "What would I buy, and what does it cost?"
+
+### Step 3: Trust Building
+
+- **Action:** Prospect looks for proof that SC has done this before.
+- **Screen:** Case study page.
+- **Content consumed:** DFG case study: hypothesis, test, data, decision, current state.
+- **Blocker (Tier 2):** DFG case study must be drafted with real metrics.
+- **Decision point:** "Do they have the track record to execute?"
+
+> **Target Customer Validation:** "A real case study with real numbers is the single most important piece of content for converting me. Show me you actually practice what you preach."
+
+### Step 4: Intake
+
+- **Action:** Clicks "Start Your Sprint" CTA or navigates to intake form.
+- **Screen:** Intake form (Typeform/Tally).
+- **Form fields:** Idea description, current stage, budget range, timeline preference, name, email, company.
+- **Post-submission:** Confirmation with expected response time (24-48 hours).
+- **Signal captured:** `POST /leads` with `custom_fields`.
+
+### Step 5: Qualification (Internal)
+
+- **Action:** SC operator reviews intake against qualification criteria.
+- **Evaluation:** Has a specific idea? Can articulate the problem? Budget aligned? Can make decisions quickly?
+- **Output:** GO (schedule scoping call) or NO-GO (decline with alternative resources).
+
+### Step 6: Scoping Call
+
+- **Action:** 30-minute call between prospect and SC operator.
+- **Discussion:** Align on sprint type, define preliminary kill criteria, agree on timeline.
+- **Output:** Draft SOW with sprint type, deliverables, timeline, price, kill criteria.
+
+> **Target Customer Validation:** "I need a human conversation before I commit. If the qualification call is genuinely diagnostic -- 'here's why your idea is or isn't a good candidate for our sprints' -- that's incredibly valuable and builds trust."
+
+### Step 7: Contract + Payment
+
+- **Action:** Prospect reviews SOW, pays via Stripe.
+- **Screen:** Stripe Checkout (hosted).
+- **Post-payment:** Confirmation email and kickoff scheduling.
+
+### Step 8: Sprint Execution (Opaque to Client)
+
+- **Delivery model:** Option B (Sanitized) -- weekly email updates with progress summary. No client access to console.
+- **Output:** Experiment landing page deployed, ad campaign live, data collecting.
+
+### Step 9: Landing Page Live
+
+- **Screen:** `/e/[slug]` -- experiment landing page rendered per archetype.
+- **Visitors:** Target audience arrives from ads, interacts with form or payment CTA.
+- **Signals captured:** `page_view`, `form_start`, `form_submit`, `payment_complete`.
+- **Client role:** Passive. Receives weekly updates.
+
+### Step 10: Decision Delivery
+
+- **Deliverable:** GO/NO-GO recommendation document containing hypothesis tested, test methodology, data collected (conversion rate, cost per lead, total spend, time elapsed), decision recommendation, evidence, and next steps.
+- **Format:** Clean, jargon-free report. The Bayesian confidence calculations and threshold registries power the recommendation but are not exposed to the client.
+
+> **Target Customer Validation:** "I don't want to see 'Beta-Binomial model with Beta(1,1) prior.' I want to see: 'Here's what happened. Here's what it means. Here's our recommendation and the evidence behind it.'"
+
+---
+
+## 8. MVP Feature Specifications
+
+### User Stories (Milestone A: Phases 1-3)
+
+#### US-001: Run v2.0 Schema Migration
+
+**As an** SC Operator, **I want** the database schema to be extended with all v2.0 columns and tables, **so that** the application can store Hypothesis Cards, Discovery Summaries, interview records, and supporting metadata without breaking existing experiments.
+
+**Acceptance Criteria:**
+
+- Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 6 new artifact columns are added to `experiments`: `hypothesis_card`, `test_blueprint`, `discovery_summary`, `campaign_package`, `page_config`, `validation_report`
+- Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 4 new supporting columns are added to `experiments`: `venture_id`, `category`, `sequence_position`, `prior_test_ref`
+- Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 1 new column `decision_detail` is added to `decision_memos`
+- Given the current v1.2 schema is deployed, when Migration 0002 is executed, then 4 new tables are created: `interviews`, `ventures`, `threshold_registry`, `venture_benchmarks`
+- Given existing experiments with archetype `interview`, when Migration 0002 runs Step 2, then draft/preflight experiments are migrated to `fake_door` and active experiments are archived
+- Given the migration completes Step 3 (table recreation), when I query for experiments, then the `archetype` CHECK constraint accepts `fake_door` and rejects `interview`
+- Given the migration completes Step 3, when I query for experiments, then the `status` CHECK constraint accepts `discovery` as a valid status
+- Given the migration is complete, when I query `SELECT COUNT(*) FROM experiments WHERE archetype = 'interview'`, then the result is 0
+- Given the migration is complete, when I compare row counts to pre-migration, then the count is preserved (no data loss)
+- Given the migration is complete, when I update any experiment's name, then the `updated_at` trigger fires and updates the timestamp
+- Given all new columns are nullable, when I query existing experiments that lack v2.0 data, then all new columns return NULL and existing behavior is unchanged
+
+**Business Rules:** All new columns are nullable; `interview` archetype replaced by `fake_door`; D1 does not enforce FKs by default; CHECK constraints require create-copy-drop-rename pattern.
+
+---
+
+#### US-002: Write a Hypothesis Card for an Experiment
+
+**As an** SC Operator, **I want** to write a Structured Hypothesis Card to an experiment, **so that** I can capture the venture narrative fields and move the experiment through the validation workflow.
+
+**Acceptance Criteria:**
+
+- Given an experiment exists, when I send `PATCH /experiments/:id` with a valid `hypothesis_card` JSON body, then the `hypothesis_card` column is updated
+- Given a Tier 1 (draft) Hypothesis Card, when I write it, then 6 required Tier 1 fields are present: `customer_segment`, `problem_statement`, `stakes_failure`, `stakes_success`, `solution_hypothesis`, `why_now`
+- Given a Tier 2 (full) Hypothesis Card, when I write it, then 4 additional fields are accepted: `current_alternatives`, `market_sizing`, `competitive_landscape`, `key_assumptions`
+- Given a Hypothesis Card with `confidence` set to `proceed`, `uncertain`, or `abandon`, then the value is accepted
+- Given a Hypothesis Card with an invalid `confidence` value, then the API returns a 400 error
+- Given a Hypothesis Card with `confidence` provided, then `confidence_rationale` must also be provided or the API returns a 400 error
+- Given a Hypothesis Card with `key_assumptions`, then each assumption has `claim`, `evidence`, `risk` (high/medium/low), and `basis` fields; between 3 and 5 assumptions required
+- Given a Hypothesis Card with `one_liner` exceeding 200 characters, then the API returns a 400 error
+
+---
+
+#### US-003: Enforce Distill Brief Write Invariant
+
+**As an** SC Operator, **I want** the legacy Distill Brief fields to be auto-populated from the Hypothesis Card and protected from direct editing, **so that** data remains consistent between the card and the legacy columns.
+
+**Acceptance Criteria:**
+
+- When `hypothesis_card` is non-null, writing to it auto-populates: `target_audience` from `customer_segment`, `problem_statement` from `problem_statement`, `value_proposition` from `solution_hypothesis`, `market_size_estimate` from `market_sizing`
+- When `hypothesis_card` is non-null, direct `PATCH` updates to any of the 4 Distill Brief columns return a 409 Conflict error with message: "Cannot update [field] directly when hypothesis_card is set. Update hypothesis_card instead."
+- When `hypothesis_card` is null, direct updates to Distill Brief columns succeed (backward compatibility)
+- When a Tier 1 card is written and `market_sizing` is null, `market_size_estimate` is set to null via projection
+
+---
+
+#### US-004: Read a Hypothesis Card from an Experiment
+
+**As an** SC Operator, **I want** to retrieve the Hypothesis Card for an experiment, **so that** I can review the structured hypothesis and use it as input for discovery and test selection.
+
+**Acceptance Criteria:**
+
+- `GET /experiments/:id` returns the full `hypothesis_card` JSON object when present, or null when absent
+- Tier 1 cards may have null Tier 2 fields; Tier 2 cards include all 10 fields plus `confidence`, `confidence_rationale`, and `tier`
+
+---
+
+#### US-005: Transition an Experiment to Discovery Status
+
+**As an** SC Operator, **I want** to transition an experiment from `preflight` to `discovery` status, **so that** I can begin recording discovery interviews.
+
+**Acceptance Criteria:**
+
+- `preflight -> discovery` succeeds
+- `draft -> discovery` returns 400 (invalid transition)
+- `discovery -> build` allowed (gate enforcement deferred to Phase 4)
+- `discovery -> archive` allowed (archive always allowed)
+- `preflight -> build` allowed (gate exception path; enforcement deferred to Phase 4)
+- Any transition not in the valid transitions table returns 400
+
+---
+
+#### US-006: Start a Discovery Sprint
+
+**As an** SC Operator, **I want** to initialize a discovery sprint for an experiment, **so that** I can formally begin the discovery process.
+
+**Acceptance Criteria:**
+
+- `POST /experiments/:id/discovery/start` transitions experiment to `discovery` from `preflight`
+- Returns 400 if experiment is in `draft` status
+- Logs `discovery_sprint_started` event to `event_log`
+- Returns 409 if sprint is already active
+
+---
+
+#### US-007: Record a Completed Interview
+
+**As an** SC Operator, **I want** to record a completed interview against an experiment, **so that** the interview data contributes to the Discovery Summary.
+
+**Acceptance Criteria:**
+
+- `POST /experiments/:id/interviews` inserts a row into `interviews` when experiment is in `discovery` status
+- Returns 400 if experiment is not in `discovery` status
+- Validates `mode` (ai/hybrid/human), `protocols_covered` (non-empty array), `pain_scores` (1-5 per dimension, null allowed for insufficient data), `participant_id` (required, non-empty)
+- Logs `interview_completed` event with structured event data
+- Returns auto-generated `id` and `created_at`
+
+---
+
+#### US-008: Retrieve Discovery Summary
+
+**As an** SC Operator, **I want** to retrieve the current Discovery Summary for an experiment, **so that** I can review aggregated interview findings and gate status.
+
+**Acceptance Criteria:**
+
+- `GET /experiments/:id/discovery/summary` returns the full Discovery Summary JSON, including `interview_count`, `weighted_interview_count` (computed from interviews table), and `stage` (draft/final)
+- Returns 404 if no summary exists
+- Mode-weighted count: ai _ 0.5, hybrid _ 0.75, human \* 1.0
+
+---
+
+#### US-009: Write a Discovery Summary
+
+**As an** SC Operator, **I want** to write or update the Discovery Summary, **so that** I can record aggregated interview findings after analysis.
+
+**Acceptance Criteria:**
+
+- `PATCH /experiments/:id` with `discovery_summary` JSON updates the column
+- Required fields: `experiment_id`, `interview_count`, `problem_confirmed`, `pain_severity`, `gate_status`, `stage`
+- Pain severity dimensions must be between 1.0 and 5.0; composite requires all 3 dimensions
+- Top quotes capped at 10 items
+- Rejects updates to a summary with `stage: final`
+
+---
+
+#### US-010: Finalize a Discovery Summary
+
+**As an** SC Operator, **I want** to lock a Discovery Summary to "final" stage, **so that** it becomes immutable input for test design.
+
+**Acceptance Criteria:**
+
+- `POST /experiments/:id/discovery/finalize` sets `stage` to `final`
+- Returns 400 if already finalized or no summary exists
+- Subsequent PATCH updates to `discovery_summary` are rejected
+- Logs `discovery_summary_finalized` event
+
+---
+
+#### US-011: Evaluate the Discovery Gate
+
+**As an** SC Operator, **I want** to evaluate the Discovery Gate, **so that** I can determine whether the experiment meets minimum discovery criteria.
+
+**Acceptance Criteria:**
+
+- `GET /experiments/:id/discovery/gate` evaluates 6 checks:
+  1. **Minimum interviews:** Weighted count >= 5.0 (computed from interviews table)
+  2. **Pain severity:** Composite >= 3.0
+  3. **Peak dimension:** Any single dimension >= 4.0
+  4. **Problem confirmed:** `discovery_summary.problem_confirmed` is true
+  5. **Assumption evidence:** At least 1 assumption updated with evidence
+  6. **Saturation:** `discovery_summary.saturation_reached` is true
+- Checks 1, 4, and 5 are required. Checks 2 and 3 are OR'd. Check 6 is recommended but not blocking.
+- Returns 400 if no discovery summary exists
+- Logs `discovery_gate_evaluated` event
+- Gate is advisory only in Phase 3; enforcement added in Phase 4
+
+---
+
+#### US-012: Query Interviews for an Experiment
+
+**As an** SC Operator, **I want** to list all interviews recorded for an experiment.
+
+**Acceptance Criteria:**
+
+- Returns array of interview records ordered by `created_at` ascending
+- Empty array for experiments with no interviews
+- Each record includes all interview fields
+
+---
+
+#### US-013: Log Discovery Events to Event Log
+
+**As an** SC Operator, **I want** discovery activities automatically logged for audit trail.
+
+**Acceptance Criteria:**
+
+- `discovery_sprint_started`, `interview_completed`, `interview_analyzed`, `discovery_summary_finalized`, `discovery_gate_evaluated` events logged with structured event data
+- Events include experiment_id, correct timestamps, and relevant metadata
+
+---
+
+### Business Rules Summary
+
+| ID     | Rule                                                                                                                                                                                                      |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BR-001 | All new v2.0 columns are nullable. Existing experiments unchanged.                                                                                                                                        |
+| BR-002 | Archetype `interview` replaced by `fake_door`. Migration converts or archives existing records.                                                                                                           |
+| BR-003 | `venture_id` is advisory, not enforced as FK until Phase 5.                                                                                                                                               |
+| BR-004 | CHECK constraint changes require create-copy-drop-rename migration pattern.                                                                                                                               |
+| BR-005 | Hypothesis Card has two tiers: Draft (6 fields) and Full (10 fields).                                                                                                                                     |
+| BR-006 | Confidence enum: `proceed`, `uncertain`, `abandon` with required `confidence_rationale`.                                                                                                                  |
+| BR-007 | `key_assumptions`: 3-5 items, each with claim, evidence, risk, basis.                                                                                                                                     |
+| BR-008 | `one_liner` max 200 characters.                                                                                                                                                                           |
+| BR-009 | When `hypothesis_card` is non-null, Distill Brief columns are read-only projections.                                                                                                                      |
+| BR-010 | Projection mapping: `target_audience` from `customer_segment`, `problem_statement` from `problem_statement`, `value_proposition` from `solution_hypothesis`, `market_size_estimate` from `market_sizing`. |
+| BR-011 | Status lifecycle: `draft -> preflight -> discovery -> build -> launch -> run -> decide -> archive`.                                                                                                       |
+| BR-012 | Valid transitions include rollbacks and archive-from-anywhere.                                                                                                                                            |
+| BR-013 | Phase 3: `discovery` status without gate enforcement. Phase 4: gate enforcement on `-> build`.                                                                                                            |
+| BR-014 | Discovery sprint start requires `preflight` or `discovery` status.                                                                                                                                        |
+| BR-015 | Interview `mode`: `ai`, `hybrid`, `human` (DB CHECK constraint).                                                                                                                                          |
+| BR-016 | Each interview linked to exactly one experiment.                                                                                                                                                          |
+| BR-017 | Valid protocols: `problem_discovery`, `solution_fit`, `willingness_to_pay`, `icp_validation`.                                                                                                             |
+| BR-018 | Pain scores: functional, emotional, opportunity; each 1-5.                                                                                                                                                |
+| BR-019 | Discovery Summary stages: `draft` (mutable) and `final` (immutable).                                                                                                                                      |
+| BR-020 | Composite pain score: unweighted average of 3 dimensions, rounded to 1 decimal.                                                                                                                           |
+| BR-021 | Top quotes capped at 10 items.                                                                                                                                                                            |
+| BR-022 | Finalized summaries are immutable.                                                                                                                                                                        |
+| BR-023 | Finalization logs event with interview_count, weighted_count, gate_passed.                                                                                                                                |
+| BR-024 | Mode-weighted counting: ai=0.5x, hybrid=0.75x, human=1.0x.                                                                                                                                                |
+| BR-025 | Minimum weighted interview count threshold: 5.0.                                                                                                                                                          |
+| BR-026 | Pain threshold: composite >= 3.0 OR any peak dimension >= 4.0 (OR logic).                                                                                                                                 |
+| BR-027 | Required gate checks: #1 (interviews), #4 (problem confirmed), #5 (assumption evidence).                                                                                                                  |
+| BR-028 | Peak dimension rule: any dimension >= 4.0 meets pain threshold regardless of composite.                                                                                                                   |
+| BR-029 | All discovery activities logged to `event_log`.                                                                                                                                                           |
+
+### Edge Cases
+
+| ID     | Description                                      | Resolution                                                                                                                                            |
+| ------ | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| EC-001 | Migration with no `interview` experiments        | UPDATE affects zero rows; migration proceeds. Verification returns 0 as expected.                                                                     |
+| EC-002 | Hypothesis Card without Discovery Summary        | Normal flow. Gate endpoint returns clear error.                                                                                                       |
+| EC-003 | Discovery Summary without Hypothesis Card        | Accepted (backward compatibility). `hypothesis_card_version` set by client.                                                                           |
+| EC-004 | Concurrent writes to Discovery Summary           | Last-write-wins (D1 default). Acceptable for single-operator MVP.                                                                                     |
+| EC-005 | Pain score with insufficient data in a dimension | Dimension set to null. Composite requires all 3 dimensions; null dimension = null composite. Peak dimension check only evaluates non-null dimensions. |
+| EC-006 | Finalized summary with status rollback           | Summary remains attached but may be stale. Addressed in Phase 4.                                                                                      |
+| EC-007 | Interview recorded for archived experiment       | 400 error. Historical interviews retained.                                                                                                            |
+| EC-008 | Gate evaluation with zero interviews             | All checks fail. `passed: false`.                                                                                                                     |
+| EC-009 | Tier 1 card clears `market_size_estimate`        | Projection from null `market_sizing` overwrites existing value with null.                                                                             |
+| EC-010 | Migration drops triggers and indexes             | Step 3 explicitly recreates them. Verified in Step 4.                                                                                                 |
+| EC-011 | All-AI interviews                                | 10 AI interviews needed to reach 5.0 weighted count. By design.                                                                                       |
+| EC-012 | Empty `assumption_updates`                       | Gate check #5 fails. At least 1 update with evidence required.                                                                                        |
+
+---
+
+## 9. Information Architecture
+
+### Screen Inventory
+
+#### Public Marketing Site (siliconcrane.com)
+
+| Screen      | Path        | Status                        | Key Content                                                                         |
+| ----------- | ----------- | ----------------------------- | ----------------------------------------------------------------------------------- |
+| Homepage    | `/`         | Exists                        | Hero, problem statement, services grid, "Why SC" proof points, contact form, footer |
+| Services    | `/services` | Exists (needs Tier 1 pricing) | Sprint type breakdown, per-sprint details, founding client offer, CTA to intake     |
+| About       | `/about`    | Exists                        | Company background, methodology overview, team                                      |
+| Case Study  | TBD         | Does not exist (Tier 2)       | DFG case study: hypothesis, test, data, decision, current state                     |
+| Intake Form | TBD         | Does not exist (Tier 1)       | Structured form: idea, stage, budget, timeline, contact info                        |
+
+#### Experiment Landing Pages (siliconcrane.com/e/[slug])
+
+| Screen       | Path                  | Status                   | Key Content                                                  |
+| ------------ | --------------------- | ------------------------ | ------------------------------------------------------------ |
+| Landing Page | `/e/[slug]`           | Exists (single template) | Headline, subheadline, value props, lead form or payment CTA |
+| Thank You    | `/e/[slug]/thank-you` | Exists                   | Confirmation, "what happens next"                            |
+| Payment      | `/e/[slug]/payment`   | Exists                   | Stripe Checkout redirect                                     |
+
+#### Admin Interface
+
+| Screen     | Path     | Status                        | Key Content                                                                          |
+| ---------- | -------- | ----------------------------- | ------------------------------------------------------------------------------------ |
+| Coda Admin | External | Phase 1 (tech spec Section 9) | Experiment list, status controls, metrics import, lead list, decision/learning memos |
+
+### Navigation Structure
+
+**Primary navigation** (marketing pages): Homepage, Services, About, Case Study (Tier 2), Contact.
+
+**Landing page navigation:** None. Experiment landing pages are standalone with no site navigation, no header links, no distractions. This is intentional: landing pages minimize exit paths to maximize conversion signal quality. The only navigation is the form CTA and the post-submission thank-you page.
+
+**Footer navigation:** Privacy Policy, Venture Crane.
+
+---
+
+## 10. Architecture & Technical Design
+
+### System Boundaries
+
+```
+                           siliconcrane.com
+                         (Cloudflare Pages)
+  +------------------------------------------------------+
+  |                                                      |
+  |  Static SSG Pages    SSR Landing Pages    Lead Forms |
+  |  (marketing)         [slug].astro         (HTML+JS)  |
+  |                                                      |
+  +----------------------+-------------------------------+
+                         | HTTPS (public + internal)
+                         v
+  +------------------------------------------------------+
+  |                     sc-api                           |
+  |               (Cloudflare Worker / Hono)             |
+  |                                                      |
+  |  Public:             Internal (X-SC-Key):            |
+  |  POST /leads         GET/POST/PATCH /experiments     |
+  |  POST /events        GET /experiments/:id/leads      |
+  |  POST /contact       POST /metrics                   |
+  |  GET /exp/by-slug/*  */decision_memos                |
+  |  POST /pay/webhook   */learning_memos                |
+  |                                                      |
+  |  v2.0 MVP additions (Phase 3):                       |
+  |  POST /experiments/:id/discovery/start               |
+  |  POST /experiments/:id/interviews                    |
+  |  GET  /experiments/:id/discovery/summary             |
+  |  POST /experiments/:id/discovery/finalize            |
+  |  GET  /experiments/:id/discovery/gate                |
+  |                                                      |
+  +-------+------------------+---------------------------+
+          |                  |
+          v                  v
+    +----------+       +----------+
+    |  sc-db   |       | sc-assets|
+    |   (D1)   |       |   (R2)   |
+    +----------+       +----------+
+
+  +------------------------------------------------------+
+  |                sc-maintenance                        |
+  |          (Cloudflare Worker, cron 2AM UTC)           |
+  |  - event_log.user_agent 90-day purge (existing)     |
+  +------------------------------------------------------+
+```
+
+### Technology Stack
+
+| Layer          | Technology                 | Responsibility                              |
+| -------------- | -------------------------- | ------------------------------------------- |
+| Frontend       | Astro 5 SSR + Tailwind CSS | Landing pages, lead forms, marketing        |
+| API            | Cloudflare Worker (Hono)   | All business logic, validation, persistence |
+| Database       | Cloudflare D1 (SQLite)     | Structured data, schema enforcement         |
+| Object Storage | Cloudflare R2              | Creative assets, interview transcripts      |
+| Scheduled Jobs | sc-maintenance Worker      | Data retention, PII anonymization           |
+
+### Key Design Decisions
+
+**Decision 1: All v2.0 artifact columns are TEXT (JSON), nullable.**
+D1/SQLite does not support native JSON columns. Storing JSON as TEXT with application-layer validation follows the established v1.2 pattern (`copy_pack`, `creative_brief`, `kill_criteria`). Nullable columns ensure zero-downtime migration.
+
+**Decision 2: Write invariant pattern over column deprecation.**
+The Distill Brief columns are not dropped. When `hypothesis_card` is non-null, those 4 columns become read-only projections. This preserves backward compatibility with the existing Coda admin pack and any scripts that read Distill Brief fields directly.
+
+**Decision 3: CHECK constraint migration via create-copy-drop-rename.**
+SQLite/D1 cannot ALTER CHECK constraints. The `archetype` and `status` constraint changes require recreating the `experiments` table. This is the only supported approach in D1.
+
+**Decision 4: No Cloudflare Queue in MVP.**
+Campaign generation (Phase 5) and threshold recalculation (Phase 7) require Cloudflare Queue. These are explicitly out of MVP scope.
+
+**Decision 5: `interviews` table uses R2 for transcript storage.**
+Interview transcripts contain PII and can be large. The `transcript_ref` column stores an R2 key, not the transcript body.
+
+---
+
+## 11. Proposed Data Model
+
+### New Columns on `experiments` Table
+
+All new columns are TEXT (JSON) and nullable, added via D1 ALTER TABLE migration.
+
+**Artifact Columns:**
+
+| Column              | Type        | Source | Description                                                                     |
+| ------------------- | ----------- | ------ | ------------------------------------------------------------------------------- |
+| `hypothesis_card`   | TEXT (JSON) | DD#1   | Structured Hypothesis Card: 10 fields, confidence score, one-liner              |
+| `test_blueprint`    | TEXT (JSON) | DD#2   | Test Blueprint: archetype, metrics/thresholds, kill criteria, decision criteria |
+| `discovery_summary` | TEXT (JSON) | DD#3   | Discovery Summary: pain severity, interview data, gate status                   |
+| `campaign_package`  | TEXT (JSON) | DD#4   | Campaign Package: copy, creative, targeting, budget, variants                   |
+| `page_config`       | TEXT (JSON) | DD#5   | Landing page config overrides per archetype                                     |
+| `validation_report` | TEXT (JSON) | DD#6   | Validation Report: metrics, evidence, confidence, verdict                       |
+
+**Supporting Columns:**
+
+| Column              | Type    | Description                                                         |
+| ------------------- | ------- | ------------------------------------------------------------------- |
+| `venture_id`        | TEXT    | FK to `ventures` table (advisory, not enforced until Phase 5)       |
+| `category`          | TEXT    | CHECK: `demand_signal`, `willingness_to_pay`, `solution_validation` |
+| `sequence_position` | INTEGER | Validation Ladder rung number (1-based)                             |
+| `prior_test_ref`    | TEXT    | Self-reference to `experiments.id` for sequential tests             |
+
+### New Column on `decision_memos` Table
+
+```sql
+ALTER TABLE decision_memos ADD COLUMN decision_detail TEXT;
+```
+
+### New Table: `interviews`
+
+```sql
+CREATE TABLE IF NOT EXISTS interviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  experiment_id TEXT NOT NULL REFERENCES experiments(id),
+  participant_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK(mode IN ('ai', 'hybrid', 'human')),
+  protocols_covered TEXT NOT NULL,
+  duration_minutes INTEGER,
+  pain_scores TEXT,
+  signal_extraction TEXT,
+  transcript_ref TEXT,
+  new_themes_detected INTEGER DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX idx_interviews_experiment ON interviews(experiment_id);
+```
+
+### New Table: `ventures`
+
+```sql
+CREATE TABLE IF NOT EXISTS ventures (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  brand_profile TEXT,
+  brand_profile_version INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE TRIGGER update_ventures_timestamp
+AFTER UPDATE ON ventures
+BEGIN
+  UPDATE ventures SET updated_at = (strftime('%s', 'now') * 1000)
+  WHERE id = NEW.id;
+END;
+```
+
+Created in Phase 1 but CRUD API deferred to Phase 5.
+
+### New Table: `threshold_registry`
+
+```sql
+CREATE TABLE IF NOT EXISTS threshold_registry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  phase INTEGER NOT NULL CHECK(phase IN (1, 2, 3)),
+  go_threshold INTEGER NOT NULL,
+  kill_threshold INTEGER NOT NULL,
+  metric TEXT NOT NULL,
+  sample_count INTEGER NOT NULL,
+  percentile_25 INTEGER,
+  percentile_75 INTEGER,
+  mean_value INTEGER,
+  std_dev INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  effective_from TEXT NOT NULL,
+  superseded_at TEXT,
+  calculation_notes TEXT,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX idx_threshold_archetype ON threshold_registry(archetype);
+CREATE INDEX idx_threshold_phase ON threshold_registry(phase);
+```
+
+Created in Phase 1 but not populated until Phase 7.
+
+### New Table: `venture_benchmarks`
+
+```sql
+CREATE TABLE IF NOT EXISTS venture_benchmarks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  industry TEXT,
+  price_range TEXT,
+  channel TEXT,
+  test_count INTEGER NOT NULL,
+  mean_cvr_bp INTEGER,
+  median_cvr_bp INTEGER,
+  p25_cvr_bp INTEGER,
+  p75_cvr_bp INTEGER,
+  std_dev_cvr_bp INTEGER,
+  mean_cpl_cents INTEGER,
+  median_cpl_cents INTEGER,
+  go_rate_pct INTEGER,
+  kill_rate_pct INTEGER,
+  pivot_rate_pct INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  last_updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  calculation_notes TEXT
+);
+
+CREATE INDEX idx_benchmarks_archetype ON venture_benchmarks(archetype);
+CREATE INDEX idx_benchmarks_industry ON venture_benchmarks(industry);
+```
+
+Created in Phase 1 but not populated until Phase 7.
+
+### CHECK Constraint Recreation
+
+The `experiments` table must be recreated via create-copy-drop-rename to update constraints:
+
+**archetype:** `CHECK(archetype IN ('fake_door','waitlist','content_magnet','priced_waitlist','presale','concierge','service_pilot'))`
+
+**status:** `CHECK(status IN ('draft','preflight','discovery','build','launch','run','decide','archive'))`
+
+**category:** `CHECK(category IS NULL OR category IN ('demand_signal','willingness_to_pay','solution_validation'))`
+
+Data migration runs before table recreation: draft/preflight `interview` experiments become `fake_door`; active `interview` experiments are archived.
+
+### Status Transition Map v2.0
+
+```
+draft --> preflight --> discovery --> build --> launch --> run --> decide --> archive
+                    \                 ^
+                     \-> build ------/  (requires discovery_gate_exception in Phase 4)
+```
+
+| From      | To        | Condition                                                             |
+| --------- | --------- | --------------------------------------------------------------------- |
+| draft     | preflight | None                                                                  |
+| draft     | archive   | None                                                                  |
+| preflight | discovery | None                                                                  |
+| preflight | build     | Phase 4: requires `discovery_gate_exception`. Phase 3: unconditional. |
+| preflight | draft     | None (rollback)                                                       |
+| preflight | archive   | None                                                                  |
+| discovery | build     | Phase 4: requires gate pass. Phase 3: unconditional.                  |
+| discovery | archive   | None                                                                  |
+| build     | launch    | None                                                                  |
+| build     | preflight | None (rollback)                                                       |
+| build     | archive   | None                                                                  |
+| launch    | run       | None                                                                  |
+| launch    | archive   | None                                                                  |
+| run       | decide    | None                                                                  |
+| run       | archive   | None                                                                  |
+| decide    | archive   | None                                                                  |
+
+### Distill Brief Write Invariant
+
+When `hypothesis_card` is non-null:
+
+| Distill Brief Column   | Projected From                        | Behavior             |
+| ---------------------- | ------------------------------------- | -------------------- |
+| `target_audience`      | `hypothesis_card.customer_segment`    | Read-only projection |
+| `problem_statement`    | `hypothesis_card.problem_statement`   | Read-only projection |
+| `value_proposition`    | `hypothesis_card.solution_hypothesis` | Read-only projection |
+| `market_size_estimate` | `hypothesis_card.market_sizing`       | Read-only projection |
+
+Direct updates return `409 Conflict` with error code `WRITE_INVARIANT_VIOLATION`.
+
+---
+
+## 12. API Surface
+
+All endpoints use the established v1.2 patterns: Hono router, JSON request/response, `X-Request-Id` header on all responses, consistent `ErrorResponse` / `SuccessResponse` shapes.
+
+### Modified Endpoints (MVP)
+
+#### POST /experiments
+
+- Validate archetype against v2.0 enum: `fake_door | waitlist | content_magnet | priced_waitlist | presale | concierge | service_pilot`
+- Accept optional `hypothesis_card`; auto-extract Distill Brief projections when provided
+- Error codes: `INVALID_REQUEST` (400), `DUPLICATE_SLUG` (409)
+
+#### PATCH /experiments/:id
+
+- New updatable fields: `hypothesis_card`, `test_blueprint`, `discovery_summary`, `campaign_package`, `page_config`, `validation_report`, `venture_id`, `category`, `sequence_position`, `prior_test_ref`
+- Enforce Distill Brief write invariant
+- Add `discovery` to valid status transitions
+- Error codes: `INVALID_STATUS_TRANSITION` (400), `EXPERIMENT_NOT_FOUND` (404), `WRITE_INVARIANT_VIOLATION` (409)
+
+#### GET /experiments/by-slug/:slug (Public)
+
+- Include `page_config` in sanitized response when non-null
+- `hypothesis_card`, `discovery_summary`, `test_blueprint`, `campaign_package`, `validation_report` are NOT included (internal artifacts)
+
+### New Discovery Endpoints (Phase 3)
+
+| Method | Path                                  | Auth     | Description                                            |
+| ------ | ------------------------------------- | -------- | ------------------------------------------------------ |
+| POST   | `/experiments/:id/discovery/start`    | X-SC-Key | Initialize discovery sprint; transition to `discovery` |
+| POST   | `/experiments/:id/interviews`         | X-SC-Key | Record completed interview                             |
+| GET    | `/experiments/:id/discovery/summary`  | X-SC-Key | Retrieve Discovery Summary with weighted counts        |
+| POST   | `/experiments/:id/discovery/finalize` | X-SC-Key | Lock summary to `final` stage                          |
+| GET    | `/experiments/:id/discovery/gate`     | X-SC-Key | Evaluate 6 gate checks (advisory, not enforcing)       |
+
+All new endpoints are internal (require `X-SC-Key`). No new public endpoints in MVP.
+
+### API Response Patterns
+
+**Discovery Start:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "experiment_id": "SC-2026-001",
+    "status": "discovery",
+    "discovery_summary": null
+  }
+}
+```
+
+**Interview Creation (201):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "experiment_id": "SC-2026-001",
+    "participant_id": "P-001",
+    "mode": "human",
+    "protocols_covered": ["problem_discovery", "solution_fit"],
+    "pain_scores": { "functional": 8, "emotional": 6, "opportunity": 7 },
+    "new_themes_detected": 2,
+    "created_at": 1740000000000
+  }
+}
+```
+
+**Gate Evaluation:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "experiment_id": "SC-2026-001",
+    "gate_status": "pass",
+    "checks": [
+      {
+        "name": "minimum_interviews",
+        "status": "pass",
+        "detail": "5 weighted interviews (threshold: 3)"
+      },
+      { "name": "pain_severity", "status": "pass", "detail": "Mean pain score 7.2 (threshold: 5)" },
+      { "name": "peak_dimension", "status": "pass", "detail": "Functional pain is peak at 8.1" },
+      {
+        "name": "problem_confirmed",
+        "status": "pass",
+        "detail": "4/5 participants confirmed core problem"
+      },
+      {
+        "name": "assumption_evidence",
+        "status": "fail",
+        "detail": "2 key assumptions lack evidence"
+      },
+      {
+        "name": "saturation",
+        "status": "pass",
+        "detail": "3 consecutive interviews with 0 new themes"
+      }
+    ],
+    "recommendation": "fail -- 1 check did not pass"
+  }
+}
+```
+
+**Write Invariant Violation (409):**
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "WRITE_INVARIANT_VIOLATION",
+    "message": "Cannot update problem_statement directly when hypothesis_card is set. Update hypothesis_card instead.",
+    "request_id": "req_..."
+  }
+}
+```
+
+---
+
+## 13. Non-Functional Requirements
+
+### Performance Budgets
+
+| Metric                          | Target  | Measurement                 |
+| ------------------------------- | ------- | --------------------------- |
+| API response time (p50)         | < 50ms  | Cloudflare Worker analytics |
+| API response time (p99)         | < 200ms | Cloudflare Worker analytics |
+| D1 query time (single row)      | < 10ms  | D1 analytics dashboard      |
+| D1 query time (list, paginated) | < 30ms  | D1 analytics dashboard      |
+| Discovery gate evaluation       | < 100ms | Application-level timing    |
+| Migration 0002 execution time   | < 30s   | Manual timing               |
+| Landing page TTFB               | < 200ms | Cloudflare Speed analytics  |
+| Landing page LCP                | < 2.5s  | Core Web Vitals             |
+
+### Data Size Budgets
+
+| Column                         | Max Payload Size | Enforcement                       |
+| ------------------------------ | ---------------- | --------------------------------- |
+| `hypothesis_card`              | 50 KB            | Application-layer JSON size check |
+| `discovery_summary`            | 100 KB           | Application-layer JSON size check |
+| `test_blueprint`               | 50 KB            | Application-layer JSON size check |
+| `campaign_package`             | 200 KB           | Application-layer JSON size check |
+| `page_config`                  | 100 KB           | Application-layer JSON size check |
+| `validation_report`            | 200 KB           | Application-layer JSON size check |
+| `interviews.signal_extraction` | 50 KB            | Application-layer JSON size check |
+
+D1 has a 1 MB row size limit. Worst case with all JSON columns populated: ~750 KB per experiment row.
+
+### Security Requirements
+
+| Requirement                            | Implementation                                            | Status   |
+| -------------------------------------- | --------------------------------------------------------- | -------- |
+| All new endpoints behind X-SC-Key auth | Auth middleware allowlist (no additions to PUBLIC_ROUTES) | MVP      |
+| Parameterized queries only             | `.bind()` on all D1 queries                               | MVP      |
+| No PII in JSON artifact columns        | `participant_id` uses pseudonyms                          | MVP      |
+| Interview transcript PII retention     | R2 objects, 90-day TTL                                    | MVP      |
+| JSON payload validation                | Validate structure before INSERT/UPDATE                   | MVP      |
+| No secrets in experiment data          | Stripe keys, API keys never in experiment columns         | Existing |
+| CORS unchanged                         | Only `siliconcrane.com` in production                     | Existing |
+
+### Scalability Targets (MVP)
+
+| Metric                    | Target   | Rationale                      |
+| ------------------------- | -------- | ------------------------------ |
+| Concurrent experiments    | 50       | Far exceeds near-term need     |
+| Interviews per experiment | 100      | Discovery typically needs 5-20 |
+| Events per day            | 10,000   | Covers moderate ad traffic     |
+| D1 database size          | < 500 MB | Within D1 free tier (5 GB)     |
+| R2 storage                | < 1 GB   | Transcripts + creative assets  |
+
+### Reliability
+
+| Requirement         | Target                                 |
+| ------------------- | -------------------------------------- |
+| Worker uptime       | 99.9% (Cloudflare SLA)                 |
+| Migration rollback  | Manual restore from D1 backup snapshot |
+| Data loss tolerance | Zero                                   |
+
+---
+
+## 14. Platform-Specific Design Constraints
+
+### Primary Platform: Mobile Web
+
+Landing pages receive traffic primarily from paid social ads (Facebook, Instagram, TikTok, LinkedIn) where the majority of users are on mobile devices.
+
+**Constraints:**
+
+1. **Viewport:** All landing page content must be legible and interactive at 320px minimum width.
+2. **Touch targets:** All interactive elements must meet 44x44px minimum (Apple HIG / WCAG 2.5.5). Form inputs at `py-2` may fall below minimum -- audit required.
+3. **Form input sizing:** All form inputs must use `text-base` (16px) or larger to prevent iOS Safari auto-zoom.
+4. **Scroll performance:** `scroll_depth` event listener must use `{ passive: true }`.
+5. **Connection reliability:** `navigator.sendBeacon` for event tracking (survives page navigation). Form submissions via `fetch` with appropriate error messaging.
+6. **Page weight:** Landing pages must load within 3 seconds on 3G. Astro's zero-JS-by-default architecture helps. Only client-side JS: form handling, signal capture, A/B variant assignment.
+7. **Above the fold:** On mobile (375x667px), headline, subheadline, and primary CTA must be visible without scrolling. For `fake_door`, the entire conversion path (headline + email field + submit button) should be above the fold.
+
+### Secondary Platform: Desktop Web
+
+- Two-column layouts via `md:` Tailwind breakpoints where appropriate
+- Maximum content width: `max-w-2xl` (current) appropriate for readability; consider `max-w-3xl` or `max-w-4xl` for pages with more sections
+- Desktop users more likely to read long-form content; prioritize scannable formatting
+
+### Accessibility (WCAG 2.1 Level AA)
+
+| Requirement         | Standard                                                   | Current Status                                            |
+| ------------------- | ---------------------------------------------------------- | --------------------------------------------------------- |
+| Color contrast      | 4.5:1 normal text, 3:1 large text                          | Passes (verified)                                         |
+| Keyboard navigation | All elements reachable via Tab/Enter/Escape                | Standard HTML forms -- passes                             |
+| Form labels         | `<label>` with `for`/`id`, `required` attribute            | Correct                                                   |
+| Semantic HTML       | One `<h1>`, proper hierarchy                               | Correct                                                   |
+| Alt text            | Meaningful alt on images, `aria-hidden` on decorative SVGs | Needs fix: decorative SVG icons lack `aria-hidden="true"` |
+| Screen reader       | `aria-live="polite"` on form messages                      | Needs fix: `#form-message` lacks `aria-live`              |
+| Motion              | Respect `prefers-reduced-motion`                           | Implement with A/B variant transitions (Phase 6)          |
+| Touch targets       | 44x44px minimum                                            | Submit button passes; form inputs need audit              |
+
+**Immediate accessibility fixes (next PR touching templates):**
+
+- Add `aria-hidden="true"` to decorative SVG checkmark icons
+- Add `aria-live="polite"` to `#form-message` div
+- Add `aria-busy="true"` and `aria-label="Submitting, please wait"` to submit button during loading
+
+---
+
+## 15. Success Metrics & Kill Criteria
+
+### MVP Success Metrics (Phase 0 / Tier 1)
+
+The MVP goal: **accept first paying client.**
+
+| Metric                          | Target                      | Measurement             | Timeline                      |
+| ------------------------------- | --------------------------- | ----------------------- | ----------------------------- |
+| First paying client acquired    | 1 client                    | Stripe payment received | Within 4 weeks of site launch |
+| Intake form submissions         | >= 5                        | Tally/Typeform count    | Within 4 weeks of site launch |
+| Warm network outreach completed | 20 contacts reached         | Manual tracking         | Week 1 post-launch            |
+| Services page live with pricing | Deployed                    | URL reachable           | End of Tier 1 sprint          |
+| Payment mechanism functional    | Working                     | Test transaction        | End of Tier 1 sprint          |
+| Contract/SOW template complete  | Signed template exists      | Document review         | End of Tier 1 sprint          |
+| DFG case study drafted          | Published with real metrics | Content review          | End of Tier 1 sprint          |
+
+### Platform Success Metrics (v2.0-alpha / Milestone A)
+
+| Metric                                   | Target                                 | Measurement                         |
+| ---------------------------------------- | -------------------------------------- | ----------------------------------- |
+| Experiments progressed through lifecycle | >= 1 reaches `run`                     | D1 query                            |
+| Hypothesis Cards populated               | 100% of new experiments                | `WHERE hypothesis_card IS NOT NULL` |
+| Discovery interviews recorded            | >= 3 per experiment entering discovery | `interviews` count                  |
+| Landing pages rendering per archetype    | All 7 render correctly                 | Manual QA                           |
+| Signal capture operational               | `event_log` receiving events           | D1 query                            |
+| Leads captured                           | >= 1 per launched experiment           | `leads` count                       |
+
+### Kill Criteria for the SC Venture
+
+| Kill Criterion                              | Threshold                                      | Evaluation Point        |
+| ------------------------------------------- | ---------------------------------------------- | ----------------------- |
+| Zero paying clients after warm outreach     | 0 conversions from 20 contacts                 | 6 weeks post-launch     |
+| Zero qualified leads from intake            | 0 qualified from 10+ submissions               | 8 weeks post-launch     |
+| Founding rate generates zero interest       | 0 expressions of interest                      | 6 weeks post-launch     |
+| Capacity conflict kills delivery quality    | Missed client deadlines more than once         | First client engagement |
+| Sprint delivery takes 2x estimated duration | Preflight > 10 days, Build-to-Launch > 20 days | First 2 engagements     |
+
+---
+
+## 16. Risks & Mitigations
+
+### Business Risks
+
+| Risk                                                                                              | Likelihood | Impact | Mitigation                                                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pricing not validated.** All sprint prices are TBD. Founding rate of $2,500 is a guess.         | High       | High   | Lock pricing before launch. Start with founding rate for first 3-5 clients. Use those engagements to calibrate real pricing. Do not launch without specific numbers.        |
+| **Capacity conflict with DFG.** If DFG needs urgent work AND a client needs attention, what wins? | High       | High   | Define priority arbitration rules before first client. Recommendation: client-facing deadlines always win. Limit to 1 concurrent engagement until DFG reaches steady state. |
+| **No case study at launch.** DFG case study may not have compelling metrics.                      | Medium     | Medium | Ship it even if modest. Frame as "Experiment #1" with transparency. Honesty about methodology is more compelling than inflated numbers.                                     |
+| **Market positioning confusion.** Prospects confuse SC with agencies, accelerators, consultants.  | Medium     | Medium | Bake "What SC Is Not" into services page, FAQ, outreach. Lead with: "We use kill criteria, you get evidence."                                                               |
+| **Single-operator dependency.** One-person operation with no redundancy.                          | High       | High   | Accept for MVP. Do not oversell capacity. Limit to 1 concurrent engagement until process is proven.                                                                         |
+
+### Technical Risks
+
+| Risk                                                                                                                                  | Severity | Likelihood | Mitigation                                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Table recreation loses data during Migration 0002.** Create-copy-drop-rename could fail mid-execution.                              | Critical | Low        | Run on local D1 first. Backup before remote. Verify row counts. D1 batch execution provides rollback on partial failure.                              |
+| **Existing `interview` archetype experiments in active states get archived.** Could interrupt live experiments.                       | High     | Low        | Query production for active `interview` experiments BEFORE migration. Coordinate with stakeholder if any exist in `launch` or `run`.                  |
+| **JSON schema drift.** Hypothesis Card schema evolves but old records have stale versions.                                            | Medium   | Medium     | Include `version` field in all JSON schemas. Application code handles version migration on read.                                                      |
+| **D1 row size limit (1 MB).** All JSON columns populated could approach limit.                                                        | Medium   | Low        | Enforce per-column size budgets. Log warnings at 80% threshold. Long term: move large payloads to R2.                                                 |
+| **Mode-weighted counting produces non-intuitive results.** 6 AI interviews = 3.0 weighted, which may not represent genuine discovery. | Medium   | Medium     | Gate response includes both raw and weighted counts. Documentation clarifies AI-only is acceptable but lower confidence.                              |
+| **Trigger cascade on table recreation.** Dropping `experiments` drops the trigger.                                                    | High     | Low        | Migration Step 3 includes trigger recreation. Verify in Step 4: `SELECT name FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'experiments'`. |
+| **FK references break during recreation.** If `PRAGMA foreign_keys` is ON, dropping experiments would fail.                           | Medium   | Very Low   | Verify `PRAGMA foreign_keys` returns 0 before migration.                                                                                              |
+
+### Execution Risks
+
+| Risk                                                                                                                  | Likelihood | Impact | Mitigation                                                                                                                                            |
+| --------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **7-phase plan is too long.** Real value delivery delayed to late phases.                                             | High       | High   | Milestone A (Phases 1-3) is the checkpoint. If > 4 weeks, re-evaluate Phases 4-7. Phase 1 enables manual workflows even without UI.                   |
+| **Scope creep from 61 recommendations.** Temptation to implement everything in each phase.                            | High       | Medium | Each phase has explicit boundaries. Feature in one phase, not "partially." Discover additional work mid-task -- finish current scope, file new issue. |
+| **Console engineering is premature infrastructure.** Building $100K+ of tooling to support a service at zero clients. | Medium     | Medium | Phase 0 validates the service with manual processes. Console automation only proceeds after first paying client proves market demand.                 |
+
+---
+
+## 17. Open Decisions / ADRs
+
+### ADR-001: Sprint Pricing
+
+- **Status:** OPEN
+- **Decision needed:** Specific dollar amounts for each sprint type
+- **Deadline:** Before first outreach
+- **Options:** (a) Fixed per-sprint, (b) Time-and-materials with cap, (c) Value-based
+- **Recommendation:** Fixed per-sprint pricing for simplicity. Founding rate of $2,500 for any sprint type for first 3-5 clients. Consider packaging sprints as a bundle rather than forcing the client to choose.
+
+> **Target Customer Validation:** "I don't want to choose between Preflight, Build-to-Launch, and Run + Decide. I want to say 'here's my idea, tell me if it's worth building' and have someone tell me which sprints I need. Package it for me. I'll pay more for simplicity."
+
+### ADR-002: Capacity and Priority Arbitration
+
+- **Status:** OPEN
+- **Decision needed:** How many engagements can run in parallel with DFG work?
+- **Deadline:** Before signing first client contract
+- **Recommendation:** Client-facing deadlines always win. Cap at 1 concurrent engagement until DFG reaches steady state.
+
+### ADR-003: Client Tooling Access
+
+- **Status:** OPEN
+- **Decision needed:** Do clients see the factory? (Option A: Transparent, B: Sanitized, C: Graduated)
+- **Deadline:** Before first client kickoff
+- **Recommendation:** Start with Option B (sanitized). Weekly updates and deliverable docs only. Revisit after 3 completed engagements.
+
+### ADR-004: Equity Option
+
+- **Status:** OPEN
+- **Decision needed:** Does SC ever take equity?
+- **Deadline:** Before 5th client outreach
+- **Recommendation:** No equity for MVP. Cash only. Equity introduces legal complexity and misaligns incentives with "kill fast."
+
+### ADR-005: Discovery Gate Enforcement Timing
+
+- **Status:** DECIDED
+- **Decision:** Phase 3 adds `discovery` status and gate evaluation. Phase 4 adds enforcement on `-> build` transitions. The `discovery_gate_exception` flag allows bypassing.
+- **Rationale:** Decoupling evaluation from enforcement allows validating gate logic against real data before it becomes a hard blocker.
+
+### ADR-006: Archetype Migration for Existing Data
+
+- **Status:** OPEN
+- **Decision needed:** How to handle active experiments with `interview` archetype
+- **Deadline:** Before Migration 0002 executes
+- **Current plan:** Draft/preflight migrate to `fake_door`; active experiments archived.
+- **Action required:** Audit all experiments before migration. If any active `interview` experiments exist, coordinate before migrating.
+
+### ADR-007: JSON Schema Validation Location (Technical)
+
+- **Status:** PROPOSED
+- **Options:** (A) Full JSON Schema validation (ajv), (B) Lightweight structural checks, (C) No validation
+- **Recommendation:** Option B for MVP. Validate `version` field and top-level structure. All endpoints are internal (X-SC-Key), so callers are controlled.
+
+### ADR-008: Discovery Summary Computation Strategy (Technical)
+
+- **Status:** PROPOSED
+- **Options:** (A) Compute on read, (B) Compute on write, (C) Explicit command
+- **Recommendation:** Option B (compute on write). Interview volume is low. Recomputing after each insert ensures the summary is current and GET is a simple read.
+
+### ADR-009: Interview Transcript R2 Key Convention (Technical)
+
+- **Status:** PROPOSED
+- **Recommendation:** `interviews/{experiment_id}/{participant_id}-{ISO_DATE}.txt`
+- **Rationale:** Groups by experiment for easy bulk operations (90-day purge).
+
+### ADR-010: Pre-Migration Backup Protocol (Technical)
+
+- **Status:** PROPOSED
+- **Recommendation:** Export via `wrangler d1 export` before each remote migration. Local first, then preview, then production. Keep export 7 days.
+
+---
+
+## 18. Phased Development Plan
+
+### Phase 0: Business Foundation (Tier 1)
+
+**Goal:** Everything needed to accept money from the first client. No platform development.
+
+**In scope:**
+
+- Lock pricing for all 4 sprint types
+- Services page on siliconcrane.com (copy + layout + prices)
+- Intake form (Typeform/Tally with notification setup)
+- Contract/SOW template
+- Payment mechanism (Stripe product + checkout/invoice)
+- DFG case study draft
+- Warm network outreach (first 20 targets)
+
+**Not in scope:** Any console development, schema migrations, or API changes.
+
+**Exit criteria:** Services page live with prices, intake form captures submissions, Stripe processes payment, SOW template ready, DFG case study published.
+
+**Dependencies:** None.
+
+---
+
+### Phase 1: Schema Foundation
+
+**Goal:** Run Migration 0002. No application code changes.
+
+**In scope:**
+
+- Execute all 4 migration steps
+- 10 new columns on `experiments` (6 artifact, 4 supporting)
+- 1 new column on `decision_memos`
+- 4 new tables (`interviews`, `ventures`, `threshold_registry`, `venture_benchmarks`)
+- Updated CHECK constraints
+- Verification in local, preview, production
+
+**Exit criteria:** All verification queries pass in all environments. Zero `interview` rows. Row counts preserved. Triggers fire.
+
+**Dependencies:** ADR-006 resolved.
+
+---
+
+### Phase 2: Hypothesis Card
+
+**Goal:** Experiments gain structured hypothesis definition.
+
+**In scope:**
+
+- `hypothesis_card` read/write via PATCH
+- Distill Brief write invariant
+- Auto-extraction of projections
+- Confidence score validation
+- `abandon` confidence -> archive recommendation (advisory)
+
+**Exit criteria:** Creating experiment with `hypothesis_card` auto-populates Distill Brief. Direct Distill Brief updates on experiments with cards return 400. Experiments without cards work as before.
+
+**Dependencies:** Phase 1 complete.
+
+---
+
+### Phase 3: Discovery Engine
+
+**Goal:** Experiments can enter `discovery` with interviews and gate evaluation.
+
+**In scope:**
+
+- `interviews` CRUD
+- `discovery_summary` read/write
+- Discovery API endpoints (start, summary, finalize, gate)
+- `discovery` status transitions
+- Gate logic (6 checks, advisory only)
+- Mode-weighted counting
+- Discovery event types
+
+**Exit criteria:** Experiment transitions `preflight -> discovery`. Interviews recorded. Gate returns structured evaluation. Summary finalizable.
+
+**Dependencies:** Phase 1 complete. Phase 2 recommended.
+
+---
+
+### Phases 4-7: Post-MVP (Roadmap Visibility)
+
+| Phase | Name                               | Key Deliverables                                                                                                    | Dependency |
+| ----- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 4     | Test Blueprint + Validation Ladder | `test_blueprint`, archetype defaults, gate enforcement, Hard/Soft Kill                                              | Phase 3    |
+| 5     | Campaign Factory                   | `campaign_package`, CampaignPackage write invariant, Ventures CRUD, Cloudflare Queue, R2 assets                     | Phase 4    |
+| 6     | The Launchpad                      | `page_config`, archetype-aware templates, SignalCapture, A/B variants, preview mode                                 | Phase 5    |
+| 7     | The Verdict                        | `validation_report`, `decision_detail`, measurement endpoints, Bayesian confidence, threshold population, PII purge | Phase 6    |
+
+**Milestone A (v2.0-alpha):** Phases 1-3 complete. Target: 2-3 weeks after Phase 0.
+**Milestone B (v2.0-beta):** Phases 4-7 complete. Target: incremental after Milestone A.
+
+### Scope Boundary Rules
+
+1. A feature lives in exactly one phase. No "partially in Phase 2, completed in Phase 3."
+2. Phase 0 has no platform development.
+3. Discover additional work mid-task -- finish current scope, file a new issue.
+4. All changes through PRs. Never push directly to main.
+5. MVP scope is Phase 0 plus Milestone A. Phases 4-7 require a separate planning cycle.
+
+---
+
+## 19. Glossary
+
+| Term                    | Definition                                                                                                                                                                                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Archetype**           | One of 7 experiment types: `fake_door`, `waitlist`, `content_magnet`, `priced_waitlist`, `presale`, `concierge`, `service_pilot`. Each archetype determines the landing page structure, signal capture events, and default kill criteria. |
+| **Artifact Chain**      | The sequence of structured documents produced during a validation sprint: Hypothesis Card -> Discovery Summary -> Test Blueprint -> Campaign Package -> Live Experiment -> Validation Report.                                             |
+| **CampaignPackage**     | JSON artifact containing generated campaign copy, creative brief, targeting parameters, budget allocation, channel variants, and A/B variants for an experiment.                                                                          |
+| **D1**                  | Cloudflare's serverless SQLite database service. The persistence layer for SC Console.                                                                                                                                                    |
+| **Decision Memo**       | A structured record of the GO/KILL/PIVOT decision for an experiment, including rationale, confidence, key metrics, and next steps.                                                                                                        |
+| **Discovery Gate**      | A 6-check evaluation that determines whether an experiment has completed sufficient customer discovery to proceed to test design. Advisory in Phase 3, enforced in Phase 4.                                                               |
+| **Discovery Summary**   | JSON artifact aggregating interview findings: pain severity, problem confirmation, ICP refinements, top quotes, assumption updates, and gate status.                                                                                      |
+| **Distill Brief**       | The v1.2 experiment description fields: `target_audience`, `problem_statement`, `value_proposition`, `market_size_estimate`. Superseded by Hypothesis Card but retained as read-only projections for backward compatibility.              |
+| **Fake Door**           | An experiment archetype that tests demand by presenting a product concept without a real product behind it. Replaced the `interview` archetype in v2.0.                                                                                   |
+| **GO/NO-GO**            | The binary outcome of a validation sprint: proceed (GO), kill (NO-GO), or pivot. Every engagement must produce this signal with evidence.                                                                                                 |
+| **Hono**                | Lightweight web framework used for the sc-api Cloudflare Worker.                                                                                                                                                                          |
+| **Hypothesis Card**     | JSON artifact capturing the structured venture narrative: customer segment, problem, stakes, solution, why-now, confidence, and key assumptions. Two tiers: Draft (6 fields) and Full (10 fields).                                        |
+| **Kill Criteria**       | Predefined thresholds that, if breached, trigger a KILL recommendation. Defined before launch, not after. Hard kills are non-negotiable; soft kills are advisory.                                                                         |
+| **Learning Memo**       | A structured record of lessons learned during or after an experiment, regardless of outcome.                                                                                                                                              |
+| **Mode-Weighted Count** | The adjusted interview count where AI interviews count as 0.5, hybrid as 0.75, and human as 1.0. Used for Discovery Gate minimum threshold.                                                                                               |
+| **R2**                  | Cloudflare's object storage service (S3-compatible). Used for creative assets and interview transcripts.                                                                                                                                  |
+| **SignalCapture**       | Client-side Astro component for tracking visitor behavior on landing pages. Uses `navigator.sendBeacon` for reliability.                                                                                                                  |
+| **Sprint**              | A time-boxed validation engagement: Preflight (3-5 days), Build-to-Launch (7-10 days), Run + Decide (14-21 days), Scale Readiness (follow-on).                                                                                            |
+| **Test Blueprint**      | JSON artifact specifying the experiment design: archetype selection, metrics, thresholds, kill criteria, buildability assessment, and decision criteria.                                                                                  |
+| **Validation Report**   | JSON artifact produced at experiment conclusion: metrics summary, evidence table, data quality assessment, trend analysis, confidence calculation, and recommended verdict.                                                               |
+| **VaaS**                | Validation-as-a-Service. Silicon Crane's service model.                                                                                                                                                                                   |
+| **Venture**             | A business idea or project being validated through SC. Each venture has experiments, a brand profile, and a position in the artifact chain.                                                                                               |
+| **Write Invariant**     | A data consistency rule where, when a newer artifact column is populated, older columns that overlap with it become read-only projections auto-extracted from the newer column.                                                           |
+| **X-SC-Key**            | The API authentication header used for all internal (non-public) sc-api endpoints.                                                                                                                                                        |
+
+---
+
+## Appendix: Unresolved Issues
+
+Issues collected from all 6 role contributions. Since only 1 review round was conducted, most items are first-pass observations rather than cross-round disputes.
+
+| ID     | Source             | Issue                                                                                                                                                     | Recommended Resolution                                                                                                                                                |
+| ------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UI-001 | Business Analyst   | Should the gate evaluation endpoint compute weighted interview count from the `interviews` table or read the pre-computed value from `discovery_summary`? | Compute from interviews table. The summary's count is a snapshot, not authoritative for gate evaluation.                                                              |
+| UI-002 | Business Analyst   | What happens to a Discovery Summary when a new interview is recorded after the summary has been written?                                                  | Phase 3: manual re-write by operator or AI agent. Auto-aggregation is Phase 4+.                                                                                       |
+| UI-003 | Business Analyst   | Should composite pain score require all 3 dimensions or average available dimensions?                                                                     | Require all 3. If any dimension is null, composite is null. Pain threshold met only via peak dimension check.                                                         |
+| UI-004 | Business Analyst   | Should `POST /interviews` accept null pain score dimensions for "insufficient data"?                                                                      | Yes. Accept null per dimension. Keep 1-5 range for non-null values.                                                                                                   |
+| UI-005 | Business Analyst   | Which is the canonical write path for Discovery Summary: PATCH or dedicated endpoint?                                                                     | Use `PATCH /experiments/:id` with `discovery_summary`. The `/discovery/finalize` POST is the only endpoint modifying stage.                                           |
+| UI-006 | Business Analyst   | Should Hypothesis Card validation be strict or lenient for partial cards?                                                                                 | Strict per tier. Draft requires all 6 Tier 1 fields. Full requires all 10 plus confidence.                                                                            |
+| UI-007 | Business Analyst   | Should CampaignPackage write invariant be implemented in Phase 2 or Phase 5?                                                                              | Phase 5. The invariant only matters when `campaign_package` is populated.                                                                                             |
+| UI-008 | Target Customer    | AI-conducted discovery interviews may produce misleading data for non-tech-savvy target markets.                                                          | Interview mode selection must match target customer comfort. For non-digital demographics, human or hybrid mode should be required. Document mode selection guidance. |
+| UI-009 | Target Customer    | Client needs lead data exported before 90-day PII purge on archived experiments.                                                                          | Make lead export an explicit step in the decision delivery process. Include lead list in GO verdict deliverables.                                                     |
+| UI-010 | Target Customer    | Sprint types are confusing as separate products; clients want packaged recommendations.                                                                   | Consider a guided intake that recommends sprint type(s) based on idea stage and budget. Package bundles for simplicity.                                               |
+| UI-011 | Target Customer    | "Build-to-Launch" sprint description blurs line with dev shop. Clients need clarity on what "build" means in validation context.                          | Clarify: "build" means landing page + tracking + signal capture, not a functional product. Update services page copy.                                                 |
+| UI-012 | Target Customer    | Sample deliverable (Validation Report / Decision Memo) needed for trust building.                                                                         | Create anonymized sample from DFG engagement. Publish alongside case study.                                                                                           |
+| UI-013 | UX Lead            | No signal capture on current landing pages. `event_log` receives zero landing-page-side events.                                                           | Prioritize SignalCapture component ahead of archetype-specific templates.                                                                                             |
+| UI-014 | UX Lead            | Thank-you page is generic across all archetypes.                                                                                                          | Ship archetype-specific variants alongside template router (Phase 6).                                                                                                 |
+| UI-015 | UX Lead            | No intake form exists (Tier 1 blocker).                                                                                                                   | Build before any func spec v2.0 implementation.                                                                                                                       |
+| UI-016 | UX Lead            | Accessibility debt: decorative SVGs lack `aria-hidden`, form messages lack `aria-live`, loading states not announced to screen readers.                   | Fix in next PR touching templates.                                                                                                                                    |
+| UI-017 | Competitor Analyst | SC Console engineering may be premature for zero-client stage.                                                                                            | Phase 0 validates service manually. Console work proceeds only after service demand is proven.                                                                        |
+| UI-018 | Competitor Analyst | "Kill bad ideas fast" is commercially difficult positioning. Founders want "yes."                                                                         | Balance messaging: lead with "find out what works" rather than "find out what doesn't." Kill criteria framing should emphasize capital protection, not negativity.    |
+
+<!-- Synthesis: 19 sections, 11520 words, 18 unresolved issues, 1 rounds -->

--- a/docs/technical/sc-functional-spec-v2.md
+++ b/docs/technical/sc-functional-spec-v2.md
@@ -1,0 +1,888 @@
+# SC Console — Functional Specification v2.0
+
+**Version:** 2.0
+**Date:** March 2, 2026
+**Status:** DRAFT — synthesized from 6 deep dives + tech spec v1.2
+**Predecessor:** Technical Specification v1.2 (January 15, 2026)
+
+---
+
+## 1. Executive Summary
+
+### What v2.0 Adds
+
+This specification is **additive to tech spec v1.2**, not a replacement. It synthesizes the recommendations from six deep dive methodology documents into a single actionable implementation plan:
+
+- **6 new artifact columns** on the `experiments` table: `hypothesis_card`, `test_blueprint`, `discovery_summary`, `campaign_package`, `page_config`, `validation_report`
+- **4 new supporting columns** on `experiments`: `venture_id`, `category`, `sequence_position`, `prior_test_ref`
+- **1 new column** on `decision_memos`: `decision_detail`
+- **4 new tables**: `interviews`, `ventures`, `threshold_registry`, `venture_benchmarks`
+- **~20 new API endpoints** across discovery, campaign generation, measurement, and ventures
+- **Updated CHECK constraints**: `archetype` (replace `interview` with `fake_door`), `status` (add `discovery`)
+- **Async pipeline support** via Cloudflare Queue for campaign generation
+- **Two write invariant patterns**: Distill Brief and CampaignPackage projection enforcement
+
+### Relationship to Tech Spec v1.2
+
+Tech spec v1.2 defines the foundation: D1 schema, API routes, Astro frontend, Cloudflare deployment. This spec extends that foundation without modifying any existing working behavior. All new columns are nullable. Existing experiments continue to work without modification.
+
+### Relationship to the Deep Dives
+
+Each deep dive produced a branded methodology component with a "Recommendations for Functional Spec v2.0" section. This spec consolidates all 61 recommendations across DD#1-DD#6 into a coherent data model, API surface, and implementation plan. The deep dives remain the canonical source for JSON schemas and methodology rationale. This spec references them by section number rather than duplicating schema bodies.
+
+| DD# | Branded Name          | Artifact                            | Recs   |
+| --- | --------------------- | ----------------------------------- | ------ |
+| 1   | The Venture Narrative | Hypothesis Card                     | 6      |
+| 2   | The Validation Ladder | Test Blueprint                      | 9      |
+| 3   | The Discovery Engine  | Discovery Summary                   | 8      |
+| 4   | The Campaign Factory  | Campaign Package                    | 10     |
+| 5   | The Launchpad         | Live Experiment (page_config)       | 11     |
+| 6   | The Verdict           | Validation Report + Decision Detail | 17     |
+|     |                       | **Total**                           | **61** |
+
+---
+
+## 2. Data Model Changes
+
+### 2.1 New Columns on `experiments` Table
+
+All new columns are TEXT (JSON) and nullable, added via D1 ALTER TABLE migration.
+
+#### Artifact Columns
+
+| Column              | Type        | Source DD | Schema Reference | Description                                                                                                                    |
+| ------------------- | ----------- | --------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `hypothesis_card`   | TEXT (JSON) | DD#1      | Section 3.7      | Structured Hypothesis Card: 10 fields across 2 tiers, confidence score, one-liner                                              |
+| `test_blueprint`    | TEXT (JSON) | DD#2      | Section 5.5      | Test Blueprint: archetype selection, metrics/thresholds, kill criteria, buildability, decision criteria                        |
+| `discovery_summary` | TEXT (JSON) | DD#3      | Section 6.5      | Discovery Summary: pain severity, interview data, gate status, assumption updates                                              |
+| `campaign_package`  | TEXT (JSON) | DD#4      | Section 6.5      | Campaign Package: copy_pack, creative_brief, social_proof, tone, channel variants, A/B variants, budget, targeting, provenance |
+| `page_config`       | TEXT (JSON) | DD#5      | Section 13       | Landing page config overrides: sections, form fields, screening questions, resource URL, pricing tiers, FAQ                    |
+| `validation_report` | TEXT (JSON) | DD#6      | Section 4.5      | Validation Report: metrics summary, evidence table, data quality, trend analysis, confidence assessment, recommended verdict   |
+
+#### Supporting Columns
+
+| Column              | Type    | Source DD | Description                                                                                                                             |
+| ------------------- | ------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `venture_id`        | TEXT    | DD#4      | FK to `ventures` table. NOT enforced as FK until Phase 5; D1 does not enforce FKs by default.                                           |
+| `category`          | TEXT    | DD#2      | CHECK constraint: `('demand_signal','willingness_to_pay','solution_validation')`. Derived from archetype, stored for query performance. |
+| `sequence_position` | INTEGER | DD#2      | Validation Ladder rung number (1, 2, 3...) for this experiment.                                                                         |
+| `prior_test_ref`    | TEXT    | DD#2      | Nullable reference to `experiments.id`. Links sequential tests on the same venture hypothesis.                                          |
+
+### 2.2 Status Transition Map v2.0
+
+The v1.2 status lifecycle gains a `discovery` state between `preflight` and `build`:
+
+```
+draft --> preflight --> discovery --> build --> launch --> run --> decide --> archive
+                    \                 ^
+                     \-> build ------/  (with discovery_gate_exception = true)
+```
+
+**Transition rules:**
+
+| From               | To        | Condition                                                  |
+| ------------------ | --------- | ---------------------------------------------------------- |
+| draft              | preflight | None                                                       |
+| preflight          | discovery | None                                                       |
+| preflight          | build     | Requires `discovery_gate_exception` flag on the experiment |
+| discovery          | build     | Requires Discovery Gate pass (Phase 4 enforcement)         |
+| build              | launch    | None                                                       |
+| launch             | run       | None                                                       |
+| run                | decide    | None                                                       |
+| decide             | archive   | None                                                       |
+| Any except archive | archive   | Always allowed                                             |
+
+**Discovery Gate** fires on BOTH `discovery -> build` and `preflight -> build` transitions. Phase 3 adds `discovery` to `VALID_STATUS_TRANSITIONS` immediately (no gate logic). Phase 4 adds gate enforcement on the `-> build` transitions.
+
+### 2.3 Modified CHECK Constraints
+
+**SQLite/D1 cannot ALTER CHECK constraints.** Both changes require the create-copy-drop-rename migration pattern (see Section 7, Step 3).
+
+**1. `archetype` column:**
+
+Replace `interview` with `fake_door`, reorder to match Validation Ladder sequence:
+
+```sql
+-- v1.2 (current)
+CHECK(archetype IN ('waitlist','priced_waitlist','presale','service_pilot','content_magnet','concierge','interview'))
+
+-- v2.0 (new)
+CHECK(archetype IN ('fake_door','waitlist','content_magnet','priced_waitlist','presale','concierge','service_pilot'))
+```
+
+**2. `status` column:**
+
+Add `discovery`:
+
+```sql
+-- v1.2 (current)
+CHECK(status IN ('draft','preflight','build','launch','run','decide','archive'))
+
+-- v2.0 (new)
+CHECK(status IN ('draft','preflight','discovery','build','launch','run','decide','archive'))
+```
+
+### 2.4 Distill Brief --> Hypothesis Card Migration
+
+DD#1 recommends replacing the 4 Distill Brief columns with the Hypothesis Card. This spec adopts the **write invariant pattern**:
+
+- When `hypothesis_card` is **non-null** on an experiment, the 4 Distill Brief columns become **read-only projections**
+- `PATCH /experiments/:id` rejects direct updates to Distill Brief fields when `hypothesis_card` is present
+- Projections are auto-extracted on write:
+
+| Distill Brief Column   | Projected From                        |
+| ---------------------- | ------------------------------------- |
+| `target_audience`      | `hypothesis_card.customer_segment`    |
+| `problem_statement`    | `hypothesis_card.problem_statement`   |
+| `value_proposition`    | `hypothesis_card.solution_hypothesis` |
+| `market_size_estimate` | `hypothesis_card.market_sizing`       |
+
+- Existing experiments without `hypothesis_card` continue to use Distill Brief fields directly (backward compatible)
+
+### 2.5 CampaignPackage Write Invariant
+
+When `campaign_package` is **non-null** on an experiment, the `copy_pack` and `creative_brief` columns become **read-only projections**. `PATCH /experiments/:id` rejects direct `copy_pack`/`creative_brief` updates. Edits go through the CampaignPackage, which re-extracts the projections. This prevents data drift between the three columns.
+
+### 2.6 New Column on `decision_memos` Table
+
+| Column            | Type        | Source DD | Schema Reference | Description                                                                                                                                        |
+| ----------------- | ----------- | --------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `decision_detail` | TEXT (JSON) | DD#6      | Section 6.5      | Structured evidence, Bayesian confidence calculation, system recommendation, human override, GO conditions, kill criteria triggered, pivot routing |
+
+Existing columns (`rationale`, `confidence_pct`, `key_metrics`, `next_steps`) remain unchanged for backward compatibility.
+
+### 2.7 New Tables
+
+#### `interviews`
+
+Per-interview records for the Discovery Engine (DD#3).
+
+```sql
+CREATE TABLE IF NOT EXISTS interviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  experiment_id TEXT NOT NULL REFERENCES experiments(id),
+  participant_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK(mode IN ('ai', 'hybrid', 'human')),
+  protocols_covered TEXT NOT NULL,        -- JSON array: ["problem_discovery", "solution_fit", ...]
+  duration_minutes INTEGER,
+  pain_scores TEXT,                       -- JSON: { functional: N, emotional: N, opportunity: N }
+  signal_extraction TEXT,                 -- JSON: full extraction report
+  transcript_ref TEXT,                    -- R2 key to transcript file
+  new_themes_detected INTEGER DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX idx_interviews_experiment ON interviews(experiment_id);
+```
+
+#### `ventures`
+
+Per-venture brand profiles for multi-venture support (DD#4).
+
+```sql
+CREATE TABLE IF NOT EXISTS ventures (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  brand_profile TEXT,                     -- JSON: BrandProfile (voice, colors, typography, image style, prohibited terms)
+  brand_profile_version INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE TRIGGER update_ventures_timestamp
+AFTER UPDATE ON ventures
+BEGIN
+  UPDATE ventures SET updated_at = (strftime('%s', 'now') * 1000)
+  WHERE id = NEW.id;
+END;
+```
+
+#### `threshold_registry`
+
+Calibration data per archetype per phase (DD#6).
+
+```sql
+CREATE TABLE IF NOT EXISTS threshold_registry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  phase INTEGER NOT NULL CHECK(phase IN (1, 2, 3)),
+  go_threshold INTEGER NOT NULL,
+  kill_threshold INTEGER NOT NULL,
+  metric TEXT NOT NULL,
+  sample_count INTEGER NOT NULL,
+  percentile_25 INTEGER,
+  percentile_75 INTEGER,
+  mean_value INTEGER,
+  std_dev INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  effective_from TEXT NOT NULL,
+  superseded_at TEXT,
+  calculation_notes TEXT,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE INDEX idx_threshold_archetype ON threshold_registry(archetype);
+CREATE INDEX idx_threshold_phase ON threshold_registry(phase);
+```
+
+#### `venture_benchmarks`
+
+Cross-venture performance aggregates (DD#6).
+
+```sql
+CREATE TABLE IF NOT EXISTS venture_benchmarks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  industry TEXT,
+  price_range TEXT,
+  channel TEXT,
+  test_count INTEGER NOT NULL,
+  mean_cvr_bp INTEGER,
+  median_cvr_bp INTEGER,
+  p25_cvr_bp INTEGER,
+  p75_cvr_bp INTEGER,
+  std_dev_cvr_bp INTEGER,
+  mean_cpl_cents INTEGER,
+  median_cpl_cents INTEGER,
+  go_rate_pct INTEGER,
+  kill_rate_pct INTEGER,
+  pivot_rate_pct INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  last_updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  calculation_notes TEXT
+);
+
+CREATE INDEX idx_benchmarks_archetype ON venture_benchmarks(archetype);
+CREATE INDEX idx_benchmarks_industry ON venture_benchmarks(industry);
+```
+
+---
+
+## 3. API Changes
+
+### 3.1 Modified Endpoints
+
+**`POST /experiments`**
+
+- Auto-populate archetype defaults for `kill_criteria`, `max_duration_days`, `max_spend_cents` when archetype is provided (DD#2 rec 8)
+- Validate archetype against updated enum (replace `interview` with `fake_door`)
+- Enforce Distill Brief write invariant: if `hypothesis_card` is provided, auto-extract projections into Distill Brief columns
+
+**`PATCH /experiments/:id`**
+
+- Add new fields to updatable set: `hypothesis_card`, `test_blueprint`, `discovery_summary`, `campaign_package`, `page_config`, `validation_report`, `venture_id`, `category`, `sequence_position`, `prior_test_ref`
+- Enforce Distill Brief write invariant: reject direct `problem_statement`, `target_audience`, `value_proposition`, `market_size_estimate` updates when `hypothesis_card` is non-null
+- Enforce CampaignPackage write invariant: reject direct `copy_pack`/`creative_brief` updates when `campaign_package` is non-null
+
+**Status transition validation:**
+
+- Add `discovery` to `VALID_STATUS_TRANSITIONS` (Phase 3)
+- Add Discovery Gate check before `discovery -> build` and `preflight -> build` transitions (Phase 4)
+
+### 3.2 New Ventures Endpoints (Phase 5)
+
+| Method | Path            | Auth     | Description                                             |
+| ------ | --------------- | -------- | ------------------------------------------------------- |
+| POST   | `/ventures`     | X-SC-Key | Create venture with `brand_profile`                     |
+| GET    | `/ventures`     | X-SC-Key | List all ventures                                       |
+| GET    | `/ventures/:id` | X-SC-Key | Get venture by ID                                       |
+| PATCH  | `/ventures/:id` | X-SC-Key | Update venture; auto-increments `brand_profile_version` |
+
+### 3.3 New Discovery Endpoints (Phase 3)
+
+| Method | Path                                  | Auth     | Description                                                      |
+| ------ | ------------------------------------- | -------- | ---------------------------------------------------------------- |
+| POST   | `/experiments/:id/discovery/start`    | X-SC-Key | Initialize discovery sprint; transition status to `discovery`    |
+| POST   | `/experiments/:id/interviews`         | X-SC-Key | Record a completed interview with pain scores, signal extraction |
+| GET    | `/experiments/:id/discovery/summary`  | X-SC-Key | Retrieve current Discovery Summary (draft or final)              |
+| POST   | `/experiments/:id/discovery/finalize` | X-SC-Key | Lock Discovery Summary to "final" stage                          |
+| GET    | `/experiments/:id/discovery/gate`     | X-SC-Key | Evaluate and return gate status (6 checks)                       |
+
+### 3.4 New Campaign Generation Endpoints (Phase 5)
+
+| Method | Path                                         | Auth     | Description                                                                       |
+| ------ | -------------------------------------------- | -------- | --------------------------------------------------------------------------------- |
+| POST   | `/experiments/:id/generate-campaign-package` | X-SC-Key | Enqueue async generation via Cloudflare Queue; returns `202 Accepted` with job ID |
+| GET    | `/experiments/:id/campaign-package/status`   | X-SC-Key | Poll for generation completion                                                    |
+
+### 3.5 New Measurement Endpoints (Phase 7)
+
+| Method | Path                                          | Auth     | Description                                                             |
+| ------ | --------------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| GET    | `/experiments/:id/validation-report`          | X-SC-Key | Current Validation Report (draft or final)                              |
+| POST   | `/experiments/:id/validation-report/finalize` | X-SC-Key | Lock report to "final" stage                                            |
+| GET    | `/experiments/:id/cumulative-metrics`         | X-SC-Key | Cumulative aggregated metrics across all days/sources                   |
+| POST   | `/experiments/:id/evaluate-thresholds`        | X-SC-Key | Trigger threshold evaluation; returns recommended verdict with evidence |
+| GET    | `/thresholds/:archetype`                      | X-SC-Key | Current threshold set from `threshold_registry`                         |
+| GET    | `/benchmarks`                                 | X-SC-Key | Portfolio benchmark data from `venture_benchmarks`                      |
+
+---
+
+## 4. Event Log Extensions
+
+Consolidated list of all new event types from DD#3-DD#6:
+
+**Discovery Events (DD#3):**
+
+- `discovery_sprint_started` -- Sprint initiated
+- `interview_scheduled` -- Participant confirmed
+- `interview_completed` -- Interview finished
+- `interview_analyzed` -- AI extraction complete
+- `saturation_detected` -- 3-in-a-row triggered
+- `discovery_gate_evaluated` -- Gate check run
+- `discovery_summary_finalized` -- Summary locked
+
+**Campaign Generation Events (DD#4):**
+
+- `campaign_gen_started` -- Pipeline begins
+- `campaign_gen_step_completed` -- Each pipeline step finishes
+- `campaign_gen_completed` -- Pipeline succeeds
+- `campaign_gen_failed` -- Pipeline fails
+- `campaign_package_approved` -- Human approves package
+
+**Landing Page Signal Events (DD#5):**
+
+- `page_view` -- Page load
+- `scroll_depth` -- Visitor scrolls to 25/50/75/100%
+- `form_start` -- First form field interaction
+- `form_submit` -- Form submitted
+- `payment_start` -- Stripe Checkout button clicked
+- `payment_complete` -- Stripe webhook confirms payment
+- `payment_failed` -- Stripe reports failure
+- `pricing_view` -- Pricing section enters viewport
+- `pricing_tier_select` -- User selects pricing tier
+- `content_preview_view` -- Content preview section visible
+- `resource_downloaded` -- Download link clicked
+- `screening_question_answered` -- Screening question completed
+- `pilot_details_view` -- Pilot details section visible
+- `experiment_pivoted` -- Campaign pivot event
+
+**Measurement Events (DD#6):**
+
+- `threshold_evaluation` -- Triggered after metrics import
+- `validation_report_generated` -- Draft report created/updated
+- `validation_report_finalized` -- Report locked to final
+- `decision_support_recommendation` -- System recommendation generated
+- `go_handoff_initiated` -- GO handoff document generated
+- `experiment_archived` -- Experiment moved to archive status
+
+---
+
+## 5. Frontend Changes
+
+All changes target `apps/sc-web/`:
+
+**Archetype-aware template router (DD#5):**
+
+- Evolve `pages/e/[slug].astro` from monolithic template to archetype-aware router
+- Add `resolvePageConfig()` function in `lib/landing.ts` with defaults for all 7 archetypes
+- Add `LandingBase.astro` layout for shared meta tags, tracking script, footer
+
+**Per-archetype template components (DD#5):**
+
+- `HeroSection.astro`, `ValueProps.astro`, `SocialProof.astro`, `PricingSection.astro`
+- `LeadCaptureForm.astro`, `QualificationForm.astro`, `ContentPreview.astro`
+- `ProcessSteps.astro`, `FaqSection.astro`, `RefundPolicy.astro`, `PilotDetails.astro`
+- `PaymentCta.astro`
+
+**SignalCapture component (DD#5):**
+
+- Client-side Astro island for all event tracking
+- Uses `navigator.sendBeacon` for reliability
+- Tracks per-archetype signal events (see Section 4)
+- Included in every landing page via `LandingBase.astro`
+
+**A/B variant support (DD#5):**
+
+- `AbVariantWrapper.astro` component
+- Hash-based deterministic variant assignment (client-side)
+- Variants override: headline, subheadline, cta_text, urgency_hook, hero_image
+- No-flicker protocol using opacity transition
+
+**Channel-aware messaging (DD#5):**
+
+- UTM parameter matching to `campaign_package.channel_variants[]`
+- Channel variant fields override default `copy_pack` values
+- Source normalization map: fb->facebook, ig->facebook, li->linkedin, etc.
+
+**Preview mode (DD#5):**
+
+- `?preview=true` query parameter bypasses status check
+- Preview pages include `<meta name="robots" content="noindex">`
+
+---
+
+## 6. Infrastructure Additions
+
+**Cloudflare Queue for async campaign generation (DD#4):**
+
+- `POST /experiments/:id/generate-campaign-package` enqueues a job
+- Queue Consumer worker executes the 7-step pipeline (15-minute execution limit)
+- Steps: Context Assembly -> Copy Generation -> Creative Brief -> Asset Generation -> Campaign Assembly -> Consistency Check -> Human Review Gate
+- Total automated time: 1-3 minutes; bottleneck is image API latency
+
+**R2 storage for creative assets and interview transcripts (DD#3, DD#4):**
+
+- Generated images stored in R2 using existing `generateAssetKey()` pattern
+- CampaignPackage stores R2 keys in `asset_references[]`, not image data
+- Interview transcripts stored with R2 reference in `interviews.transcript_ref`
+- Transcripts contain PII; follow 90-day retention policy
+
+**sc-maintenance worker updates (DD#3, DD#6):**
+
+- Extend daily cron to handle 90-day PII purge for **archived experiments** (not just `event_log.user_agent`)
+- On archive: after 90 days, purge `leads.email` (hash it), null out `leads.name`, `leads.company`, `leads.phone`
+- Preserve anonymized data: `leads.custom_fields`, `leads.utm_*`, `leads.ip_country`, all `metrics_daily`, all `event_log` except `user_agent`
+
+**Scheduled threshold recalculation job (DD#6):**
+
+- Weekly (or after each completed experiment) recalculation
+- When completed test count crosses Phase 2 (10 tests) or Phase 3 (50 tests), update `threshold_registry`
+
+---
+
+## 7. Migration Plan
+
+### Migration 0002: v2.0 Schema Changes
+
+Four steps executed in a single migration file. The order is critical.
+
+**Step 1: Add new columns and create new tables** (safe, no data changes)
+
+```sql
+-- New columns on experiments
+ALTER TABLE experiments ADD COLUMN hypothesis_card TEXT;
+ALTER TABLE experiments ADD COLUMN test_blueprint TEXT;
+ALTER TABLE experiments ADD COLUMN discovery_summary TEXT;
+ALTER TABLE experiments ADD COLUMN campaign_package TEXT;
+ALTER TABLE experiments ADD COLUMN page_config TEXT;
+ALTER TABLE experiments ADD COLUMN validation_report TEXT;
+ALTER TABLE experiments ADD COLUMN venture_id TEXT;
+ALTER TABLE experiments ADD COLUMN category TEXT;
+ALTER TABLE experiments ADD COLUMN sequence_position INTEGER;
+ALTER TABLE experiments ADD COLUMN prior_test_ref TEXT;
+
+-- New column on decision_memos
+ALTER TABLE decision_memos ADD COLUMN decision_detail TEXT;
+
+-- New tables
+CREATE TABLE IF NOT EXISTS interviews (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  experiment_id TEXT NOT NULL REFERENCES experiments(id),
+  participant_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK(mode IN ('ai', 'hybrid', 'human')),
+  protocols_covered TEXT NOT NULL,
+  duration_minutes INTEGER,
+  pain_scores TEXT,
+  signal_extraction TEXT,
+  transcript_ref TEXT,
+  new_themes_detected INTEGER DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+CREATE INDEX idx_interviews_experiment ON interviews(experiment_id);
+
+CREATE TABLE IF NOT EXISTS ventures (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  brand_profile TEXT,
+  brand_profile_version INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE TRIGGER update_ventures_timestamp
+AFTER UPDATE ON ventures
+BEGIN
+  UPDATE ventures SET updated_at = (strftime('%s', 'now') * 1000)
+  WHERE id = NEW.id;
+END;
+
+CREATE TABLE IF NOT EXISTS threshold_registry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  phase INTEGER NOT NULL CHECK(phase IN (1, 2, 3)),
+  go_threshold INTEGER NOT NULL,
+  kill_threshold INTEGER NOT NULL,
+  metric TEXT NOT NULL,
+  sample_count INTEGER NOT NULL,
+  percentile_25 INTEGER,
+  percentile_75 INTEGER,
+  mean_value INTEGER,
+  std_dev INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  effective_from TEXT NOT NULL,
+  superseded_at TEXT,
+  calculation_notes TEXT,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+CREATE INDEX idx_threshold_archetype ON threshold_registry(archetype);
+CREATE INDEX idx_threshold_phase ON threshold_registry(phase);
+
+CREATE TABLE IF NOT EXISTS venture_benchmarks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  archetype TEXT NOT NULL,
+  industry TEXT,
+  price_range TEXT,
+  channel TEXT,
+  test_count INTEGER NOT NULL,
+  mean_cvr_bp INTEGER,
+  median_cvr_bp INTEGER,
+  p25_cvr_bp INTEGER,
+  p75_cvr_bp INTEGER,
+  std_dev_cvr_bp INTEGER,
+  mean_cpl_cents INTEGER,
+  median_cpl_cents INTEGER,
+  go_rate_pct INTEGER,
+  kill_rate_pct INTEGER,
+  pivot_rate_pct INTEGER,
+  prior_alpha REAL,
+  prior_beta REAL,
+  last_updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  calculation_notes TEXT
+);
+CREATE INDEX idx_benchmarks_archetype ON venture_benchmarks(archetype);
+CREATE INDEX idx_benchmarks_industry ON venture_benchmarks(industry);
+```
+
+**Step 2: Data migration** (runs BEFORE table recreation -- new CHECK rejects `interview`)
+
+```sql
+-- Migrate draft/preflight interview experiments to fake_door
+UPDATE experiments SET archetype = 'fake_door'
+  WHERE archetype = 'interview' AND status IN ('draft', 'preflight');
+
+-- Archive active interview experiments that cannot be migrated
+UPDATE experiments SET status = 'archive'
+  WHERE archetype = 'interview' AND status NOT IN ('draft', 'preflight');
+
+-- Catch any remaining interview rows
+UPDATE experiments SET archetype = 'fake_door'
+  WHERE archetype = 'interview';
+```
+
+**Step 3: CHECK constraint recreation** (create-copy-drop-rename pattern)
+
+```sql
+-- Create new table with updated constraints
+CREATE TABLE experiments_v2 (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK(status IN ('draft','preflight','discovery','build','launch','run','decide','archive')),
+  archetype TEXT NOT NULL
+    CHECK(archetype IN ('fake_door','waitlist','content_magnet','priced_waitlist','presale','concierge','service_pilot')),
+
+  -- Distill Brief
+  problem_statement TEXT,
+  target_audience TEXT,
+  value_proposition TEXT,
+  market_size_estimate TEXT,
+
+  -- Experiment Spec
+  min_signups INTEGER,
+  max_spend_cents INTEGER CHECK(max_spend_cents IS NULL OR max_spend_cents >= 0),
+  max_duration_days INTEGER CHECK(max_duration_days IS NULL OR max_duration_days > 0),
+  kill_criteria TEXT,
+
+  -- Copy Pack / Creative Brief
+  copy_pack TEXT,
+  creative_brief TEXT,
+
+  -- Stripe Config
+  stripe_price_id TEXT,
+  stripe_product_id TEXT,
+  price_cents INTEGER CHECK(price_cents IS NULL OR price_cents >= 0),
+
+  -- v2.0 Artifact Columns
+  hypothesis_card TEXT,
+  test_blueprint TEXT,
+  discovery_summary TEXT,
+  campaign_package TEXT,
+  page_config TEXT,
+  validation_report TEXT,
+
+  -- v2.0 Supporting Columns
+  venture_id TEXT,
+  category TEXT,
+  sequence_position INTEGER,
+  prior_test_ref TEXT,
+
+  -- Timestamps
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+  launched_at INTEGER,
+  decided_at INTEGER
+);
+
+-- Copy all data
+INSERT INTO experiments_v2 SELECT
+  id, name, slug, status, archetype,
+  problem_statement, target_audience, value_proposition, market_size_estimate,
+  min_signups, max_spend_cents, max_duration_days, kill_criteria,
+  copy_pack, creative_brief,
+  stripe_price_id, stripe_product_id, price_cents,
+  hypothesis_card, test_blueprint, discovery_summary, campaign_package, page_config, validation_report,
+  venture_id, category, sequence_position, prior_test_ref,
+  created_at, updated_at, launched_at, decided_at
+FROM experiments;
+
+-- Drop old table and rename
+DROP TABLE experiments;
+ALTER TABLE experiments_v2 RENAME TO experiments;
+
+-- Recreate indexes
+CREATE INDEX idx_experiments_status ON experiments(status);
+CREATE INDEX idx_experiments_slug ON experiments(slug);
+
+-- Recreate trigger
+CREATE TRIGGER update_experiments_timestamp
+AFTER UPDATE ON experiments
+BEGIN
+  UPDATE experiments SET updated_at = (strftime('%s', 'now') * 1000)
+  WHERE id = NEW.id;
+END;
+```
+
+**NOTE:** D1 does not enforce FKs by default. The 6 tables referencing `experiments` (leads, payments, metrics_daily, decision_memos, learning_memos, event_log) use TEXT references. No FK constraint enforcement needed unless `PRAGMA foreign_keys = ON`. Verify PRAGMA state before deploying.
+
+**Step 4: Verification** (run in local D1 before deploying)
+
+```sql
+-- No interview archetypes remain
+SELECT COUNT(*) FROM experiments WHERE archetype = 'interview';
+-- Expected: 0
+
+-- Row count preserved
+SELECT COUNT(*) FROM experiments;
+-- Expected: matches pre-migration count
+
+-- Trigger fires correctly
+UPDATE experiments SET name = name WHERE id = (SELECT id FROM experiments LIMIT 1);
+-- Verify updated_at changed
+```
+
+**Backward compatibility:** All new columns are nullable. Existing experiments without new JSON columns continue to work. Write invariants only activate when the new columns are populated.
+
+---
+
+## 8. Implementation Phases
+
+### Milestone A -- "v2.0-alpha" (Phases 1-3)
+
+First user-facing value. Experiments get Hypothesis Cards, discovery interviews can be recorded, `discovery` status works. Target: ~2-3 weeks.
+
+### Milestone B -- "v2.0-beta" (Phases 4-7)
+
+Full artifact chain operational. Target: incremental after alpha.
+
+---
+
+**Phase 1: Schema Foundation**
+
+Run Migration 0002 (all columns, tables, CHECK constraints). No application code changes.
+
+- Execute all 4 migration steps
+- Verify in local D1, then deploy to preview, then production
+- Run Step 4 verification queries in each environment
+
+---
+
+**Phase 2: Hypothesis Card** (DD#1)
+
+- `hypothesis_card` column write/read via `PATCH /experiments/:id`
+- Implement Distill Brief write invariant: reject direct Distill Brief updates when `hypothesis_card` is non-null; auto-extract projections on `hypothesis_card` write
+- Confidence score validation: `proceed` / `uncertain` / `abandon`
+- `abandon` confidence triggers archive recommendation (advisory, not enforced)
+- Ventures table created in Phase 1 migration but Ventures CRUD API deferred to Phase 5
+
+---
+
+**Phase 3: Discovery Engine** (DD#3)
+
+- `interviews` table CRUD: `POST /experiments/:id/interviews`, query by experiment_id
+- `discovery_summary` column read/write via API
+- Discovery API endpoints: `/discovery/start`, `/discovery/summary`, `/discovery/finalize`, `/discovery/gate`
+- Add `discovery` to `VALID_STATUS_TRANSITIONS`: `preflight -> ['discovery', 'build', 'draft', 'archive']`, `discovery -> ['build', 'archive']`
+- Basic Discovery Gate logic: evaluate 6 checks (minimum interviews, pain severity, peak dimension, problem confirmed, assumption evidence, saturation)
+- Mode-weighted counting: `ai * 0.5 + hybrid * 0.75 + human * 1.0`
+- Discovery event types added to `event_log`
+
+---
+
+**Phase 4: Test Blueprint + Validation Ladder** (DD#2)
+
+- `test_blueprint` column write/read
+- Archetype defaults auto-population on `POST /experiments`: populate `kill_criteria`, `max_duration_days`, `max_spend_cents` from hardcoded per-archetype defaults (migrated to `threshold_registry` in Phase 7)
+- `category` and `sequence_position` columns populated on experiment creation
+- `prior_test_ref` linkage for test sequencing
+- Discovery Gate enforcement on `-> build` transitions per Status Transition Map (Section 2.2)
+- Hard Kill vs. Soft Kill `severity` field on kill criteria rules
+- **Depends on Phase 3** (Discovery Gate references Discovery Summary)
+
+---
+
+**Phase 5: Campaign Factory** (DD#4)
+
+- `campaign_package` column write/read
+- CampaignPackage write invariant enforcement
+- Ventures CRUD API: `POST /ventures`, `GET /ventures`, `GET /ventures/:id`, `PATCH /ventures/:id`
+- `venture_id` FK population on experiments (advisory, not enforced at DB level)
+- Async campaign generation pipeline: Cloudflare Queue Consumer worker
+- `POST /experiments/:id/generate-campaign-package` -> 202 Accepted
+- `GET /experiments/:id/campaign-package/status` for polling
+- R2 asset storage for generated images
+- Campaign generation event types
+- Expand `metrics_daily.source` documentation to include: `facebook`, `google`, `tiktok`, `linkedin`, `reddit`, `twitter`, `email`, `manual`
+
+---
+
+**Phase 6: The Launchpad** (DD#5)
+
+- `page_config` column write/read via `PATCH /experiments/:id`
+- Archetype-aware template router in `[slug].astro`
+- `resolvePageConfig()` function with archetype defaults
+- `LandingBase.astro` layout
+- `SignalCapture.astro` component (highest priority item -- enables `metrics_daily` feeding)
+- Per-archetype section components (HeroSection, ValueProps, SocialProof, etc.)
+- A/B variant assignment (`AbVariantWrapper.astro`)
+- Channel-aware UTM matching
+- Preview mode (`?preview=true`)
+- Event-to-metrics aggregation logic: `page_view` count -> `sessions`, `form_submit`/`payment_complete` -> `conversions`
+
+---
+
+**Phase 7: The Verdict** (DD#6)
+
+- `validation_report` column write/read
+- `decision_detail` column on `decision_memos`
+- Measurement endpoints: `/validation-report`, `/cumulative-metrics`, `/evaluate-thresholds`, `/thresholds/:archetype`, `/benchmarks`
+- Cumulative metric aggregation (SUM across `metrics_daily` rows per experiment, derived metrics from totals)
+- Data quality flag detection (bot traffic, tracking gaps, platform anomalies)
+- Bayesian confidence calculation: Beta-Binomial model, Phase 1 uses Beta(1,1) prior
+- Decision support algorithm (Section 9 of DD#6): evaluate after each `POST /metrics` import
+- `threshold_registry` population: Phase 1 defaults hardcoded, Phase 2+ from portfolio data
+- `venture_benchmarks` recomputation job
+- Archetype defaults migrated from hardcoded values to `threshold_registry` lookups
+- 90-day PII purge extension in `sc-maintenance` worker
+- Measurement event types
+
+---
+
+## 9. Traceability Appendix
+
+Every recommendation from each deep dive mapped to its location in this spec.
+
+| DD# | Rec# | Summary                                                                   | Spec Section                  |
+| --- | ---- | ------------------------------------------------------------------------- | ----------------------------- |
+| 1   | 1    | Replace Distill Brief with Hypothesis Card schema                         | 2.4                           |
+| 1   | 2    | Add `hypothesis_card` column to experiments                               | 2.1                           |
+| 1   | 3    | Keep legacy Distill Brief columns as computed views                       | 2.4                           |
+| 1   | 4    | Add confidence score as workflow gate                                     | 8 (Phase 2)                   |
+| 1   | 5    | Define AI agent scaffolding as system capability                          | 8 (Phase 2, advisory)         |
+| 1   | 6    | Key Assumptions bridge to kill_criteria                                   | 8 (Phase 4)                   |
+| 2   | 1    | Update archetype CHECK constraint (interview -> fake_door)                | 2.3, 7 (Step 2-3)             |
+| 2   | 2    | Add `test_blueprint` column                                               | 2.1                           |
+| 2   | 3    | Add `category` column                                                     | 2.1                           |
+| 2   | 4    | Add `sequence_position` column                                            | 2.1                           |
+| 2   | 5    | Add `prior_test_ref` column                                               | 2.1                           |
+| 2   | 6    | Migrate existing interview experiments                                    | 7 (Step 2)                    |
+| 2   | 7    | Update KillCriteria schema with Hard/Soft Kill severity                   | 8 (Phase 4)                   |
+| 2   | 8    | Add archetype defaults to API (auto-populate on create)                   | 3.1, 8 (Phase 4)              |
+| 2   | 9    | Define Discovery Gate as pre-launch validation                            | 2.2, 8 (Phase 4)              |
+| 3   | 1    | Add `discovery_summary` column                                            | 2.1                           |
+| 3   | 2    | Create `interviews` table                                                 | 2.7                           |
+| 3   | 3    | Add discovery API endpoints                                               | 3.3                           |
+| 3   | 4    | Implement mode-weighted counting                                          | 8 (Phase 3)                   |
+| 3   | 5    | Add discovery event types to event_log                                    | 4                             |
+| 3   | 6    | Add `discovery` to status CHECK constraint                                | 2.3, 7 (Step 3)               |
+| 3   | 7    | Store interview transcripts in R2                                         | 6                             |
+| 3   | 8    | Plan D1 migration for discovery changes                                   | 7                             |
+| 4   | 1    | Add `campaign_package` column                                             | 2.1                           |
+| 4   | 2    | Add `ventures` table with `venture_id` FK on experiments                  | 2.7, 2.1                      |
+| 4   | 3    | Add `campaign_package` to PATCH updatable fields; enforce write invariant | 2.5, 3.1                      |
+| 4   | 4    | Add async campaign generation endpoints                                   | 3.4                           |
+| 4   | 5    | Extend landing page template for social_proof and tone                    | 5                             |
+| 4   | 6    | Store generated creative assets in R2                                     | 6                             |
+| 4   | 7    | Add campaign generation event types                                       | 4                             |
+| 4   | 8    | Add platform-specific creative spec validation                            | 8 (Phase 5)                   |
+| 4   | 9    | Expand metrics_daily.source documentation                                 | 8 (Phase 5)                   |
+| 4   | 10   | Add provenance.generation_tier and brand_profile_version                  | 2.1 (campaign_package schema) |
+| 5   | 1    | Add `page_config` column                                                  | 2.1                           |
+| 5   | 2    | Evolve [slug].astro to archetype-aware router                             | 5                             |
+| 5   | 3    | Add SignalCapture component                                               | 5                             |
+| 5   | 4    | Add LandingBase.astro layout                                              | 5                             |
+| 5   | 5    | Add preview mode                                                          | 5                             |
+| 5   | 6    | Standardize landing page event types in event_log                         | 4                             |
+| 5   | 7    | Add aggregation logic (event_log -> metrics_daily)                        | 8 (Phase 6)                   |
+| 5   | 8    | Add resolvePageConfig function                                            | 5                             |
+| 5   | 9    | Add page_config to PATCH updatable fields                                 | 3.1                           |
+| 5   | 10   | Extend leads API for custom_fields (screening questions)                  | 8 (Phase 6)                   |
+| 5   | 11   | Add full UTM parameters to event_log event_data                           | 4                             |
+| 6   | 1    | Add `validation_report` column                                            | 2.1                           |
+| 6   | 2    | Add `decision_detail` column on decision_memos                            | 2.6                           |
+| 6   | 3    | Create `threshold_registry` table                                         | 2.7                           |
+| 6   | 4    | Create `venture_benchmarks` table                                         | 2.7                           |
+| 6   | 5    | Add GET /validation-report endpoint                                       | 3.5                           |
+| 6   | 6    | Add POST /validation-report/finalize endpoint                             | 3.5                           |
+| 6   | 7    | Add GET /cumulative-metrics endpoint                                      | 3.5                           |
+| 6   | 8    | Add POST /evaluate-thresholds endpoint                                    | 3.5                           |
+| 6   | 9    | Add GET /thresholds/:archetype endpoint                                   | 3.5                           |
+| 6   | 10   | Add GET /benchmarks endpoint                                              | 3.5                           |
+| 6   | 11   | Implement decision support algorithm                                      | 8 (Phase 7)                   |
+| 6   | 12   | Implement Bayesian confidence calculation                                 | 8 (Phase 7)                   |
+| 6   | 13   | Add cumulative metric aggregation                                         | 8 (Phase 7)                   |
+| 6   | 14   | Add data quality flag detection                                           | 8 (Phase 7)                   |
+| 6   | 15   | Extend sc-maintenance for 90-day PII purge (archived experiments)         | 6                             |
+| 6   | 16   | Add threshold recalculation scheduled job                                 | 6                             |
+| 6   | 17   | Add measurement event types to event_log                                  | 4                             |
+
+**Coverage: 61/61 recommendations mapped. No gaps.**
+
+---
+
+## 10. Artifact Chain Summary
+
+```
+Raw Idea
+    |
+    v
+DD#1: The Venture Narrative ----------> Hypothesis Card
+    |                                   (customer segment, problem, stakes,
+    |                                    solution, why now, confidence)
+    v
+DD#3: The Discovery Engine -----------> Discovery Summary
+    |                                   (pain severity, quotes, WTP signal,
+    |                                    ICP refinements, gate status)
+    v
+DD#2: The Validation Ladder ----------> Test Blueprint
+    |                                   (archetype, metrics, thresholds,
+    |                                    kill criteria, decision rules)
+    v
+DD#4: The Campaign Factory -----------> Campaign Package
+    |                                   (copy, creative, targeting, budget,
+    |                                    channel variants, A/B variants)
+    v
+DD#5: The Launchpad ------------------> Live Experiment
+    |                                   (deployed page, tracking verified,
+    |                                    signals capturing)
+    v
+DD#6: The Verdict --------------------> Validation Report + Decision Memo
+    |                                   (metrics vs. thresholds, evidence,
+    |                                    Bayesian confidence, verdict)
+    |
+    |---> GO -------> Handoff Document -------> Product Development
+    |
+    |---> KILL -----> Kill Archive ------------> Kill Library (learning)
+    |
+    |---> PIVOT ----> Pivot Routing -----------> Re-entry at Step 1-5
+    |
+    |---> INVALID --> Resolution --------------> Extend / Relaunch / Redesign
+```
+
+---
+
+**End of Functional Specification v2.0**


### PR DESCRIPTION
## Summary

- Synthesize 61 recommendations from 6 deep dive methodology documents into an actionable functional spec (`sc-functional-spec-v2.md`)
- Run a 6-role PRD review (PM, Tech Lead, BA, UX Lead, Target Customer, Competitor Analyst) producing a unified PRD with 13 user stories, 29 business rules, 18 unresolved issues, and 10 ADRs
- Commit the 7 methodology deep dive source documents (migrated from Notion, March 2026)

## Files

| File | Purpose |
|------|---------|
| `docs/technical/sc-functional-spec-v2.md` | v2.0 functional spec (871 lines, 61 recommendations traced) |
| `docs/pm/prd.md` | Synthesized PRD (19 sections, 11,520 words) |
| `docs/pm/prd-contributions/round-1/*.md` | 6 role contribution audit trail |
| `docs/methodology/*.md` | 7 deep dive source documents |

## Test plan

- [ ] Review functional spec traceability appendix (61/61 recommendations mapped)
- [ ] Review PRD unresolved issues appendix (18 items)
- [ ] Verify migration SQL in functional spec Section 7 against current schema
- [ ] Confirm deep dive documents match canonical versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)