### PR TITLE
chore: bootstrap Clerk + Playwright auth for sc-web (Astro)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ dist/
 .cache/
 .codex/
 .gemini/
+
+# Playwright
+playwright/.clerk/
+playwright-report/
+test-results/

--- a/apps/sc-web/.env.example
+++ b/apps/sc-web/.env.example
@@ -6,3 +6,22 @@ PUBLIC_GA4_MEASUREMENT_ID=G-XXXXXXXXXX
 
 # Stripe Publishable Key (for client-side payment flows)
 PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_XXXXXXXXX
+
+# --- Clerk E2E auth (Playwright) ---
+# Required for the auth bootstrap; safe to commit (placeholders only).
+# Real values live in Infisical at /sc/E2E_*.
+#
+# Crane runbook (in crane-console): docs/runbooks/clerk-playwright-auth-setup.md
+
+# The test user's email, must match `*+clerk_test@*` to enable Clerk's testing mode.
+# Create this user in the Clerk Dashboard under Users > Create user.
+E2E_CLERK_USER_EMAIL=agent-test+clerk_test@venturecrane.com
+
+# Optional: base URL for the test target. Defaults to http://localhost:4321 in playwright.config.ts.
+# Override for testing against deployed previews:
+#   E2E_BASE_URL=https://preview-xyz.workers.dev
+# E2E_BASE_URL=
+
+# Already-required Clerk env vars (re-listed here as a reminder):
+# CLERK_SECRET_KEY=sk_test_...
+# PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...   # Astro uses PUBLIC_ prefix (NOT NEXT_PUBLIC_)

--- a/apps/sc-web/package.json
+++ b/apps/sc-web/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "@clerk/testing": "^2.0.21",
+    "@playwright/test": "^1.59.1",
     "@vite-pwa/astro": "^1.2.0",
     "typescript": "^5.7.0"
   }

--- a/apps/sc-web/playwright.config.ts
+++ b/apps/sc-web/playwright.config.ts
@@ -1,0 +1,55 @@
+/**
+ * Playwright config for sc-web (Astro).
+ *
+ * Crane runbook: docs/runbooks/clerk-playwright-auth-setup.md (in crane-console)
+ *
+ * Notes:
+ *   - Astro dev server defaults to port 4321
+ *   - `setup-clerk` project runs auth.setup.ts once and saves storageState
+ *   - Authenticated browser projects depend on it and load the captured state
+ */
+
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:4321'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'setup-clerk',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'chromium-authed',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.clerk/user.json',
+      },
+      dependencies: ['setup-clerk'],
+    },
+    {
+      name: 'chromium-public',
+      testMatch: /.*\.public\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/apps/sc-web/playwright/auth.setup.ts
+++ b/apps/sc-web/playwright/auth.setup.ts
@@ -1,0 +1,61 @@
+/**
+ * Playwright global auth setup for Clerk-protected Astro app (sc-web).
+ *
+ * Source: https://clerk.com/docs/guides/development/testing/playwright/test-authenticated-flows
+ * Crane runbook: docs/runbooks/clerk-playwright-auth-setup.md (in crane-console)
+ *
+ * Astro variant note:
+ *   @clerk/testing's clerkSetup() auto-detects publishable key from
+ *   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, VITE_CLERK_PUBLISHABLE_KEY,
+ *   CLERK_PUBLISHABLE_KEY, REACT_APP_CLERK_PUBLISHABLE_KEY, EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY.
+ *   It does NOT auto-detect Astro's PUBLIC_CLERK_PUBLISHABLE_KEY.
+ *   We bridge by reading PUBLIC_CLERK_PUBLISHABLE_KEY (or CLERK_PUBLISHABLE_KEY)
+ *   and passing it explicitly to clerkSetup().
+ *
+ * Required env (in apps/sc-web/.env or CI secrets):
+ *   - CLERK_SECRET_KEY              — server-side Clerk key for the test instance
+ *   - PUBLIC_CLERK_PUBLISHABLE_KEY  — Astro frontend Clerk key
+ *   - E2E_CLERK_USER_EMAIL          — test user email, e.g. agent-test+clerk_test@venturecrane.com
+ */
+
+import { clerk, clerkSetup } from '@clerk/testing/playwright'
+import { test as setup } from '@playwright/test'
+import path from 'path'
+
+setup.describe.configure({ mode: 'serial' })
+
+setup('global clerk setup', async () => {
+  const publishableKey =
+    process.env.PUBLIC_CLERK_PUBLISHABLE_KEY ?? process.env.CLERK_PUBLISHABLE_KEY
+
+  if (!publishableKey) {
+    throw new Error(
+      'PUBLIC_CLERK_PUBLISHABLE_KEY (or CLERK_PUBLISHABLE_KEY) is required. ' +
+        'Astro convention is PUBLIC_; @clerk/testing does not auto-detect that prefix, ' +
+        'so we pass it explicitly. See docs/runbooks/clerk-playwright-auth-setup.md.'
+    )
+  }
+
+  await clerkSetup({ publishableKey })
+})
+
+const authFile = path.join(__dirname, '.clerk/user.json')
+
+setup('authenticate and save state', async ({ page }) => {
+  if (!process.env.E2E_CLERK_USER_EMAIL) {
+    throw new Error(
+      'E2E_CLERK_USER_EMAIL not set. See docs/runbooks/clerk-playwright-auth-setup.md'
+    )
+  }
+  if (!process.env.CLERK_SECRET_KEY) {
+    throw new Error('CLERK_SECRET_KEY not set. Required for server-side sign-in token.')
+  }
+
+  await page.goto('/')
+  await clerk.signIn({
+    page,
+    emailAddress: process.env.E2E_CLERK_USER_EMAIL,
+  })
+
+  await page.context().storageState({ path: authFile })
+})

--- a/apps/sc-web/tsconfig.json
+++ b/apps/sc-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "playwright", "playwright.config.ts", "e2e"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.6",
+        "@clerk/testing": "^2.0.21",
+        "@playwright/test": "^1.59.1",
         "@vite-pwa/astro": "^1.2.0",
         "typescript": "^5.7.0"
       }
@@ -3117,12 +3119,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.3.0.tgz",
-      "integrity": "sha512-6KuOaIig4CQPSn23I7xExkGKKi2rE2PEH3mvhnA41fktv3LqtPSifRb0xjmJEAwSZwJ8QY6uzk/jDccNof2eUA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.4.1.tgz",
+      "integrity": "sha512-+Tgo1uPEFpBRvyFW3JtPbrTMRgiP+pWBo9gi2tTB0AxEqR2I/kSYy5l3+KqWciUpbVZtVvLXm1j+NEE2WEG+jg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.8.3",
+        "@clerk/shared": "^4.8.5",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -3131,9 +3133,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.3.tgz",
-      "integrity": "sha512-HZViZBCTfOR2OreSBDMXcIRPgYiiYCE+GCCPrpjq/ZPcA6OsGiRCIQgUoGgGdAoFgr6Hk0TT00hnVK7g0qRKqQ==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.5.tgz",
+      "integrity": "sha512-YxgUWHoKEXEbRPWPEcB2Q0o+NJkDc0/zQRp4QCsnGIM5e32hlBUwxcYpyDjDlZ2lYB+GUXHuEc3KETnxWGp26g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3155,6 +3157,33 @@
           "optional": true
         },
         "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.0.21.tgz",
+      "integrity": "sha512-LlpWQyk0cH/jpNgwuUgXYQi9FrsfzzM+VupBi1HRl7rT2Faf5vzSsoOfiHoUJjxdCgO0NIL5K1fjENrVGPUOsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.4.1",
+        "@clerk/shared": "^4.8.5",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
           "optional": true
         }
       }
@@ -4457,6 +4486,22 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
@@ -7074,6 +7119,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dset": {
@@ -11020,6 +11078,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {


### PR DESCRIPTION
## Summary

Adopts the canonical Clerk + Playwright auth bootstrap from `crane-console#737`, with Astro-specific tweaks (PUBLIC_ env prefix, port 4321, tsconfig exclude). E2E tests and agent-driven Playwright flows authenticate without manual login.

Verify: full 112-test suite + typecheck + lint + format green.

## ⚠️ BLOCKED — Clerk app does not exist yet

Per crane-console issue #739: sc-console imports `@clerk/astro` v3 but **no Clerk app exists in the workspace** for Silicon Crane. The auth-bootstrap PR is correctly wired and CI-green, but the `setup-clerk` Playwright project will fail at runtime with no Clerk instance.

**Unblocking sequence:**
1. Resolve crane-console#739 — provision a "Silicon Crane" app in the Clerk workspace
2. Populate Infisical `/sc`:
   - `CLERK_SECRET_KEY`, `PUBLIC_CLERK_PUBLISHABLE_KEY` (note: `PUBLIC_` prefix, not `NEXT_PUBLIC_`)
   - `E2E_CLERK_USER_EMAIL=agent-test+clerk_test@venturecrane.com`
   - `E2E_CLERK_USER_PASSWORD` (Bitwarden)
3. Add the same env to GitHub Actions secrets
4. Mark this PR ready and merge

## Astro-specific decisions

These tweaks have been folded back into the canonical template via crane-console#737's refinement commit.

## Related

- Canonical template + runbook: venturecrane/crane-console#737
- Portfolio Clerk audit: venturecrane/crane-console#739
- Rollout siblings: ke-console#204 (ready), dfg-console#296 (also blocked on Clerk app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)