### PR TITLE
chore(marketing): hide sign-in CTAs during private alpha

### DIFF
--- a/apps/sc-web/src/pages/index.astro
+++ b/apps/sc-web/src/pages/index.astro
@@ -17,8 +17,7 @@ export const prerender = true;
       </a>
       <div class="flex items-center gap-5">
         <a href="#waitlist" class="hidden sm:inline text-sm text-slate-600 hover:text-slate-900 transition-colors">Validation tooling</a>
-        <a href="#contact" class="hidden sm:inline text-sm text-slate-600 hover:text-slate-900 transition-colors">Start a sprint</a>
-        <a href="/sign-in" class="text-sm font-medium text-slate-900 hover:text-slate-700 transition-colors">Sign in</a>
+        <a href="#contact" class="text-sm font-medium text-slate-900 hover:text-slate-700 transition-colors">Start a sprint</a>
       </div>
     </div>
   </nav>
@@ -179,9 +178,6 @@ export const prerender = true;
             Request access
           </button>
 
-          <p class="text-blue-100 text-sm text-center">
-            Already invited? <a href="/sign-in" class="underline hover:text-white">Sign in</a>
-          </p>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Removes the "Sign in" link from the top nav and the "Already invited?" line in the waitlist section. The `/sign-in` route stays live and reachable by direct URL — just unlinked so casual visitors do not see an auth gate they cannot get past.

When public beta opens, restore the links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)