### PR TITLE
ci(dependabot): add auto-merge workflow for safe bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot auto-merge
+
+# Auto-enable squash-merge on Dependabot PRs when the bump is low-risk:
+#   - any patch bump (semver says backwards-compatible)
+#   - dev-dep minor bumps (tooling, can't reach production)
+#   - security patch updates (CVE-driven, usually a patch anyway)
+#
+# GitHub's native auto-merge means the PR lands only after every required
+# check passes — there's no "skip CI" path. If CI goes red, the PR just
+# stays open for manual review, same as today.
+#
+# Runtime-dep minors and any major bumps never match these conditions and
+# always require explicit review.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe bumps
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-security' ||
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+           steps.metadata.outputs.dependency-type == 'direct:development')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Mirrors [crane-console PR #619](https://github.com/venturecrane/crane-console/pull/619). Adds GitHub-native auto-merge for low-risk Dependabot PRs so the backlog stops accumulating.

## What auto-merges

- Patch bumps (semver-compatible per spec)
- Dev-dep minor bumps (tooling only, cannot reach production)
- Security patches (CVE-driven)

CI still gates every merge. If a bump breaks CI the PR stays open for review, same as today.

## What still needs review

- Runtime-dep minors
- Any major bump

## Test plan

- [x] YAML validates
- [ ] CI green
- [ ] Next Dependabot patch/dev-minor PR lands automatically after its CI passes

QA: grade 1 (workflow file only; no code or config touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)