### PR TITLE
feat: migrate @venturecrane/* harness to GitHub Packages registry

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,9 +20,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
           cache: 'npm'
 
       - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci
 
       - name: Run audit

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,9 +18,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
           cache: 'npm'
 
       - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm ci
 
       - name: Typecheck

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@venturecrane:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5311,8 +5311,8 @@
     },
     "node_modules/@venturecrane/crane-test-harness": {
       "version": "0.1.0",
-      "resolved": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
-      "integrity": "sha512-TZNAZPD5n8UUcWYlIKjLulV7KKQDuyflZmsPIgTxI5PBvXPH0cguEbXnxIhxs/546/0vEXBRheLa5A+h5DcMRg==",
+      "resolved": "https://npm.pkg.github.com/download/@venturecrane/crane-test-harness/0.1.0/768d12bf8583340607a9d60ab8a8824baa067326",
+      "integrity": "sha512-6zxAPaltQuC+SQp3cu5bvrzlTo8P/vPWuDwSV+KCWrpAbjPPKR/k2heGWwgWSFP6intAtta5qgWkZ4CEYtwtvQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15251,7 +15251,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240129.0",
-        "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+        "@venturecrane/crane-test-harness": "^0.1.0",
         "typescript": "^5.7.0",
         "vitest": "^4.0.18",
         "wrangler": "^4.69.0"

--- a/workers/sc-api/package.json
+++ b/workers/sc-api/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240129.0",
-    "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+    "@venturecrane/crane-test-harness": "^0.1.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.18",
     "wrangler": "^4.69.0"


### PR DESCRIPTION
## Summary

- Swap `@venturecrane/crane-test-harness` from a pinned GitHub Releases tarball URL to a `^0.1.0` semver dep resolved from the GitHub Packages npm registry.
- Add `.npmrc` at repo root for the `@venturecrane` scope + `NODE_AUTH_TOKEN` auth pattern.
- Update `verify.yml` and `security.yml` setup-node steps to declare the registry and pass `NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}` on `npm ci`.
- Regenerate `package-lock.json` so the resolved URL points at `npm.pkg.github.com`.

## Context

Companion migration to venturecrane/crane-console#579 (merged). The foundation PR added `NODE_AUTH_TOKEN` to `config/ventures.json` `sharedSecrets.keys`, so Infisical `/vc` + the `crane` launcher carry the token into every venture's agent shell for local `npm install`. CI uses the Actions-provided `GITHUB_TOKEN` with `packages: read` inherited from the default permissions.

sc-console was one of 4 ventures that adopted the harness via tarball URLs the morning after ss-console introduced the registry pattern; this brings sc-console onto the uniform shape.

## Test plan

- [x] `npm install` locally resolves from `npm.pkg.github.com/download/@venturecrane/crane-test-harness/0.1.0/...` (verified via `package-lock.json` diff).
- [x] `npm run verify` (typecheck + format + lint + test) passes locally.
- [ ] CI Verify + Security workflows pass on this branch — first registry-authenticated install in sc-console CI.
- [ ] Confirm no other consumers of the harness in this repo remain on tarball URL (`grep -r "releases/download/crane-test-harness" .` returns zero).

## Related

- crane-console PR #579 — foundation (merged: ff6d5f5)
- crane-console `docs/infra/github-packages-auth.md` — full design + rotation + troubleshooting
- dfg/ke/dc equivalents follow in parallel PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)